### PR TITLE
migrate context/swoole from main repo

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,13 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php-version: ['7.4', '8.0', '8.1']
-        project: ['Aws', 'Symfony', 'Instrumentation/Slim', 'Instrumentation/Psr15']
+        project: [
+          'Aws',
+          'Context/Swoole',
+          'Instrumentation/Slim',
+          'Instrumentation/Psr15',
+          'Symfony'
+        ]
         exclude:
           - project: 'Instrumentation/Slim'
             php-version: 7.4

--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -14,6 +14,8 @@ splits:
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/contrib-auto-psr15.git"
   - prefix: "src/Instrumentation/Slim"
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/contrib-auto-slim.git"
+  - prefix: "src/Context/Swoole"
+    target: "https://${GH_TOKEN}@github.com/opentelemetry-php/context-swoole.git"
 
 # List of references to split (defined as regexp)
 origins:

--- a/src/Context/Swoole/.php-cs-fixer.php
+++ b/src/Context/Swoole/.php-cs-fixer.php
@@ -1,0 +1,43 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->exclude('var/cache')
+    ->in(__DIR__);
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+    'concat_space' => ['spacing' => 'one'],
+    'declare_equal_normalize' => ['space' => 'none'],
+    'is_null' => true,
+    'modernize_types_casting' => true,
+    'ordered_imports' => true,
+    'php_unit_construct' => true,
+    'single_line_comment_style' => true,
+    'yoda_style' => false,
+    '@PSR2' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'blank_line_after_opening_tag' => true,
+    'blank_line_before_statement' => true,
+    'cast_spaces' => true,
+    'declare_strict_types' => true,
+    'function_typehint_space' => true,
+    'include' => true,
+    'lowercase_cast' => true,
+    'new_with_braces' => true,
+    'no_extra_blank_lines' => true,
+    'no_leading_import_slash' => true,
+    'echo_tag_syntax' => true,
+    'no_unused_imports' => true,
+    'no_useless_else' => true,
+    'no_useless_return' => true,
+    'phpdoc_order' => true,
+    'phpdoc_scalar' => true,
+    'phpdoc_types' => true,
+    'short_scalar_cast' => true,
+    'single_blank_line_before_namespace' => true,
+    'single_quote' => true,
+    'trailing_comma_in_multiline' => true,
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder($finder);
+

--- a/src/Context/Swoole/README.md
+++ b/src/Context/Swoole/README.md
@@ -1,0 +1,1 @@
+# OpenTelemetry Swoole context

--- a/src/Context/Swoole/composer.json
+++ b/src/Context/Swoole/composer.json
@@ -1,0 +1,34 @@
+{
+  "name": "open-telemetry/context-swoole",
+  "description": "Async Swoole/OpenSwoole context implementation for OpenTelemetry PHP.",
+  "keywords": ["opentelemetry", "otel", "contrib", "context", "swoole", "openswoole", "coroutine"],
+  "type": "library",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "opentelemetry-php contributors",
+      "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+    }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0",
+    "open-telemetry/context": "^0"
+  },
+  "autoload": {
+    "psr-4": {
+      "OpenTelemetry\\Contrib\\Context\\Swoole\\": "src/"
+    }
+  },
+  "require-dev": {
+    "friendsofphp/php-cs-fixer": "^3",
+    "nyholm/psr7": "*",
+    "phan/phan": "^5.0",
+    "php-http/mock-client": "*",
+    "phpstan/phpstan": "^1.1",
+    "phpstan/phpstan-phpunit": "^1.0",
+    "psalm/plugin-phpunit": "^0.16",
+    "open-telemetry/sdk": "^0",
+    "phpunit/phpunit": "^9.5",
+    "vimeo/psalm": "^4.0"
+  }
+}

--- a/src/Context/Swoole/phpstan.neon.dist
+++ b/src/Context/Swoole/phpstan.neon.dist
@@ -1,0 +1,9 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+
+parameters:
+    tmpDir: var/cache/phpstan
+    level: 8
+    paths:
+        - src
+        - tests

--- a/src/Context/Swoole/phpunit.xml.dist
+++ b/src/Context/Swoole/phpunit.xml.dist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    cacheResult="false"
+    colors="false"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    forceCoversAnnotation="false"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    stopOnRisky="false"
+    timeoutForSmallTests="1"
+    timeoutForMediumTests="10"
+    timeoutForLargeTests="60"
+    verbose="true">
+
+    <coverage processUncoveredFiles="true" disableCodeCoverageIgnore="false">
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
+
+    <php>
+        <ini name="date.timezone" value="UTC" />
+        <ini name="display_errors" value="On" />
+        <ini name="display_startup_errors" value="On" />
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
+
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/src/Context/Swoole/psalm.xml.dist
+++ b/src/Context/Swoole/psalm.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="3"
+    cacheDirectory="var/cache/psalm"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="tests"/>
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/Context/Swoole/src/SwooleContextDestructor.php
+++ b/src/Context/Swoole/src/SwooleContextDestructor.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Context\Swoole;
+
+use OpenTelemetry\Context\ExecutionContextAwareInterface;
+
+/**
+ * @internal
+ */
+final class SwooleContextDestructor
+{
+    private ExecutionContextAwareInterface $storage;
+    private int $cid;
+
+    public function __construct(ExecutionContextAwareInterface $storage, int $cid)
+    {
+        $this->storage = $storage;
+        $this->cid = $cid;
+    }
+
+    public function __destruct()
+    {
+        $this->storage->destroy($this->cid);
+    }
+}

