### PR TITLE
handle slim routing failure

### DIFF
--- a/src/Instrumentation/Slim/src/SlimInstrumentation.php
+++ b/src/Instrumentation/Slim/src/SlimInstrumentation.php
@@ -30,6 +30,7 @@ class SlimInstrumentation
          * This relies upon the existence of a request attribute with key SpanInterface::class
          * and type SpanInterface which represents the root span, having been previously set (eg
          * by PSR-15 auto-instrumentation)
+         * If routing fails (eg 404/not found), then the root span name will not be updated.
          *
          * @psalm-suppress ArgumentTypeCoercion
          */

--- a/src/Instrumentation/Slim/src/SlimInstrumentation.php
+++ b/src/Instrumentation/Slim/src/SlimInstrumentation.php
@@ -37,8 +37,8 @@ class SlimInstrumentation
             RoutingMiddleware::class,
             'performRouting',
             pre: null,
-            post: static function (RoutingMiddleware $middleware, array $params, ServerRequestInterface $request, ?Throwable $exception) {
-                if ($exception) {
+            post: static function (RoutingMiddleware $middleware, array $params, ?ServerRequestInterface $request, ?Throwable $exception) {
+                if ($exception || !$request) {
                     return;
                 }
                 $span = $request->getAttribute(SpanInterface::class);


### PR DESCRIPTION
if routing fails, there will be no request parameter to the post hook callback, so make it optional.