### PR TITLE
Adding basic php components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+DC_RUN_PHP = docker-compose run --rm php
+
+install:
+	$(DC_RUN_PHP) composer install
+update:
+	$(DC_RUN_PHP) composer update
+test:
+	$(DC_RUN_PHP) php ./vendor/bin/phpunit --colors=always --coverage-text --testdox --coverage-clover coverage.clover
+phan:
+	$(DC_RUN_PHP) env PHAN_DISABLE_XDEBUG_WARN=1 php ./vendor/bin/phan
+psalm:
+	$(DC_RUN_PHP) php ./vendor/bin/psalm
+psalm-info:
+	$(DC_RUN_PHP) php ./vendor/bin/psalm --show-info=true
+phpstan: 
+	$(DC_RUN_PHP) php ./vendor/bin/phpstan analyse
+bash:
+	$(DC_RUN_PHP) bash
+style:
+	$(DC_RUN_PHP) php ./vendor/bin/php-cs-fixer fix
+FORCE:

--- a/composer.json
+++ b/composer.json
@@ -1,54 +1,30 @@
 {
-    "name": "open-telemetry/opentelemetry",
-    "description": "OpenTelemetry makes robust, portable telemetry a built-in feature of cloud-native software.",
+    "name": "open-telemetry/opentelemetry-php-contrib",
+    "description": "The contributor repo for opentelemetry-php",
     "type": "library",
     "license": "Apache-2.0",
     "require": {
         "php": "^7.3 || ^8.0",
-        "ext-json": "*",
-        "promphp/prometheus_client_php": "^2.2.1",
-        "grpc/grpc": "^1.30",
-        "google/protobuf": "^v3.3.0",
-        "psr/http-client-implementation": "^1.0",
-        "psr/http-factory-implementation": "^1.0"
+        "ext-json": "*"
     },
     "authors": [
         {
             "name": "Bob Strecansky",
             "email": "bob.strecansky@gmail.com"
-        },
-        {
-            "name": "Dmitry Krokhin",
-            "email": "nekufa@gmail.com"
-        },
-        {
-            "name": "Levi Morrison",
-            "email": "levim@php.net"
         }
     ],
     "autoload": {
-        "psr-4": {
-            "OpenTelemetry\\Context\\": "Context",
-            "OpenTelemetry\\": "api",
-            "OpenTelemetry\\Sdk\\": "sdk",
-            "OpenTelemetry\\Contrib\\": "contrib",
-            "Opentelemetry\\Proto\\Collector\\Trace\\V1\\": "proto/Opentelemetry/Proto/Collector/Trace/V1",
-            "Opentelemetry\\Proto\\Trace\\V1\\":"proto/Opentelemetry/Proto/Trace/V1",
-            "Opentelemetry\\Proto\\Common\\V1\\":"proto/Opentelemetry/Proto/Common/V1",
-            "Opentelemetry\\Proto\\Resource\\V1\\":"proto/Opentelemetry/Proto/Resource/V1",
-            "GPBMetadata\\Opentelemetry\\Proto\\Collector\\Trace\\V1\\": "proto/GPBMetadata/Opentelemetry/Proto/Collector/Trace/V1",
-            "GPBMetadata\\Opentelemetry\\Proto\\Trace\\V1\\":"proto/GPBMetadata/Opentelemetry/Proto/Trace/V1",
-            "GPBMetadata\\Opentelemetry\\Proto\\Common\\V1\\":"proto/GPBMetadata/Opentelemetry/Proto/Common/V1",
-            "GPBMetadata\\Opentelemetry\\Proto\\Resource\\V1\\":"proto/GPBMetadata/Opentelemetry/Proto/Resource/V1"
-        }
+        "classmap": [
+            "src/"
+        ] 
     },
     "autoload-dev": {
-        "psr-4": {
-            "OpenTelemetry\\Tests\\": "tests/"
-        }
+        "classmap": [
+            "src/"
+        ] 
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3",
+        "phpunit/phpunit": "^9.5",
         "composer/xdebug-handler": "^1.3",
         "phan/phan": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.18",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: '3.7'
+services:
+  php:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    volumes:
+    - ./:/usr/src/myapp
+  zipkin:
+    image: openzipkin/zipkin-slim
+    ports:
+    - 9411:9411
+  jaeger:
+    image: jaegertracing/all-in-one
+    environment:
+      COLLECTOR_ZIPKIN_HOST_PORT: 9412
+    ports:
+    - 9412:9412
+    - 16686:16686

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM php:8-buster
+
+RUN apt-get -y update && apt-get -y install git zip && \
+curl -sS https://getcomposer.org/installer | php && \
+mv composer.phar /usr/local/bin/composer && \
+chmod +x /usr/local/bin/composer && \
+pecl install ast-1.0.10 xdebug && \
+docker-php-ext-enable ast xdebug && \
+# The pcntl extension is used for speeding up `make phan`
+docker-php-ext-install pcntl
+
+# install GRPC
+RUN apt install -y --no-install-recommends zlib1g-dev && \
+    pecl install grpc && \
+    docker-php-ext-enable grpc
+
+WORKDIR /usr/src/myapp

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,8 +25,7 @@
 
     <coverage processUncoveredFiles="true">
         <include>
-            <directory>contrib</directory>	
-            <directory>sdk</directory>
+            <directory>src</directory>
         </include>
     </coverage>
 
@@ -38,19 +37,9 @@
     </php>
 
     <testsuites>
-<!--        <testsuite name="Sdk Unit Tests">
-            <directory>./tests/Sdk/Unit</directory>
+        <testsuite name="Unit Tests">
+            <directory>tests/unit</directory>
         </testsuite>
-        <testsuite name="Integration Tests">
-            <directory>./tests/Sdk/Integration</directory>
-        </testsuite>
-        <testsuite name="Contrib Unit Tests">
-            <directory>./tests/Contrib/Unit</directory>
-        </testsuite>
-        <testsuite name="Context Unit Tests">
-            <directory>./tests/Context/Unit</directory>
-        </testsuite>
-!-->
     </testsuites>
 
 </phpunit>

--- a/src/Email.php
+++ b/src/Email.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+final class Email
+{
+    private $email;
+
+    private function __construct(string $email)
+    {
+        $this->ensureIsValidEmail($email);
+
+        $this->email = $email;
+    }
+
+    public static function fromString(string $email): self
+    {
+        return new self($email);
+    }
+
+    public function __toString(): string
+    {
+        return $this->email;
+    }
+
+    private function ensureIsValidEmail(string $email): void
+    {
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    '"%s" is not a valid email address',
+                    $email
+                )
+            );
+        }
+    }
+}

