### PR TITLE
Adjust stale-bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,10 +5,11 @@ daysUntilStale: 30
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - pinned
-  - security
+  - 'pinned'
+  - 'security'
+  - 'help wanted'
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: 'stale'
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
Adjustments to stale-bot configuration as discussed in SIG meeting and slack.

- Change `staleLabel`from `wontfix` to `stale`
- Add `help wanted` to `exemptLabels`
