### PR TITLE
monolog scope name from channel

### DIFF
--- a/src/Logs/Monolog/.php-cs-fixer.php
+++ b/src/Logs/Monolog/.php-cs-fixer.php
@@ -34,7 +34,7 @@ return $config->setRules([
     'phpdoc_scalar' => true,
     'phpdoc_types' => true,
     'short_scalar_cast' => true,
-    'single_blank_line_before_namespace' => true,
+    'blank_lines_before_namespace' => true,
     'single_quote' => true,
     'trailing_comma_in_multiline' => true,
     ])

--- a/src/Logs/Monolog/README.md
+++ b/src/Logs/Monolog/README.md
@@ -65,3 +65,11 @@ $logger = new \Monolog\Logger(
 );
 $logger->info('hello world');
 ```
+
+### Monolog context + extra
+
+Monolog's `context` and `extra` fields will be added as attributes to the log (with `context` taking precedence if the same key appears
+in both).
+
+Array values in context/extra [must be homogeneous](https://opentelemetry.io/docs/specs/otel/common/#attribute); if mixed values
+are found, the key will be dropped.

--- a/src/Logs/Monolog/README.md
+++ b/src/Logs/Monolog/README.md
@@ -65,11 +65,3 @@ $logger = new \Monolog\Logger(
 );
 $logger->info('hello world');
 ```
-
-### Monolog context + extra
-
-Monolog's `context` and `extra` fields will be added as attributes to the log (with `context` taking precedence if the same key appears
-in both).
-
-Array values in context/extra [must be homogeneous](https://opentelemetry.io/docs/specs/otel/common/#attribute); if mixed values
-are found, the key will be dropped.

--- a/src/Logs/Monolog/composer.json
+++ b/src/Logs/Monolog/composer.json
@@ -25,6 +25,7 @@
     "open-telemetry/exporter-otlp": ">=1.0.0beta6",
     "open-telemetry/sdk": ">=1.0.0beta7",
     "phan/phan": "^5.0",
+    "phpbench/phpbench": "^1.2",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.16",

--- a/src/Logs/Monolog/example/multiple-channels.php
+++ b/src/Logs/Monolog/example/multiple-channels.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Monolog\Logger;
+use OpenTelemetry\Contrib\Logs\Monolog\Handler;
+use OpenTelemetry\Contrib\Otlp\LogsExporter;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Common\Export\Stream\StreamTransportFactory;
+use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeFactory;
+use OpenTelemetry\SDK\Common\Time\ClockFactory;
+use OpenTelemetry\SDK\Logs\LoggerProvider;
+use OpenTelemetry\SDK\Logs\Processor\BatchLogsProcessor;
+use Psr\Log\LogLevel;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+/**
+ * Example of using the handler in two channels. The logs will each be attached to a different scope, named
+ * for the logger name/channel.
+ */
+
+$loggerProvider = new LoggerProvider(
+    new BatchLogsProcessor(
+        new LogsExporter((new StreamTransportFactory())->create('php://stdout', 'application/json')),
+        ClockFactory::getDefault()
+    ),
+    new InstrumentationScopeFactory(Attributes::factory()),
+);
+
+$handler = new Handler(
+    $loggerProvider,
+    LogLevel::INFO,
+);
+$logger_one = new Logger('monolog-one', [$handler]);
+$logger_two = new Logger('monolog-two', [$handler]);
+
+$logger_one->info('hello from logger one');
+$logger_two->info('hello from logger two');
+
+$loggerProvider->shutdown();

--- a/src/Logs/Monolog/phpbench.json.dist
+++ b/src/Logs/Monolog/phpbench.json.dist
@@ -1,0 +1,6 @@
+{
+    "$schema":"./vendor/phpbench/phpbench/phpbench.schema.json",
+    "runner.bootstrap": "vendor/autoload.php",
+    "runner.path": "tests/Benchmark",
+    "runner.file_pattern": "*Bench.php"
+}

--- a/src/Logs/Monolog/src/Handler.php
+++ b/src/Logs/Monolog/src/Handler.php
@@ -55,36 +55,10 @@ class Handler extends AbstractProcessingHandler
         $attributes = [];
         foreach (['extra', 'context'] as $key) {
             if (isset($formatted[$key]) && count($formatted[$key]) > 0) {
-                foreach ($formatted[$key] as $k => $v) {
-                    if ($mapped = self::mapToSemConv($k, $v, $record[$key][$k])) {
-                        $attributes += $mapped;
-                    } else {
-                        $attributes[$k] = $v;
-                    }
-                }
+                $logRecord->setAttribute($key, $formatted[$key]);
             }
         }
         $logRecord->setAttributes($attributes);
         $this->getLogger($record['channel'])->emit($logRecord);
-    }
-
-    /**
-     * @see https://github.com/open-telemetry/semantic-conventions/blob/main/specification/logs/semantic_conventions/exceptions.md
-     * @todo use SemConv, when generated for logs
-     */
-    protected static function mapToSemConv($key, $formatted, $original)
-    {
-        switch ($key) {
-            case 'exception':
-                /** @var \Throwable $original */
-                return [
-                    'exception.type' => $formatted['class'] ?? null,
-                    'exception.message' => $formatted['message'] ?? null,
-                    'exception.stacktrace' => $original->getTraceAsString(),
-                ];
-            default:
-        }
-
-        return null;
     }
 }