--- a/src/Email.php
+++ b/src/Email.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 final class Email
 {
     private $email;

--- a/tests/unit/EmailTest.php
+++ b/tests/unit/EmailTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+
+final class EmailTest extends TestCase
+{
+    public function testCanBeCreatedFromValidEmailAddress(): void
+    {
+        $this->assertInstanceOf(
+            Email::class,
+            Email::fromString('user@example.com')
+        );
+    }
+
+    public function testCannotBeCreatedFromInvalidEmailAddress(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Email::fromString('invalid');
+    }
+
+    public function testCanBeUsedAsString(): void
+    {
+        $this->assertEquals(
+            'user@example.com',
+            Email::fromString('user@example.com')
+        );
+    }
+}

--- a/tests/unit/EmailTest.php
+++ b/tests/unit/EmailTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 final class EmailTest extends TestCase


### PR DESCRIPTION
While troubleshooting with @ohamuy yesterday, we recognized this repo didn't have all the necessary things to start development.

This PR does a couple things:

* Adds our `Makefile` (mostly cloned from the opentelemetry-php repo)
* Updates the `composer.json` to be something more reasonable for this repo
* Adds a `docker-compose.yaml` file and a `docker/Dockerfile` (so we can run all of our Make entries)
* Updates the `phpunit.xml.dist` to use the correct references for testsuites so the test suite can be run correctly
* Adds a {temporary} `src/Email.php` and `tests/unit/EmailTest.php`.  @ohamuy and I were discussing this yesterday, and I thought adding an example would help him in his initial quest to start working on this repository.  These two files are the examples from the PHPUnit documentation and should be removed when we have other unit tests in this repository.

The README.md should be updated for this repo, but I want to discuss with others in the SIG meeting tomorrow whether this should have its own separate README.md or if it should link back to the opentelmetry-php README.md.