--- a/src/Context/Swoole/src/SwooleContextHandler.php
+++ b/src/Context/Swoole/src/SwooleContextHandler.php
@@ -1,0 +1,61 @@
+<?php
+
+/** @noinspection PhpComposerExtensionStubsInspection */
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Context\Swoole;
+
+use OpenTelemetry\Context\ExecutionContextAwareInterface;
+use Swoole\Coroutine;
+
+/**
+ * @internal
+ *
+ * @phan-file-suppress PhanUndeclaredClassMethod
+ * @psalm-suppress UndefinedClass
+ */
+final class SwooleContextHandler
+{
+    private ExecutionContextAwareInterface $storage;
+
+    public function __construct(ExecutionContextAwareInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    public function switchToActiveCoroutine(): void
+    {
+        $cid = Coroutine::getCid();
+        if ($cid !== -1 && !$this->isForked($cid)) {
+            for ($pcid = $cid; ($pcid = Coroutine::getPcid($pcid)) !== -1 && !$this->isForked($pcid);) {
+            }
+
+            $this->storage->switch($pcid);
+            $this->forkCoroutine($cid);
+        }
+
+        $this->storage->switch($cid);
+    }
+
+    public function splitOffChildCoroutines(): void
+    {
+        $pcid = Coroutine::getCid();
+        foreach (Coroutine::listCoroutines() as $cid) {
+            if ($pcid === Coroutine::getPcid($cid) && !$this->isForked($cid)) {
+                $this->forkCoroutine($cid);
+            }
+        }
+    }
+
+    private function isForked(int $cid): bool
+    {
+        return isset(Coroutine::getContext($cid)[__CLASS__]);
+    }
+
+    private function forkCoroutine(int $cid): void
+    {
+        $this->storage->fork($cid);
+        Coroutine::getContext($cid)[__CLASS__] = new SwooleContextDestructor($this->storage, $cid);
+    }
+}

--- a/src/Context/Swoole/src/SwooleContextScope.php
+++ b/src/Context/Swoole/src/SwooleContextScope.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Context\Swoole;
+
+use OpenTelemetry\Context\ContextInterface;
+use OpenTelemetry\Context\ContextStorageScopeInterface;
+use OpenTelemetry\Context\ScopeInterface;
+
+/**
+ * @internal
+ */
+final class SwooleContextScope implements ScopeInterface, ContextStorageScopeInterface
+{
+    private ContextStorageScopeInterface $scope;
+    private SwooleContextHandler $handler;
+
+    public function __construct(ContextStorageScopeInterface $scope, SwooleContextHandler $handler)
+    {
+        $this->scope = $scope;
+        $this->handler = $handler;
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return $this->scope->offsetExists($offset);
+    }
+
+    /**
+     * @phan-suppress PhanUndeclaredClassAttribute
+     */
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        return $this->scope->offsetGet($offset);
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        $this->scope->offsetSet($offset, $value);
+    }
+
+    public function offsetUnset($offset): void
+    {
+        $this->scope->offsetUnset($offset);
+    }
+
+    public function context(): ContextInterface
+    {
+        return $this->scope->context();
+    }
+
+    public function detach(): int
+    {
+        $this->handler->switchToActiveCoroutine();
+
+        return $this->scope->detach();
+    }
+}

--- a/src/Context/Swoole/src/SwooleContextStorage.php
+++ b/src/Context/Swoole/src/SwooleContextStorage.php
@@ -1,0 +1,77 @@
+<?php
+
+/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Context\Swoole;
+
+use OpenTelemetry\Context\ContextInterface;
+use OpenTelemetry\Context\ContextStorageInterface;
+use OpenTelemetry\Context\ContextStorageScopeInterface;
+use OpenTelemetry\Context\ExecutionContextAwareInterface;
+
+final class SwooleContextStorage implements ContextStorageInterface, ExecutionContextAwareInterface
+{
+    /** @var ContextStorageInterface&ExecutionContextAwareInterface */
+    private ContextStorageInterface $storage;
+    private SwooleContextHandler $handler;
+
+    /**
+     * @param ContextStorageInterface&ExecutionContextAwareInterface $storage
+     */
+    public function __construct(ContextStorageInterface $storage)
+    {
+        $this->storage = $storage;
+        $this->handler = new SwooleContextHandler($storage);
+    }
+
+    public function fork($id): void
+    {
+        $this->handler->switchToActiveCoroutine();
+
+        $this->storage->fork($id);
+    }
+
+    public function switch($id): void
+    {
+        $this->handler->switchToActiveCoroutine();
+
+        $this->storage->switch($id);
+    }
+
+    public function destroy($id): void
+    {
+        $this->handler->switchToActiveCoroutine();
+
+        $this->storage->destroy($id);
+    }
+
+    public function scope(): ?ContextStorageScopeInterface
+    {
+        $this->handler->switchToActiveCoroutine();
+
+        if (($scope = $this->storage->scope()) === null) {
+            return null;
+        }
+
+        return new SwooleContextScope($scope, $this->handler);
+    }
+
+    public function current(): ContextInterface
+    {
+        $this->handler->switchToActiveCoroutine();
+
+        return $this->storage->current();
+    }
+
+    public function attach(ContextInterface $context): ContextStorageScopeInterface
+    {
+        $this->handler->switchToActiveCoroutine();
+        $this->handler->splitOffChildCoroutines();
+
+        $scope = $this->storage->attach($context);
+
+        return new SwooleContextScope($scope, $this->handler);
+    }
+}

--- a/src/Context/Swoole/tests/Unit/SwooleTest.php
+++ b/src/Context/Swoole/tests/Unit/SwooleTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Context\Swoole\tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class SwooleTest extends TestCase
+{
+    public function test_dummy(): void
+    {
+        $this->markTestSkipped('no tests exist for Context/Swoole');
+    }
+}


### PR DESCRIPTION
The original PR implementing swoole (https://github.com/open-telemetry/opentelemetry-php/pull/675) recommended that it be moved into contrib "in the future". Today is the future.