### PR TITLE
Update wordpress example to work without lockfile

### DIFF
--- a/examples/instrumentation/Wordpress/autoinstrumented-wordpress.dockerfile
+++ b/examples/instrumentation/Wordpress/autoinstrumented-wordpress.dockerfile
@@ -1,6 +1,6 @@
 # Pull in dependencies with composer
 FROM composer:2.5 as build
-COPY composer.json composer.lock ./
+COPY composer.json ./
 RUN composer install --ignore-platform-reqs
 
 FROM wordpress:6.2


### PR DESCRIPTION
When I commited the example originally, I had the lockfile locally but it is actually gitignored causing the example to fail in a clean repo. Removed it from the dockerfile to fix.

Or should I check-in a lockfile?