### PR TITLE
Make bundle works with new sdk version (0.13)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "open-telemetry/opentelemetry": "^0.0.12",
+        "open-telemetry/opentelemetry": "^0.0.13",
         "php-http/discovery": "^1.14",
         "php-http/message": "^1.12"
     },

--- a/src/Aws/Ec2/Detector.php
+++ b/src/Aws/Ec2/Detector.php
@@ -70,7 +70,7 @@ class Detector implements ResourceDetectorInterface
             if ($token === null) {
                 return ResourceInfoFactory::emptyResource();
             }
-            
+
             $hostName = $this->fetchHostname($token);
 
             $identitiesJson = $this->fetchIdentity($token);
@@ -78,42 +78,42 @@ class Detector implements ResourceDetectorInterface
             if (!$token || !$identitiesJson) {
                 return ResourceInfoFactory::emptyResource();
             }
-            
-            $attributes = new Attributes();
+
+            $attributes = [];
 
             foreach ($identitiesJson as $key => $value) {
                 switch ($key) {
                     case 'instanceId':
-                        $attributes->setAttribute(ResourceAttributes::HOST_ID, $value);
+                        $attributes[ResourceAttributes::HOST_ID] = $value;
 
                         break;
                     case 'availabilityZone':
-                        $attributes->setAttribute(ResourceAttributes::CLOUD_AVAILABILITY_ZONE, $value);
+                        $attributes[ResourceAttributes::CLOUD_AVAILABILITY_ZONE] = $value;
 
                         break;
                     case 'instanceType':
-                        $attributes->setAttribute(ResourceAttributes::HOST_TYPE, $value);
+                        $attributes[ResourceAttributes::HOST_TYPE] = $value;
 
                         break;
                     case 'imageId':
-                        $attributes->setAttribute(ResourceAttributes::HOST_IMAGE_ID, $value);
+                        $attributes[ResourceAttributes::HOST_IMAGE_ID] = $value;
 
                         break;
                     case 'accountId':
-                        $attributes->setAttribute(ResourceAttributes::CLOUD_ACCOUNT_ID, $value);
+                        $attributes[ResourceAttributes::CLOUD_ACCOUNT_ID] = $value;
 
                         break;
                     case 'region':
-                        $attributes->setAttribute(ResourceAttributes::CLOUD_REGION, $value);
+                        $attributes[ResourceAttributes::CLOUD_REGION] = $value;
 
                         break;
                 }
             }
 
-            $attributes->setAttribute(ResourceAttributes::HOST_NAME, $hostName);
-            $attributes->setAttribute(ResourceAttributes::CLOUD_PROVIDER, self::CLOUD_PROVIDER);
+            $attributes[ResourceAttributes::HOST_NAME] = $hostName;
+            $attributes[ResourceAttributes::CLOUD_PROVIDER] = self::CLOUD_PROVIDER;
 
