### PR TITLE
Use main image built in core repo

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: '3.7'
 services:
   php:
+    image: ghcr.io/open-telemetry/opentelemetry-php/opentelemetry-php-base:${PHP_VERSION:-7.4}
     build:
       context: ./docker
       dockerfile: Dockerfile


### PR DESCRIPTION
Instead of building a new one, we can reference the one that's already being built.