### PR TITLE
adding semconv dependency to packages that use it

### DIFF
--- a/src/Instrumentation/HttpAsyncClient/composer.json
+++ b/src/Instrumentation/HttpAsyncClient/composer.json
@@ -11,7 +11,8 @@
   "require": {
     "php": "^8.0",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1.0",
+    "open-telemetry/api": "^1",
+    "open-telemetry/sem-conv": "^1",
     "php-http/httplug": "^2"
   },
   "autoload": {

--- a/src/Instrumentation/IO/composer.json
+++ b/src/Instrumentation/IO/composer.json
@@ -10,7 +10,8 @@
   "require": {
     "php": "^8.2",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1"
+    "open-telemetry/api": "^1",
+    "open-telemetry/sem-conv": "^1"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",

--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -11,7 +11,8 @@
     "php": "^8.0",
     "laravel/framework": "*",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1"
+    "open-telemetry/api": "^1",
+    "open-telemetry/sem-conv": "^1"
   },
   "require-dev": {
     "laravel/sanctum": "*",

--- a/src/Instrumentation/PDO/composer.json
+++ b/src/Instrumentation/PDO/composer.json
@@ -10,7 +10,8 @@
   "require": {
     "php": "^8.2",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1"
+    "open-telemetry/api": "^1",
+    "open-telemetry/sem-conv": "^1"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",

--- a/src/Instrumentation/Psr15/composer.json
+++ b/src/Instrumentation/Psr15/composer.json
@@ -11,7 +11,8 @@
   "require": {
     "php": "^8.0",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1.0",
+    "open-telemetry/api": "^1",
+    "open-telemetry/sem-conv": "^1",
     "psr/http-server-middleware": "^1"
   },
   "autoload": {

--- a/src/Instrumentation/Psr18/composer.json
+++ b/src/Instrumentation/Psr18/composer.json
@@ -11,7 +11,8 @@
   "require": {
     "php": "^8.0",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1.0",
+    "open-telemetry/api": "^1",
+    "open-telemetry/sem-conv": "^1",
     "psr/http-client": "^1"
   },
   "autoload": {

--- a/src/Instrumentation/Slim/composer.json
+++ b/src/Instrumentation/Slim/composer.json
@@ -12,7 +12,8 @@
     "php": "^8.0",
     "ext-opentelemetry": "*",
     "ext-reflection": "*",
-    "open-telemetry/api": "^1.0",
+    "open-telemetry/api": "^1",
+    "open-telemetry/sem-conv": "^1",
     "slim/slim": "^4"
   },
   "require-dev": {

--- a/src/Instrumentation/Symfony/composer.json
+++ b/src/Instrumentation/Symfony/composer.json
@@ -11,6 +11,7 @@
     "php": "^8.0",
     "ext-opentelemetry": "*",
     "open-telemetry/api": "^1",
+    "open-telemetry/sem-conv": "^1",
     "symfony/http-kernel": "*",
     "symfony/http-client-contracts": "*"
   },

--- a/src/Instrumentation/Wordpress/composer.json
+++ b/src/Instrumentation/Wordpress/composer.json
@@ -11,6 +11,7 @@
     "php": "^8.0",
     "ext-opentelemetry": "*",
     "open-telemetry/api": "^1",
+    "open-telemetry/sem-conv": "^1",
     "nyholm/psr7": "^1",
     "nyholm/psr7-server": "^1"
   },

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -15,6 +15,7 @@
         "open-telemetry/exporter-newrelic": "^1",
         "open-telemetry/exporter-otlp": "^1",
         "open-telemetry/exporter-zipkin": "^1",
+        "open-telemetry/sem-conv": "^1",
         "php-http/discovery": "^1.14",
         "php-http/message": "^1.12"
     },


### PR DESCRIPTION
semconv was previously a dependency of the API, but that was recently removed