### PR TITLE
store root span info directly in context instead of request attribute

### DIFF
--- a/src/Instrumentation/Psr15/src/Psr15Instrumentation.php
+++ b/src/Instrumentation/Psr15/src/Psr15Instrumentation.php
@@ -10,7 +10,6 @@ use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\Context\ContextKey;
 use function OpenTelemetry\Instrumentation\hook;
 use OpenTelemetry\SemConv\TraceAttributes;
 use Psr\Http\Message\ResponseInterface;
@@ -24,12 +23,11 @@ use Throwable;
  */
 class Psr15Instrumentation
 {
-    public static ContextKey $rootSpan;
+    public static $rootSpan;
 
     public static function register(): void
     {
         $instrumentation = new CachedInstrumentation('io.opentelemetry.contrib.php.psr15');
-
         /**
          * Create a span for each psr-15 middleware that is executed.
          */
@@ -126,4 +124,4 @@ class Psr15Instrumentation
     }
 }
 
-Psr15Instrumentation::$rootSpan = Context::createKey('rootSpan');
+Psr15Instrumentation::$rootSpan ??= Context::createKey('rootSpan');

--- a/src/Instrumentation/Psr15/tests/Integration/Psr15InstrumentationTest.php
+++ b/src/Instrumentation/Psr15/tests/Integration/Psr15InstrumentationTest.php
@@ -13,7 +13,9 @@ use OpenTelemetry\API\Common\Instrumentation\Configurator;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanInterface;
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\Contrib\Instrumentation\Psr15\Psr15Instrumentation;
 use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
@@ -161,8 +163,9 @@ class Psr15InstrumentationTest extends TestCase
                 if ($this->exception) {
                     throw $this->exception;
                 }
-                $span = $request->getAttribute(SpanInterface::class);
-                Assert::assertInstanceOf(Span::class, $span);
+                $rootSpan = Context::getCurrent()->get(Psr15Instrumentation::$rootSpan);
+                Assert::assertNotNull($rootSpan);
+                Assert::assertInstanceOf(Span::class, $rootSpan);
 
                 return new Response();
             }

--- a/src/Instrumentation/Psr15/tests/Integration/Psr15InstrumentationTest.php
+++ b/src/Instrumentation/Psr15/tests/Integration/Psr15InstrumentationTest.php
@@ -163,7 +163,7 @@ class Psr15InstrumentationTest extends TestCase
                 if ($this->exception) {
                     throw $this->exception;
                 }
-                $rootSpan = Context::getCurrent()->get(Psr15Instrumentation::$rootSpan);
+                $rootSpan = Context::getCurrent()->get(Psr15Instrumentation::getRootSpan());
                 Assert::assertNotNull($rootSpan);
                 Assert::assertInstanceOf(Span::class, $rootSpan);
 


### PR DESCRIPTION
Stop relying on library request attribute and use context instead to store information about root span