### PR TITLE
fixing otel version requirements

### DIFF
--- a/src/Aws/composer.json
+++ b/src/Aws/composer.json
@@ -14,7 +14,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4 || ^8.0",
-        "open-telemetry/sdk": "*",
+        "open-telemetry/sdk": "^1.0",
         "aws/aws-sdk-php": "^3.232"
     },
     "require-dev": {

--- a/src/Aws/src/Ecs/Detector.php
+++ b/src/Aws/src/Ecs/Detector.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Aws\Ecs;
 
-use OpenTelemetry\SDK\Behavior\LogsMessagesTrait;
+use OpenTelemetry\API\Behavior\LogsMessagesTrait;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Resource\ResourceDetectorInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;

--- a/src/Aws/tests/Unit/Ecs/DetectorTest.php
+++ b/src/Aws/tests/Unit/Ecs/DetectorTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Response;
+use OpenTelemetry\API\Common\Log\LoggerHolder;
 use OpenTelemetry\Aws\Ecs\DataProvider;
 use OpenTelemetry\Aws\Ecs\Detector;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
@@ -17,6 +18,7 @@ use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 use OpenTelemetry\SemConv\ResourceAttributes;
 use OpenTelemetry\SemConv\ResourceAttributeValues;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 
 class DetectorTest extends TestCase
 {
@@ -35,6 +37,11 @@ class DetectorTest extends TestCase
     private const ECS_ENV_VAR_V3_KEY = 'ECS_CONTAINER_METADATA_URI';
     private const ECS_ENV_VAR_V4_VAL = 'ecs_metadata_v4_uri';
     private const ECS_ENV_VAR_V3_VAL = 'ecs_metadata_v3_uri';
+
+    public function setUp(): void
+    {
+        LoggerHolder::set(new NullLogger());
+    }
 
     /**
      * @test

--- a/src/Context/Swoole/composer.json
+++ b/src/Context/Swoole/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^7.4 || ^8.0",
-    "open-telemetry/context": "*"
+    "open-telemetry/context": "^1.0"
   },
   "autoload": {
     "psr-4": {
@@ -27,7 +27,7 @@
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.16",
-    "open-telemetry/sdk": "^0",
+    "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "^4.0"
   }

--- a/src/Context/Swoole/composer.json
+++ b/src/Context/Swoole/composer.json
@@ -10,6 +10,8 @@
       "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
     }
   ],
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
     "php": "^7.4 || ^8.0",
     "open-telemetry/context": "^1.0"

--- a/src/Instrumentation/HttpAsyncClient/composer.json
+++ b/src/Instrumentation/HttpAsyncClient/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "^8.0",
     "ext-otel_instrumentation": "*",
-    "open-telemetry/api": "^1",
+    "open-telemetry/api": "^1.0",
     "php-http/httplug": "^2"
   },
   "autoload": {
@@ -31,7 +31,7 @@
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.16",
-    "open-telemetry/sdk": "*",
+    "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "^4.0"
   }

--- a/src/Instrumentation/HttpAsyncClient/composer.json
+++ b/src/Instrumentation/HttpAsyncClient/composer.json
@@ -7,6 +7,7 @@
   "readme": "./README.md",
   "license": "Apache-2.0",
   "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
     "php": "^8.0",
     "ext-otel_instrumentation": "*",

--- a/src/Instrumentation/Psr15/composer.json
+++ b/src/Instrumentation/Psr15/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "^8.0",
     "ext-otel_instrumentation": "*",
-    "open-telemetry/api": "*",
+    "open-telemetry/api": "^1.0",
     "psr/http-server-middleware": "^1"
   },
   "autoload": {
@@ -29,7 +29,7 @@
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.16",
-    "open-telemetry/sdk": "^0",
+    "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "^4.0"
   }

--- a/src/Instrumentation/Psr15/composer.json
+++ b/src/Instrumentation/Psr15/composer.json
@@ -7,6 +7,7 @@
   "readme": "./README.md",
   "license": "Apache-2.0",
   "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
     "php": "^8.0",
     "ext-otel_instrumentation": "*",

--- a/src/Instrumentation/Psr18/composer.json
+++ b/src/Instrumentation/Psr18/composer.json
@@ -7,6 +7,7 @@
   "readme": "./README.md",
   "license": "Apache-2.0",
   "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
     "php": "^8.0",
     "ext-otel_instrumentation": "*",

--- a/src/Instrumentation/Psr18/composer.json
+++ b/src/Instrumentation/Psr18/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "^8.0",
     "ext-otel_instrumentation": "*",
-    "open-telemetry/api": "*",
+    "open-telemetry/api": "^1.0",
     "psr/http-client": "^1"
   },
   "autoload": {
@@ -29,7 +29,7 @@
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.16",
-    "open-telemetry/sdk": "^0",
+    "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "^4.0"
   }

--- a/src/Instrumentation/Slim/composer.json
+++ b/src/Instrumentation/Slim/composer.json
@@ -11,7 +11,7 @@
     "php": "^8.0",
     "ext-otel_instrumentation": "*",
     "ext-reflection": "*",
-    "open-telemetry/api": "*",
+    "open-telemetry/api": "^1.0",
     "slim/slim": "^4"
   },
   "require-dev": {
@@ -24,7 +24,7 @@
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.16",
-    "open-telemetry/sdk": "^0",
+    "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "^4.0"
   },

--- a/src/Instrumentation/Slim/composer.json
+++ b/src/Instrumentation/Slim/composer.json
@@ -7,6 +7,7 @@
   "readme": "./README.md",
   "license": "Apache-2.0",
   "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
     "php": "^8.0",
     "ext-otel_instrumentation": "*",


### PR DESCRIPTION
making core otel version requirements consistent, since some requirements were still ^0. Now, everything (except symfony) depends on ^1.0