### PR TITLE
fixing phpstan errors

### DIFF
--- a/src/Aws/src/AwsSdkInstrumentation.php
+++ b/src/Aws/src/AwsSdkInstrumentation.php
@@ -93,7 +93,7 @@ class AwsSdkInstrumentation implements InstrumentationInterface
 
                 $carrier = [];
                 /** @phan-suppress-next-line PhanTypeMismatchArgument */
-                $this->span = $tracer->spanBuilder($this->clientName)->setSpanKind(AwsSdkInstrumentation::SPAN_KIND)->startSpan(); //@phpstan-ignore-line
+                $this->span = $tracer->spanBuilder($this->clientName)->setSpanKind(AwsSdkInstrumentation::SPAN_KIND)->startSpan();
                 $this->scope = $this->span->activate();
 
                 $propagator->inject($carrier);

--- a/src/Instrumentation/Slim/src/SlimInstrumentation.php
+++ b/src/Instrumentation/Slim/src/SlimInstrumentation.php
@@ -65,7 +65,7 @@ class SlimInstrumentation
             pre: static function (InvocationStrategyInterface $strategy, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
                 $callable = $params[0];
                 $name = CallableFormatter::format($callable);
-                $builder = $instrumentation->tracer()->spanBuilder($name) //@phpstan-ignore-line
+                $builder = $instrumentation->tracer()->spanBuilder($name)
                     ->setAttribute('code.function', $function)
                     ->setAttribute('code.namespace', $class)
                     ->setAttribute('code.filepath', $filename)


### PR DESCRIPTION
a recent phpstan feature is to complain about annotations that are not relevant (eg ignoring an error that is not there), so remove the offending annotations