-            return ResourceInfo::create(new Attributes($attributes), ResourceAttributes::SCHEMA_URL);
+            return ResourceInfo::create(Attributes::create($attributes), ResourceAttributes::SCHEMA_URL);
         } catch (\Throwable $e) {
             //TODO: add 'Process is not running on K8S when logging is added
             return ResourceInfoFactory::emptyResource();
@@ -175,7 +175,7 @@ class Detector implements ResourceDetectorInterface
             if (!empty($body) && $responseCode < 300 && $responseCode >= 200) {
                 return $body;
             }
-            
+
             return null;
         } catch (Throwable $e) {
             // TODO: add log for exception. The code below

--- a/src/Aws/Ecs/Detector.php
+++ b/src/Aws/Ecs/Detector.php
@@ -37,14 +37,14 @@ class Detector implements ResourceDetectorInterface
     private const ECS_METADATA_KEY_V3 = 'ECS_CONTAINER_METADATA_URI';
 
     private const CONTAINER_ID_LENGTH = 64;
-    
+
     private DataProvider $processData;
 
     public function __construct(DataProvider $processData)
     {
         $this->processData = $processData;
     }
-    
+
     /**
      * If running on ECS, runs getContainerId(), getClusterName(), and
      * returns resource with valid extracted values
@@ -63,7 +63,7 @@ class Detector implements ResourceDetectorInterface
 
         return !$hostName && !$containerId
             ? ResourceInfoFactory::emptyResource()
-            : ResourceInfo::create(new Attributes([
+            : ResourceInfo::create(Attributes::create([
                 ResourceAttributes::CONTAINER_NAME => $hostName,
                 ResourceAttributes::CONTAINER_ID => $containerId,
             ]));

--- a/src/Aws/Eks/Detector.php
+++ b/src/Aws/Eks/Detector.php
@@ -58,7 +58,7 @@ class Detector implements ResourceDetectorInterface
         $this->client = $client;
         $this->requestFactory = $requestFactory;
     }
-    
+
     public function getResource(): ResourceInfo
     {
         try {
@@ -68,10 +68,10 @@ class Detector implements ResourceDetectorInterface
 
             $clusterName = $this->getClusterName();
             $containerId = $this->getContainerId();
-    
+
             return !$clusterName && !$containerId
                 ? ResourceInfoFactory::emptyResource()
-                : ResourceInfo::create(new Attributes([
+                : ResourceInfo::create(Attributes::create([
                     ResourceAttributes::CONTAINER_ID => $containerId,
                     ResourceAttributes::K8S_CLUSTER_NAME => $clusterName,
                 ]));

--- a/src/Aws/Lambda/Detector.php
+++ b/src/Aws/Lambda/Detector.php
@@ -43,7 +43,7 @@ class Detector implements ResourceDetectorInterface
         $lambdaName = getenv(self::LAMBDA_NAME_ENV);
         $functionVersion = getenv(self::LAMBDA_VERSION_ENV);
         $awsRegion = getenv(self::AWS_REGION_ENV);
-        
+
         // The following ternary operations are created because
         // the attributes class will only NOT create a variable
         // when it is set to null. getenv returns false when unsuccessful
@@ -53,7 +53,7 @@ class Detector implements ResourceDetectorInterface
 
         return !$lambdaName && !$awsRegion && !$functionVersion
             ? ResourceInfoFactory::emptyResource()
-            : ResourceInfo::create(new Attributes([
+            : ResourceInfo::create(Attributes::create([
                 ResourceAttributes::FAAS_NAME => $lambdaName,
                 ResourceAttributes::FAAS_VERSION => $functionVersion,
                 ResourceAttributes::CLOUD_REGION => $awsRegion,

--- a/src/Symfony/OtelSdkBundle/Resources/config/sdk.php
+++ b/src/Symfony/OtelSdkBundle/Resources/config/sdk.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Symfony\OtelSdkBundle\Resources;
 
-use OpenTelemetry\SDK\Common\Attribute\AttributeLimits;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Time\SystemClock;
 use OpenTelemetry\SDK\Resource;
@@ -44,12 +43,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // RESOURCE
 
-    $helper->setService(AttributeLimits::class);
-
     $helper->setService(Attributes::class)
         ->args([
             ConfigHelper::wrapParameter(Parameters::RESOURCE_ATTRIBUTES),
-            ConfigHelper::createReferenceFromClass(AttributeLimits::class),
+            0,
         ]);
 
     $helper->setService(Resource\ResourceInfo::class)

--- a/tests/Integration/Symfony/OtelSdkBundle/DependencyInjection/OtelSdkExtensionTest.php
+++ b/tests/Integration/Symfony/OtelSdkBundle/DependencyInjection/OtelSdkExtensionTest.php
@@ -6,7 +6,6 @@ namespace OpenTelemetry\Test\Integration\Symfony\OtelSdkBundle\DependencyInjecti
 
 use Exception;
 use OpenTelemetry\SDK;
-use OpenTelemetry\SDK\Common\Attribute\AttributeLimits;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Time\SystemClock;
 use OpenTelemetry\SDK\Trace\SpanProcessor;
@@ -60,11 +59,14 @@ class OtelSdkExtensionTest extends TestCase
     {
         $data = $this->loadTestData('resource');
 
-        $limits = $this->getDefinitionByClass(AttributeLimits::class);
+        $spanLimitsBuilder = $this->getDefinitionByClass(SDK\Trace\SpanLimitsBuilder::class);
 
         $this->assertEquals(
             array_values($data['resource']['limits']),
-            $limits->getArguments()
+            [
+                $spanLimitsBuilder->getMethodCalls()[0][1][0],
+                $spanLimitsBuilder->getMethodCalls()[1][1][0],
+            ]
         );
     }
 
@@ -87,7 +89,7 @@ class OtelSdkExtensionTest extends TestCase
             ConfigHelper::wrapParameter(Parameters::RESOURCE_ATTRIBUTES),
             $arguments[0]
         );
-        $this->assertReference(AttributeLimits::class, $arguments[1]);
+        $this->assertEquals(0, $arguments[1]);
     }
 
     public function testDefaultSampler(): void

--- a/tests/Integration/Symfony/OtelSdkBundle/Resources/SdkConfigTest.php
+++ b/tests/Integration/Symfony/OtelSdkBundle/Resources/SdkConfigTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenTelemetry\Test\Integration\Symfony\OtelSdkBundle\Resources;
 
 use Exception;
-use OpenTelemetry\SDK\Common\Attribute\AttributeLimits;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Time\SystemClock;
 use OpenTelemetry\SDK\Resource;
@@ -63,7 +62,6 @@ class SdkConfigTest extends TestCase
      */
     public function testResource()
     {
-        $this->assertServiceSetup(AttributeLimits::class);
         $this->assertServiceSetup(Attributes::class);
         $this->assertServiceSetup(Resource\ResourceInfo::class);
     }

--- a/tests/Unit/Aws/Ec2/DetectorTest.php
+++ b/tests/Unit/Aws/Ec2/DetectorTest.php
@@ -64,7 +64,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($client, $requestFactory);
 
         $this->assertEquals(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::HOST_ID => self::HOST_ID,
                     ResourceAttributes::CLOUD_AVAILABILITY_ZONE => self::CLOUD_ZONE,
@@ -147,7 +147,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($client, $requestFactory);
 
         $this->assertEquals(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::HOST_ID => self::HOST_ID,
                     ResourceAttributes::CLOUD_AVAILABILITY_ZONE => self::CLOUD_ZONE,
@@ -206,7 +206,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($client, $requestFactory);
 
         $this->assertEquals(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::HOST_ID => self::HOST_ID,
                     ResourceAttributes::CLOUD_AVAILABILITY_ZONE => self::CLOUD_ZONE,

--- a/tests/Unit/Aws/Ecs/DetectorTest.php
+++ b/tests/Unit/Aws/Ecs/DetectorTest.php
@@ -45,7 +45,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::CONTAINER_NAME => self::HOST_NAME,
                     ResourceAttributes::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
@@ -56,7 +56,7 @@ class DetectorTest extends TestCase
         //unset environment variable
         putenv(self::ECS_ENV_VAR_V4_KEY);
     }
-    
+
     /**
      * @test
      */
@@ -72,7 +72,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::CONTAINER_NAME => self::HOST_NAME,
                     ResourceAttributes::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
@@ -115,7 +115,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::CONTAINER_NAME => self::HOST_NAME,
                 ]
@@ -138,14 +138,14 @@ class DetectorTest extends TestCase
         $mockData->method('getHostName')->willReturn(self::HOST_NAME);
 
         $detector = new Detector($mockData);
-      
+
         $invalidCgroups = [self::INVALID_CGROUP_LENGTH, self::INVALID_CGROUP_EMPTY, self::INVALID_CGROUP_VALUES];
 
         foreach ($invalidCgroups as $invalidCgroup) {
             $mockData->method('getCgroupData')->willReturn($invalidCgroup);
 
             $this->assertEquals(ResourceInfo::create(
-                new Attributes(
+                Attributes::create(
                     [
                         ResourceAttributes::CONTAINER_NAME => self::HOST_NAME,
                     ]
@@ -172,7 +172,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
                 ]
@@ -195,7 +195,7 @@ class DetectorTest extends TestCase
 
         $mockData->method('getCgroupData')->willReturn(self::INVALID_CGROUP_LENGTH);
         $mockData->method('getHostName')->willReturn(null);
-        
+
         $detector = new Detector($mockData);
 
         $this->assertEquals(ResourceInfoFactory::emptyResource(), $detector->getResource());

--- a/tests/Unit/Aws/Eks/DetectorTest.php
+++ b/tests/Unit/Aws/Eks/DetectorTest.php
@@ -33,7 +33,7 @@ class DetectorTest extends TestCase
 
     private const EXTRACTED_CONTAINER_ID = 'bcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm';
     private const EXTRACTED_CLUSTER_NAME = 'my-cluster';
-    
+
     public function testValidKubernetes()
     {
         $mockData = $this->createMock(DataProvider::class);
@@ -47,7 +47,7 @@ class DetectorTest extends TestCase
             new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
 
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();
@@ -55,7 +55,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData, $client, $requestFactory);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
                     ResourceAttributes::K8S_CLUSTER_NAME => self::EXTRACTED_CLUSTER_NAME,
@@ -77,7 +77,7 @@ class DetectorTest extends TestCase
             new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
 
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();
@@ -85,7 +85,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData, $client, $requestFactory);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::K8S_CLUSTER_NAME => self::EXTRACTED_CLUSTER_NAME,
                 ]
@@ -106,7 +106,7 @@ class DetectorTest extends TestCase
             new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
 
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();
@@ -114,7 +114,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData, $client, $requestFactory);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::K8S_CLUSTER_NAME => self::EXTRACTED_CLUSTER_NAME,
                 ]
@@ -135,7 +135,7 @@ class DetectorTest extends TestCase
             new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
 
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();
@@ -143,7 +143,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData, $client, $requestFactory);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::K8S_CLUSTER_NAME => self::EXTRACTED_CLUSTER_NAME,
                 ]
