### PR TITLE
Update Mock SpanExporter to accept serviceName

### DIFF
--- a/tests/Integration/Symfony/OtelSdkBundle/Mock/SpanExporter.php
+++ b/tests/Integration/Symfony/OtelSdkBundle/Mock/SpanExporter.php
@@ -9,15 +9,17 @@ use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 class SpanExporter implements SpanExporterInterface
 {
     private ?string $logFile;
+    private ?string $serviceName;
 
-    public function __construct(?string $logFile = null)
+    public function __construct(?string $serviceName = null, ?string $logFile = null)
     {
+        $this->serviceName = $serviceName;
         $this->logFile = $logFile;
     }
 
     public static function fromConnectionString(string $endpointUrl, string $name, string $args): self
     {
-        return new self();
+        return new self($name, $args);
     }
 
     public function export(iterable $spans): int
@@ -33,6 +35,11 @@ class SpanExporter implements SpanExporterInterface
     public function forceFlush(): bool
     {
         return true;
+    }
+
+    public function getServiceName(): ?string
+    {
+        return $this->serviceName;
     }
 
     public function getLogFile(): ?string


### PR DESCRIPTION
This update to the Mock SpanExporter (used in itegration tests) will prevent updates as in https://github.com/open-telemetry/opentelemetry-php-contrib/pull/43 from failing the tests.