### PR TITLE
relax otel requirements, dont gitsplit tags

### DIFF
--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -23,5 +23,3 @@ splits:
 origins:
   - ^main$
   - ^split$
-  - ^v?\d+\.\d+\.\d+$
-  - ^v?\d+\.\d+\.\d+-?beta\d+$

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,31 +3,32 @@ FROM php:${PHP_VERSION}-cli-alpine as php_build
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN chmod +x /usr/local/bin/install-php-extensions; \
-    apk add --update binutils; \
-    install-php-extensions \
+RUN chmod +x /usr/local/bin/install-php-extensions \
+    && apk add --update binutils \
+    && install-php-extensions \
         ast \
+        grpc \
         xdebug \
         zip \
         pcntl \
         intl \
         @composer \
         open-telemetry/opentelemetry-php-instrumentation@main \
-    ; \
+     \
     # strip debug symbols from extensions to reduce size
-    find /usr/local/lib/php/extensions -name "*.so" -exec strip --strip-debug {} \;;
+    && find /usr/local/lib/php/extensions -name "*.so" -exec strip --strip-debug {} \;
 
 FROM php_build
 
 WORKDIR /usr/src/myapp
 
-RUN   apk add --no-cache bash git; \
-      find /usr/local/lib/php/extensions -type d -exec chmod +x -R {} \;; \
-      addgroup -g "1000" -S php; \
-      adduser --system \
+RUN   apk add --no-cache bash git \
+      && find /usr/local/lib/php/extensions -type d -exec chmod +x -R {} \; \
+      && addgroup -g "1000" -S php \
+      && adduser --system \
         --gecos "" \
         --ingroup "php" \
         --uid "1000" \
-        "php";
+        "php"
 
 USER php

--- a/src/Aws/composer.json
+++ b/src/Aws/composer.json
@@ -14,7 +14,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4 || ^8.0",
-        "open-telemetry/sdk": "^0",
+        "open-telemetry/sdk": "*",
         "aws/aws-sdk-php": "^3.232"
     },
     "require-dev": {

--- a/src/Context/Swoole/composer.json
+++ b/src/Context/Swoole/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^7.4 || ^8.0",
-    "open-telemetry/context": "^0"
+    "open-telemetry/context": "*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Psr15/composer.json
+++ b/src/Instrumentation/Psr15/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "^8.0",
     "ext-otel_instrumentation": "*",
-    "open-telemetry/api": "^0",
+    "open-telemetry/api": "*",
     "psr/http-server-middleware": "^1"
   },
   "autoload": {

--- a/src/Instrumentation/Psr18/composer.json
+++ b/src/Instrumentation/Psr18/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "^8.0",
     "ext-otel_instrumentation": "*",
-    "open-telemetry/api": "^0",
+    "open-telemetry/api": "*",
     "psr/http-client": "^1"
   },
   "autoload": {

--- a/src/Instrumentation/Slim/composer.json
+++ b/src/Instrumentation/Slim/composer.json
@@ -11,7 +11,7 @@
     "php": "^8.0",
     "ext-otel_instrumentation": "*",
     "ext-reflection": "*",
-    "open-telemetry/api": "^0",
+    "open-telemetry/api": "*",
     "slim/slim": "^4"
   },
   "require-dev": {

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "open-telemetry/opentelemetry": "*",
+        "open-telemetry/opentelemetry": "0.0.15",
         "php-http/discovery": "^1.14",
         "php-http/message": "^1.12"
     },
@@ -27,6 +27,7 @@
     "require-dev": {
         "composer/xdebug-handler": "^2.0",
         "dg/bypass-finals": "^1.3",
+        "ext-grpc": "*",
         "friendsofphp/php-cs-fixer": "^3.0",
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^2.0@RC",

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "open-telemetry/opentelemetry": "^0.0.15",
+        "open-telemetry/opentelemetry": "*",
         "php-http/discovery": "^1.14",
         "php-http/message": "^1.12"
     },


### PR DESCRIPTION
now that we have a beta, the versioning has changed so update projects that can work with beta.
Symfony doesn't, and needs some attention to make it work with >= 0.0.15, so for now peg it to that version
improve Dockerfile, as the use of semi-colons between commands in a build step causes some failures to be ignored, which is never what we want.