### PR TITLE
Update the TracingKernelSubscriber example

### DIFF
--- a/src/Symfony/OtelSdkBundle/README.md
+++ b/src/Symfony/OtelSdkBundle/README.md
@@ -199,7 +199,7 @@ So our Listener class could look like this:
 namespace App\EventSubscriber;
 
 use OpenTelemetry\API\Trace\SpanInterface;
-use OpenTelemetry\SDK\Trace\Tracer;
+use OpenTelemetry\SDK\Trace\TracerProvider;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
@@ -207,20 +207,23 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class TracingKernelSubscriber implements EventSubscriberInterface
 {
-    private Tracer $tracer;
+    private TracerProvider $provider;
     private ?SpanInterface $mainSpan = null;
 
-    public function __construct(Tracer $tracer)
+    public function __construct(TracerProvider $provider)
     {
-        // store a reference to the Tracer instance in case we want to create
+        // store a reference to the TracerProvider in case we want to create
         // more spans on different events (not covered in this example)
-        $this->tracer = $tracer;
+        $this->provider = $provider;
     }
 
     public function onRequestEvent(RequestEvent $event)
     {
         // Create our main span and activate it
-        $this->mainSpan = $this->tracer->spanBuilder('main')->startSpan();
+        $this->mainSpan = $this->provider
+            ->getTracer('io.opentelemetry.contrib.php')
+            ->spanBuilder('main')
+            ->startSpan();
         $this->mainSpan->activate();
     }
 


### PR DESCRIPTION
Since changes in https://github.com/open-telemetry/opentelemetry-php/pull/760,
the original Kernel Listener example no longer works...

Following those changes, the stored Tracer instance gets deleted before the
application terminates so mainSpan can't be ended and none of the collected
trace info gets sent.
By refactoring to use TracerProvider instead, mainSpan's Tracer remains valid
during KernelEvents::TERMINATE so the trace session can be sent successfully.