### PR TITLE
[Fix]Laravel login error 

### DIFF
--- a/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\Contrib\Instrumentation\Laravel;
 use Illuminate\Foundation\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Http\RedirectResponse;
 use OpenTelemetry\API\Common\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Common\Instrumentation\Globals;
 use OpenTelemetry\API\Trace\Span;
@@ -54,7 +55,7 @@ class LaravelInstrumentation
 
                 return [$request];
             },
-            post: static function (Kernel $kernel, array $params, ?Response $response, ?Throwable $exception) {
+            post: static function (Kernel $kernel, array $params, Response|RedirectResponse|null $response, ?Throwable $exception) {
                 $scope = Context::storage()->scope();
                 if (!$scope) {
                     return;


### PR DESCRIPTION
After enter my credentials on Laravel login application, I received this error. So I change $response type adding Illuminate\Http\RedirectResponse to fix below error:

`
OpenTelemetry\Contrib\Instrumentation\Laravel\LaravelInstrumentation::OpenTelemetry\Contrib\Instrumentation\Laravel\{closure}(): Argument #3 ($response) must be of type ?Illuminate\Http\Response, Illuminate\Http\RedirectResponse given, called in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php on line 155 
`

This fix: https://github.com/open-telemetry/opentelemetry-php/issues/944