### PR TITLE
Dont forcefully set service_name option on any exporter

### DIFF
--- a/src/Symfony/OtelSdkBundle/DependencyInjection/OtelSdkExtension.php
+++ b/src/Symfony/OtelSdkBundle/DependencyInjection/OtelSdkExtension.php
@@ -318,7 +318,7 @@ class OtelSdkExtension extends Extension implements LoggerAwareInterface
         if (isset($config[Conf::URL_NODE])) {
             $options[Conf::URL_NODE] = $config[Conf::URL_NODE];
         }
-        if (!isset($options[Conf::SERVICE_NAME_NODE])) {
+        if (in_array(Conf::SERVICE_NAME_NODE, $definedOptions) && !isset($options[Conf::SERVICE_NAME_NODE])) {
             $options[Conf::SERVICE_NAME_NODE] = $this->serviceName;
         }
 


### PR DESCRIPTION
Some exporters do not define this option (OTLP f.e.) and setting this option
breaks them.