--- a/src/Logs/Monolog/src/Handler.php
+++ b/src/Logs/Monolog/src/Handler.php
@@ -12,7 +12,9 @@ use OpenTelemetry\API\Logs as API;
 
 class Handler extends AbstractProcessingHandler
 {
-    private API\LoggerInterface $logger;
+    /** @var API\LoggerInterface[] */
+    private array $loggers = [];
+    private API\LoggerProviderInterface $loggerProvider;
 
     /**
      * @psalm-suppress InvalidArgument
@@ -20,7 +22,16 @@ class Handler extends AbstractProcessingHandler
     public function __construct(API\LoggerProviderInterface $loggerProvider, $level, bool $bubble = true)
     {
         parent::__construct($level, $bubble);
-        $this->logger = $loggerProvider->getLogger('monolog');
+        $this->loggerProvider = $loggerProvider;
+    }
+
+    protected function getLogger(string $channel): API\LoggerInterface
+    {
+        if (!array_key_exists($channel, $this->loggers)) {
+            $this->loggers[$channel] = $this->loggerProvider->getLogger($channel);
+        }
+
+        return $this->loggers[$channel];
     }
 
     protected function getDefaultFormatter(): FormatterInterface
@@ -40,13 +51,40 @@ class Handler extends AbstractProcessingHandler
             ->setSeverityNumber(API\Map\Psr3::severityNumber($record['level_name']))
             ->setSeverityText($record['level_name'])
             ->setBody($formatted['message'])
-            ->setAttribute('channel', $record['channel'])
         ;
-        foreach (['context', 'extra'] as $key) {
+        $attributes = [];
+        foreach (['extra', 'context'] as $key) {
             if (isset($formatted[$key]) && count($formatted[$key]) > 0) {
-                $logRecord->setAttribute($key, $formatted[$key]);
+                foreach ($formatted[$key] as $k => $v) {
+                    if ($mapped = self::mapToSemConv($k, $v, $record[$key][$k])) {
+                        $attributes += $mapped;
+                    } else {
+                        $attributes[$k] = $v;
+                    }
+                }
             }
         }
-        $this->logger->emit($logRecord);
+        $logRecord->setAttributes($attributes);
+        $this->getLogger($record['channel'])->emit($logRecord);
+    }
+
+    /**
+     * @see https://github.com/open-telemetry/semantic-conventions/blob/main/specification/logs/semantic_conventions/exceptions.md
+     * @todo use SemConv, when generated for logs
+     */
+    protected static function mapToSemConv($key, $formatted, $original)
+    {
+        switch ($key) {
+            case 'exception':
+                /** @var \Throwable $original */
+                return [
+                    'exception.type' => $formatted['class'] ?? null,
+                    'exception.message' => $formatted['message'] ?? null,
+                    'exception.stacktrace' => $original->getTraceAsString(),
+                ];
+            default:
+        }
+
+        return null;
     }
 }