@@ -151,7 +151,7 @@ class DetectorTest extends TestCase
         ), $detector->getResource());
     }
 
-    public function testValidContianerIdEmptyClusterName()
+    public function testValidContainerIdEmptyClusterName()
     {
         $mockData = $this->createMock(DataProvider::class);
 
@@ -164,7 +164,7 @@ class DetectorTest extends TestCase
             new Response(200, ['Foo' => 'Bar'], self::MOCK_EMPTY_CLUSTER_NAME),
 
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();
@@ -172,7 +172,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData, $client, $requestFactory);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
                 ]
@@ -193,7 +193,7 @@ class DetectorTest extends TestCase
             new Response(200, ['Foo' => 'Bar'], self::MOCK_EMPTY_CLUSTER_DATA),
 
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();
@@ -201,7 +201,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData, $client, $requestFactory);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
                 ]
@@ -209,7 +209,7 @@ class DetectorTest extends TestCase
         ), $detector->getResource());
     }
 
-    public function testValidContianerIdEmptyBody()
+    public function testValidContainerIdEmptyBody()
     {
         $mockData = $this->createMock(DataProvider::class);
 
@@ -222,7 +222,7 @@ class DetectorTest extends TestCase
             new Response(200, ['Foo' => 'Bar'], self::MOCK_EMPTY_BODY),
 
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();
@@ -230,7 +230,7 @@ class DetectorTest extends TestCase
         $detector = new Detector($mockData, $client, $requestFactory);
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes(
+            Attributes::create(
                 [
                     ResourceAttributes::CONTAINER_ID => self::EXTRACTED_CONTAINER_ID,
                 ]
@@ -251,7 +251,7 @@ class DetectorTest extends TestCase
             new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
 
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();
@@ -274,7 +274,7 @@ class DetectorTest extends TestCase
             new Response(200, ['Foo' => 'Bar'], self::MOCK_VALID_CLUSTER_RESPONSE),
 
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();
@@ -297,7 +297,7 @@ class DetectorTest extends TestCase
             new Response(200, ['Foo' => 'Bar'], self::MOCK_EMPTY_BODY),
 
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();
@@ -318,7 +318,7 @@ class DetectorTest extends TestCase
         $mockGuzzle = new MockHandler([
             new Response(200, ['Foo' => 'Bar'], self::MOCK_AWS_AUTH),
         ]);
-        
+
         $handlerStack = HandlerStack::create($mockGuzzle);
         $client = new Client(['handler' => $handlerStack]);
         $requestFactory = new HttpFactory();

--- a/tests/Unit/Aws/Lambda/DetectorTest.php
+++ b/tests/Unit/Aws/Lambda/DetectorTest.php
@@ -34,7 +34,7 @@ class DetectorTest extends TestCase
         $detector = new Detector();
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes([
+            Attributes::create([
                 ResourceAttributes::FAAS_NAME => self::LAMBDA_NAME_VAL,
                 ResourceAttributes::FAAS_VERSION => self::LAMBDA_VERSION_VAL,
                 ResourceAttributes::CLOUD_REGION => self::AWS_REGION_VAL,
@@ -67,7 +67,7 @@ class DetectorTest extends TestCase
         $detector = new Detector();
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes([
+            Attributes::create([
                 ResourceAttributes::FAAS_NAME => self::LAMBDA_NAME_VAL,
                 ResourceAttributes::CLOUD_PROVIDER => self::CLOUD_PROVIDER,
                 ])
@@ -88,7 +88,7 @@ class DetectorTest extends TestCase
         $detector = new Detector();
 
         $this->assertEquals(ResourceInfo::create(
-            new Attributes([
+            Attributes::create([
                 ResourceAttributes::FAAS_NAME => self::LAMBDA_NAME_VAL,
                 ResourceAttributes::CLOUD_REGION => self::AWS_REGION_VAL,
                 ResourceAttributes::CLOUD_PROVIDER => self::CLOUD_PROVIDER,


### PR DESCRIPTION
Symfony bundle do not work with open-telemetry/opentelemetry ^0.0.13

I was trying to fix it. 

Since https://github.com/open-telemetry/opentelemetry-php/commit/41f74d2aff169d651a56b0168bd78e0042b6dfe8 AttributeLimits was removed and Attributes contrustor was set to internal.

I managed to

- Remove AttributeLimit (in bundle config & in AWS Detector + fix tests)
- Fix Attributes construct (usage `Attributes::create` instead of `new Attributes()` )

PS : It's my first open source contribution, please let met know if I doind something wrong, i.e maybe i need to open issue somewhere before create PR)