### PR TITLE
Remove stop-on-violation from 'make style'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ phpstan:
 bash:
 	$(DC_RUN_PHP) bash
 style:
-	$(DC_RUN_PHP) php ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --stop-on-violation --using-cache=no -vvv
+	$(DC_RUN_PHP) php ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --using-cache=no -vvv
 FORCE:


### PR DESCRIPTION
This just removes the "stop-on-violation" flag from the cs fixer call in 'make style', so it can be used to fix style errors in one go.