--- a/src/Logs/Monolog/src/Handler.php
+++ b/src/Logs/Monolog/src/Handler.php
@@ -52,13 +52,11 @@ class Handler extends AbstractProcessingHandler
             ->setSeverityText($record['level_name'])
             ->setBody($formatted['message'])
         ;
-        $attributes = [];
-        foreach (['extra', 'context'] as $key) {
+        foreach (['context', 'extra'] as $key) {
             if (isset($formatted[$key]) && count($formatted[$key]) > 0) {
                 $logRecord->setAttribute($key, $formatted[$key]);
             }
         }
-        $logRecord->setAttributes($attributes);
         $this->getLogger($record['channel'])->emit($logRecord);
     }
 }

--- a/src/Logs/Monolog/tests/Benchmark/LoggingBench.php
+++ b/src/Logs/Monolog/tests/Benchmark/LoggingBench.php
@@ -1,14 +1,9 @@
 <?php
 
+declare(strict_types=1);
 
 use Monolog\Logger;
 use OpenTelemetry\Contrib\Logs\Monolog\Handler;
-use OpenTelemetry\SDK\Common\Attribute\Attributes;
-use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeFactory;
-use OpenTelemetry\SDK\Common\Time\ClockFactory;
-use OpenTelemetry\SDK\Logs\Exporter\InMemoryExporter;
-use OpenTelemetry\SDK\Logs\LoggerProvider;
-use OpenTelemetry\SDK\Logs\Processor\BatchLogsProcessor;
 
 class LoggingBench
 {

--- a/src/Logs/Monolog/tests/Benchmark/LoggingBench.php
+++ b/src/Logs/Monolog/tests/Benchmark/LoggingBench.php
@@ -8,8 +8,6 @@ use OpenTelemetry\Contrib\Logs\Monolog\Handler;
 class LoggingBench
 {
     private array $loggers = [];
-    private ArrayObject $storage;
-
     public function setUp(array $params): void
     {
         $provider = new \OpenTelemetry\SDK\Logs\NoopLoggerProvider();

--- a/src/Logs/Monolog/tests/Benchmark/LoggingBench.php
+++ b/src/Logs/Monolog/tests/Benchmark/LoggingBench.php
@@ -1,0 +1,52 @@
+<?php
+
+
+use Monolog\Logger;
+use OpenTelemetry\Contrib\Logs\Monolog\Handler;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeFactory;
+use OpenTelemetry\SDK\Common\Time\ClockFactory;
+use OpenTelemetry\SDK\Logs\Exporter\InMemoryExporter;
+use OpenTelemetry\SDK\Logs\LoggerProvider;
+use OpenTelemetry\SDK\Logs\Processor\BatchLogsProcessor;
+
+class LoggingBench
+{
+    private array $loggers = [];
+    private ArrayObject $storage;
+
+    public function setUp(array $params): void
+    {
+        $provider = new \OpenTelemetry\SDK\Logs\NoopLoggerProvider();
+        $handler = new Handler($provider, \Psr\Log\LogLevel::INFO);
+        for ($i=0; $i<$params[0]; $i++) {
+            $this->loggers[$i] = new Logger('channel_' . $i, [$handler]);
+        }
+    }
+
+    /**
+     * @BeforeMethods("setUp")
+     * @ParamProviders("provideChannelCounts")
+     * @Revs(10)
+     * @Iterations(1)
+     * @OutputTimeUnit("microseconds")
+     */
+    public function benchEmitLogs(array $params): void
+    {
+        for ($i=0; $i<$params[1]; $i++) {
+            $this->loggers[array_rand($this->loggers)]->info('hello world');
+        }
+    }
+
+    public function provideChannelCounts(): \Generator
+    {
+        yield '1 channel, 100 logs' => [1, 100];
+        yield '1 channel, 10000 logs' => [1, 1000];
+        yield '4 channels, 100 logs' => [4, 100];
+        yield '4 channels, 10000 logs' => [4, 10000];
+        yield '16 channels, 100 logs' => [16, 100];
+        yield '16 channels, 10000 logs' => [16, 10000];
+        yield '256 channels, 100 logs' => [256, 100];
+        yield '256 channels, 10000 logs' => [256, 10000];
+    }
+}

--- a/src/Logs/Monolog/tests/Integration/HandlerTest.php
+++ b/src/Logs/Monolog/tests/Integration/HandlerTest.php
@@ -49,7 +49,7 @@ class HandlerTest extends TestCase
         $this->assertSame('INFO', $record->getSeverityText());
         $this->assertSame(9, $record->getSeverityNumber());
         $this->assertGreaterThan(0, $record->getTimestamp());
-        $this->assertSame('monolog', $record->getInstrumentationScope()->getName());
+        $this->assertSame('test', $record->getInstrumentationScope()->getName(), 'scope name is set from logger name');
     }
 
     public function test_log_debug_is_not_handled(): void

--- a/src/Logs/Monolog/tests/Unit/HandlerTest.php
+++ b/src/Logs/Monolog/tests/Unit/HandlerTest.php
@@ -63,16 +63,10 @@ class HandlerTest extends TestCase
                     $this->assertGreaterThan(0, $readable->getTimestamp());
                     $this->assertSame('message', $readable->getBody());
                     $attributes = $readable->getAttributes();
-                    $this->assertCount(3, $attributes);
-                    $this->assertEquals(['channel','context','extra'], array_keys($attributes->toArray()));
-                    $this->assertEquals([
-                        'foo' => 'bar',
-                        'baz' => 'bat',
-                    ], $attributes->get('extra'));
-                    $this->assertSame('bar', $attributes->get('context')['foo']);
-                    $this->assertSame('test', $attributes->get('channel'));
-                    $this->assertSame('bar', $attributes->get('context')['foo']);
-                    $this->assertNotNull($attributes->get('context')['exception']);
+                    $this->assertGreaterThan(3, count($attributes));
+                    $this->assertSame('bar', $attributes->get('foo'));
+                    $this->assertNotNull($attributes->get('exception.message'));
+                    $this->assertNotNull($attributes->get('exception.stacktrace'));
 
                     return true;
                 }

--- a/src/Logs/Monolog/tests/Unit/HandlerTest.php
+++ b/src/Logs/Monolog/tests/Unit/HandlerTest.php
@@ -69,7 +69,7 @@ class HandlerTest extends TestCase
                     $this->assertSame('message', $readable->getBody());
                     $attributes = $readable->getAttributes();
                     $this->assertCount(2, $attributes);
-                    $this->assertEquals(['extra', 'context'], array_keys($attributes->toArray()));
+                    $this->assertEquals(['context', 'extra'], array_keys($attributes->toArray()));
                     $this->assertEquals([
                         'foo' => 'bar',
                         'baz' => 'bat',


### PR DESCRIPTION
* exceptions were being emitted as an array under the 'exception' key, which does not conform to our new enforcement that array attribute values must be homogeneous. Instead, format the exception to use the proper sementic convention attributes ('exception.xyz`)
* do not emit context + extra as their own attribute keys. This will very often break the 'must be homogeneous' test, so move them up to top-level attribute (with context taking precedence if the same key exists in both)
* use the monolog channel name to create a scope for each channel (which means now the logger will create and reference one logger per scope/channel)

Fixes: https://github.com/open-telemetry/opentelemetry-php/issues/1049