### PR TITLE
creating opentelemetry metapackage

### DIFF
--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -6,6 +6,8 @@ project_url: "https://github.com/open-telemetry/opentelemetry-php-contrib.git"
 
 # List of splits.
 splits:
+  - prefix: "src/MetaPackages/opentelemetry"
+    target: "https://${GH_TOKEN}@github.com/opentelemetry-meta/.git"
   - prefix: "src/Aws"
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/contrib-aws.git"
   - prefix: "src/Symfony"

--- a/src/MetaPackages/opentelemetry/README.md
+++ b/src/MetaPackages/opentelemetry/README.md
@@ -1,0 +1,14 @@
+# OpenTelemetry PHP metapackage
+
+[![Total Downloads](http://poser.pugx.org/open-telemetry/opentelemetry/downloads)](https://packagist.org/packages/open-telemetry/opentelemetry)
+
+This is a metapackage which provides:
+- the OpenTelemetry API and SDK
+- common HTTP-based exporters (OTLP and zipkin)
+- an HTTP factory (nyholm/psr7)
+- an HTTP client (symfony/http-client)
+
+This metapackage is useful to try out OpenTelemetry for PHP, but for production use we recommend requiring the packages/versions
+you need directly in your composer.json file.
+
+This is a read-only repository, please file issues and PRs at https://github.com/open-telemetry/opentelemetry-php

--- a/src/MetaPackages/opentelemetry/composer.json
+++ b/src/MetaPackages/opentelemetry/composer.json
@@ -1,0 +1,24 @@
+{
+  "name": "open-telemetry/opentelemetry",
+  "type": "metapackage",
+  "description": "OpenTelemetry metapackage",
+  "keywords": ["opentelemetry", "otel", "open-telemetry", "tracing", "logging", "metrics"],
+  "homepage": "https://opentelemetry.io/docs/php",
+  "readme": "./README.md",
+  "license": "Apache-2.0",
+  "require": {
+    "open-telemetry/api": "^1",
+    "open-telemetry/context": "^1",
+    "open-telemetry/sdk": "^1",
+    "open-telemetry/exporter-otlp": "^1",
+    "open-telemetry/exporter-zipkin": "^1",
+    "symfony/http-client": "^6",
+    "nyholm/psr7": "^1.5"
+  },
+  "authors": [
+    {
+      "name": "opentelemetry-php contributors",
+      "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+    }
+  ]
+}


### PR DESCRIPTION
to replace the popular but broken open-telemetry/opentelemetry package which was based on our monorepo before we started independently versioning packages.