### PR TITLE
Be less restrictive when autoloading instrumentation libraries

### DIFF
--- a/src/Instrumentation/IO/_register.php
+++ b/src/Instrumentation/IO/_register.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use OpenTelemetry\Contrib\Instrumentation\IO\IOInstrumentation;
 
-if (extension_loaded('otel_instrumentation') === true) {
-    IOInstrumentation::register();
-} else {
+if (extension_loaded('otel_instrumentation') === false) {
     trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry IO auto-instrumentation', E_USER_WARNING);
+
+    return;
 }
+
+IOInstrumentation::register();

--- a/src/Instrumentation/IO/_register.php
+++ b/src/Instrumentation/IO/_register.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
-assert(extension_loaded('otel_instrumentation'));
+use OpenTelemetry\Contrib\Instrumentation\IO\IOInstrumentation;
 
-\OpenTelemetry\Contrib\Instrumentation\IO\IOInstrumentation::register();
+if (extension_loaded('otel_instrumentation') === true) {
+    IOInstrumentation::register();
+} else {
+    trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry IO auto-instrumentation', E_USER_WARNING);
+}

--- a/src/Instrumentation/Laravel/_register.php
+++ b/src/Instrumentation/Laravel/_register.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use OpenTelemetry\Contrib\Instrumentation\Laravel\LaravelInstrumentation;
 
-if (extension_loaded('otel_instrumentation') === true) {
-    LaravelInstrumentation::register();
-} else {
+if (extension_loaded('otel_instrumentation') === false) {
     trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry Laravel auto-instrumentation', E_USER_WARNING);
+
+    return;
 }
+
+LaravelInstrumentation::register();

--- a/src/Instrumentation/Laravel/_register.php
+++ b/src/Instrumentation/Laravel/_register.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
-assert(extension_loaded('otel_instrumentation'));
+use OpenTelemetry\Contrib\Instrumentation\Laravel\LaravelInstrumentation;
 
-\OpenTelemetry\Contrib\Instrumentation\Laravel\LaravelInstrumentation::register();
+if (extension_loaded('otel_instrumentation') === true) {
+    LaravelInstrumentation::register();
+} else {
+    trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry Laravel auto-instrumentation', E_USER_WARNING);
+}

--- a/src/Instrumentation/PDO/_register.php
+++ b/src/Instrumentation/PDO/_register.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
-assert(extension_loaded('otel_instrumentation'));
+use OpenTelemetry\Contrib\Instrumentation\PDO\PDOInstrumentation;
 
-\OpenTelemetry\Contrib\Instrumentation\PDO\PDOInstrumentation::register();
+if (extension_loaded('otel_instrumentation') === true) {
+    PDOInstrumentation::register();
+} else {
+    trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry PDO auto-instrumentation', E_USER_WARNING);
+}

--- a/src/Instrumentation/PDO/_register.php
+++ b/src/Instrumentation/PDO/_register.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use OpenTelemetry\Contrib\Instrumentation\PDO\PDOInstrumentation;
 
-if (extension_loaded('otel_instrumentation') === true) {
-    PDOInstrumentation::register();
-} else {
+if (extension_loaded('otel_instrumentation') === false) {
     trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry PDO auto-instrumentation', E_USER_WARNING);
+
+    return;
 }
+
+PDOInstrumentation::register();

--- a/src/Instrumentation/Slim/_register.php
+++ b/src/Instrumentation/Slim/_register.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
-assert(extension_loaded('otel_instrumentation'));
+use OpenTelemetry\Contrib\Instrumentation\Slim\SlimInstrumentation;
 
-\OpenTelemetry\Contrib\Instrumentation\Slim\SlimInstrumentation::register();
+if (extension_loaded('otel_instrumentation') === true) {
+    SlimInstrumentation::register();
+} else {
+    trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry Slim Framework auto-instrumentation', E_USER_WARNING);
+}

--- a/src/Instrumentation/Slim/_register.php
+++ b/src/Instrumentation/Slim/_register.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use OpenTelemetry\Contrib\Instrumentation\Slim\SlimInstrumentation;
 
-if (extension_loaded('otel_instrumentation') === true) {
-    SlimInstrumentation::register();
-} else {
+if (extension_loaded('otel_instrumentation') === false) {
     trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry Slim Framework auto-instrumentation', E_USER_WARNING);
+
+    return;
 }
+
+SlimInstrumentation::register();

--- a/src/Instrumentation/Symfony/_register.php
+++ b/src/Instrumentation/Symfony/_register.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use OpenTelemetry\Contrib\Instrumentation\Symfony\SymfonyInstrumentation;
 
-if (extension_loaded('otel_instrumentation') === true) {
-    SymfonyInstrumentation::register();
-} else {
+if (extension_loaded('otel_instrumentation') === false) {
     trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry Laravel auto-instrumentation', E_USER_WARNING);
+
+    return;
 }
+
+SymfonyInstrumentation::register();

--- a/src/Instrumentation/Symfony/_register.php
+++ b/src/Instrumentation/Symfony/_register.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
-assert(extension_loaded('otel_instrumentation'));
+use OpenTelemetry\Contrib\Instrumentation\Symfony\SymfonyInstrumentation;
 
-\OpenTelemetry\Contrib\Instrumentation\Symfony\SymfonyInstrumentation::register();
+if (extension_loaded('otel_instrumentation') === true) {
+    SymfonyInstrumentation::register();
+} else {
+    trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry Laravel auto-instrumentation', E_USER_WARNING);
+}

--- a/src/Instrumentation/Wordpress/_register.php
+++ b/src/Instrumentation/Wordpress/_register.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use OpenTelemetry\Contrib\Instrumentation\Wordpress\WordpressInstrumentation;
 
-assert(extension_loaded('otel_instrumentation'));
-
-WordpressInstrumentation::register();
+if (extension_loaded('otel_instrumentation') === true) {
+    WordpressInstrumentation::register();
+} else {
+    trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry Wordpress auto-instrumentation', E_USER_WARNING);
+}

--- a/src/Instrumentation/Wordpress/_register.php
+++ b/src/Instrumentation/Wordpress/_register.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use OpenTelemetry\Contrib\Instrumentation\Wordpress\WordpressInstrumentation;
 
-if (extension_loaded('otel_instrumentation') === true) {
-    WordpressInstrumentation::register();
-} else {
+if (extension_loaded('otel_instrumentation') === false) {
     trigger_error('The otel_instrumentation extension must be loaded in order to autoload the OpenTelemetry Wordpress auto-instrumentation', E_USER_WARNING);
+
+    return;
 }
+
+WordpressInstrumentation::register();


### PR DESCRIPTION
Emit a warning through PHP's `trigger_error` instead of using an `assert` function call. This allows one to use the libraries in environments where the extension might not be available. However, in case of issues, it will be clear through logs why code might not be instrumented. 

The following approach was shortly discussed in the CNCF Slack, which should be fine for the use case at hand. The project can still run in environments that are not compatible or that are misconfigured. 

I would personally also add a check for the `OTEL_PHP_AUTOLOAD_ENABLED` to let these autoload/configure. Through that, one could use the code in the libraries but not autoload it, or just let it autoload when needed. This can be discussed at a later point in time, though.

As a side note, I noticed that only the WordPress auto-instrumenter had an import for the Instrumentation class, so I took the liberty to add imports in all the files. Now they are more the same.