### PR TITLE
metapackage version and relaxed symfony http requirement

### DIFF
--- a/src/MetaPackages/opentelemetry/README.md
+++ b/src/MetaPackages/opentelemetry/README.md
@@ -8,7 +8,9 @@ This is a metapackage which provides:
 - an HTTP factory (nyholm/psr7)
 - an HTTP client (symfony/http-client)
 
-This metapackage is useful to try out OpenTelemetry for PHP, but for production use we recommend requiring the packages/versions
+This meta-package is useful to try out OpenTelemetry for PHP, but for production use we recommend requiring the packages/versions
 you need directly in your composer.json file.
+
+The version of this meta-package does not align with any particular OpenTelemetry package versions.
 
 This is a read-only repository, please file issues and PRs at https://github.com/open-telemetry/opentelemetry-php

--- a/src/MetaPackages/opentelemetry/composer.json
+++ b/src/MetaPackages/opentelemetry/composer.json
@@ -7,12 +7,12 @@
   "readme": "./README.md",
   "license": "Apache-2.0",
   "require": {
-    "open-telemetry/api": "^1",
-    "open-telemetry/context": "^1",
-    "open-telemetry/sdk": "^1",
-    "open-telemetry/exporter-otlp": "^1",
-    "open-telemetry/exporter-zipkin": "^1",
-    "symfony/http-client": "^6",
+    "open-telemetry/api": "^1-beta",
+    "open-telemetry/context": "^1-beta",
+    "open-telemetry/sdk": "^1-beta",
+    "open-telemetry/exporter-otlp": "^1-beta",
+    "open-telemetry/exporter-zipkin": "^1-beta",
+    "symfony/http-client": "^5|^6",
     "nyholm/psr7": "^1.5"
   },
   "authors": [


### PR DESCRIPTION
allow supported symfony http packages (5.x is still LTS) so that we don't conflict with installs requiring a lesser version of that package. ensure that beta tag only installs beta stability, and update meta-package readme to mention versioning aims.