### PR TITLE
Adds fallback support for get host name method for all laravel versions

### DIFF
--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -9,7 +9,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": "^8.0",
-    "laravel/framework": "*",
+    "laravel/framework": "^6.0",
     "ext-opentelemetry": "*",
     "open-telemetry/api": "^1",
     "open-telemetry/sem-conv": "^1"

--- a/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
@@ -119,11 +119,11 @@ class LaravelInstrumentation
 
     private static function httpHostName(Request $request): string
     {
-        if (method_exists($request, 'getHost')) {
-            return $request->getHost();
-        }
         if (method_exists($request, 'host')) {
             return $request->host();
+        }
+        if (method_exists($request, 'getHost')) {
+            return $request->getHost();
         }
         return null;
     }

--- a/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
@@ -56,7 +56,7 @@ class LaravelInstrumentation
                         ->setAttribute(TraceAttributes::HTTP_FLAVOR, $request->getProtocolVersion())
                         ->setAttribute(TraceAttributes::HTTP_CLIENT_IP, $request->ip())
                         ->setAttribute(TraceAttributes::HTTP_TARGET, self::httpTarget($request))
-                        ->setAttribute(TraceAttributes::NET_HOST_NAME, $request->host())
+                        ->setAttribute(TraceAttributes::NET_HOST_NAME, self::httpHostName($request))
                         ->setAttribute(TraceAttributes::NET_HOST_PORT, $request->getPort())
                         ->setAttribute(TraceAttributes::NET_PEER_PORT, $request->server('REMOTE_PORT'))
                         ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->userAgent())
@@ -115,5 +115,16 @@ class LaravelInstrumentation
         $question = $request->getBaseUrl() . $request->getPathInfo() === '/' ? '/?' : '?';
 
         return $query ? $request->path() . $question . $query : $request->path();
+    }
+
+    private static function httpHostName(Request $request): string
+    {
+        if (method_exists($request, 'getHost')) {
+            return $request->getHost();
+        }
+        if (method_exists($request, 'host')) {
+            return $request->host();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-php/issues/1045

First checks if `$request->host()` (introduced in [Illuminate Request 9.x](https://github.com/illuminate/http/blob/9.x/Request.php#L247) ) method exists, if yes then calls it to get the host name else fall back to `$request->getHost()` method  else returns `null`