### PR TITLE
fixing pdo constructor exception

### DIFF
--- a/src/Instrumentation/PDO/composer.json
+++ b/src/Instrumentation/PDO/composer.json
@@ -36,5 +36,10 @@
     "psr-4": {
       "OpenTelemetry\\Tests\\Instrumentation\\PDO\\": "tests/"
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": false
+    }
   }
 }

--- a/src/Instrumentation/PDO/src/PDOInstrumentation.php
+++ b/src/Instrumentation/PDO/src/PDOInstrumentation.php
@@ -30,8 +30,9 @@ class PDOInstrumentation
                 $builder = self::makeBuilder($instrumentation, 'PDO::__construct', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT);
                 if ($class === \PDO::class) {
-                    $builder->setAttribute(TraceAttributes::DB_CONNECTION_STRING, $params[0] ?? 'unknown')
-                    ->setAttribute(TraceAttributes::DB_USER, $params[1] ?? 'unknown');
+                    $builder
+                        ->setAttribute(TraceAttributes::DB_CONNECTION_STRING, $params[0] ?? 'unknown')
+                        ->setAttribute(TraceAttributes::DB_USER, $params[1] ?? 'unknown');
                 }
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();
@@ -43,8 +44,13 @@ class PDOInstrumentation
                     return;
                 }
                 $span = Span::fromContext($scope->context());
-                $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
-                $span->setAttribute(TraceAttributes::DB_SYSTEM, $dbSystem);
+
+                try {
+                    $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, $dbSystem);
+                } catch (\Error $e) {
+                    //do nothing
+                }
                 self::end($exception);
             }
         );

--- a/src/Instrumentation/PDO/tests/Integration/PDOInstrumentationTest.php
+++ b/src/Instrumentation/PDO/tests/Integration/PDOInstrumentationTest.php
@@ -72,6 +72,13 @@ class PDOInstrumentationTest extends TestCase
         $this->assertSame('PDO::__construct', $span->getName());
     }
 
+    public function test_constructor_exception(): void
+    {
+        $this->expectException(\PDOException::class);
+        $this->expectExceptionMessage('could not find driver');
+        new \PDO('unknown:foo');
+    }
+
     public function test_statement_execution(): void
     {
         // @var ImmutableSpan $span


### PR DESCRIPTION
if PDO constructor fails, then we cannot get attributes which throws an exception from the post hook (obscuring the original exception). Adding a try/catch to avoid this.

Fixes https://github.com/open-telemetry/opentelemetry-php/issues/1017