### PR TITLE
Move Symfony demo to opentelemetry-php org

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ composer require open-telemetry/opentelemetry-php-contrib
 ### Symfony
 #### SdkBundle
 - The documentation for the Symfony SdkBundle can be found [here](/src/Symfony/OtelSdkBundle/README.md).
-- An example symfony application using the SdkBundle can be found [here](https://github.com/tidal/otel-sdk-bundle-example-sf5).
+- An example symfony application using the SdkBundle can be found [here](https://github.com/opentelemetry-php/otel-sdk-bundle-example-sf5).
 
 
 ## Development

--- a/src/Symfony/OtelSdkBundle/README.md
+++ b/src/Symfony/OtelSdkBundle/README.md
@@ -311,5 +311,5 @@ For further usage of spans (events, attributes, etc.), please consult the docume
 
 ## 4. Demo Application
 
-You can find a demo application using the SdkBundle [here](https://github.com/tidal/otel-sdk-bundle-example-sf5). The demo extends the examples given above and comes with a 
+You can find a demo application using the SdkBundle [here](https://github.com/opentelemetry-php/otel-sdk-bundle-example-sf5). The demo extends the examples given above and comes with a 
 docker-compose setup, so it is easy to try out.


### PR DESCRIPTION
I moved the Symfony SDK Bundle demo from my private space to the opentelemetry-php org.
This is PR is just updating the respective links accordingly.