### PR TITLE
Update CODEOWNERS to use the @open-telemetry/php-approvers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @bobstrecansky @zsistla @tidal @brettmc
+* @open-telemetry/php-approvers


### PR DESCRIPTION
Update CODEOWNERS to use the https://github.com/orgs/open-telemetry/teams/php-approvers team rather than individual contributor tags