### PR TITLE
Initial version of MongoDB instrumentation

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -132,7 +132,7 @@ jobs:
         mongodb-version: 6.0
 
     - name: Wait for MongoDB
-      uses: iFaxity/wait-on-action@1.1.0
+      uses: iFaxity/wait-on-action@v1.1.0
       if: ${{ matrix.project == 'Instrumentation/MongoDB' }}
       with:
         resource: tcp://localhost:27017

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,6 +27,7 @@ jobs:
           'Instrumentation/PDO',
           'Instrumentation/Symfony',
           'Instrumentation/Laravel',
+          'Instrumentation/MongoDB',
           'Logs/Monolog',
           'Propagation/TraceResponse',
           'ResourceDetectors/Container',

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -130,12 +130,7 @@ jobs:
       if: ${{ matrix.project == 'Instrumentation/MongoDB' }}
       with:
         mongodb-version: 6.0
-
-    - name: Wait for MongoDB
-      uses: iFaxity/wait-on-action@v1.1.0
-      if: ${{ matrix.project == 'Instrumentation/MongoDB' }}
-      with:
-        resource: tcp://localhost:27017
+        mongodb-replica-set: otel-php
 
     - name: Run PHPUnit (integration tests)
       working-directory: src/${{ matrix.project }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -132,7 +132,7 @@ jobs:
         mongodb-version: 6.0
 
     - name: Wait for MongoDB
-      uses: iFaxity/wait-on-action
+      uses: iFaxity/wait-on-action@1.1.0
       if: ${{ matrix.project == 'Instrumentation/MongoDB' }}
       with:
         resource: tcp://localhost:27017

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -131,6 +131,12 @@ jobs:
       with:
         mongodb-version: 6.0
 
+    - name: Wait for MongoDB
+      uses: iFaxity/wait-on-action
+      if: ${{ matrix.project == 'Instrumentation/MongoDB' }}
+      with:
+        resource: tcp://localhost:27017
+
     - name: Run PHPUnit (integration tests)
       working-directory: src/${{ matrix.project }}
       run: vendor/bin/phpunit --testsuite integration

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -125,6 +125,12 @@ jobs:
       working-directory: src/${{ matrix.project }}
       run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover --testsuite unit
 
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.8.0
+      if: ${{ matrix.project == 'Instrumentation/MongoDB' }}
+      with:
+        mongodb-version: 6.0
+
     - name: Run PHPUnit (integration tests)
       working-directory: src/${{ matrix.project }}
       run: vendor/bin/phpunit --testsuite integration

--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -18,6 +18,8 @@ splits:
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/contrib-auto-io.git"
   - prefix: "src/Instrumentation/Laravel"
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/contrib-auto-laravel.git"
+  - prefix: "src/Instrumentation/MongoDB"
+    target: "https://${GH_TOKEN}@github.com/opentelemetry-php/contrib-auto-mongodb.git"
   - prefix: "src/Instrumentation/PDO"
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/contrib-auto-pdo.git"
   - prefix: "src/Instrumentation/Psr3"

--- a/src/Instrumentation/MongoDB/.php-cs-fixer.php
+++ b/src/Instrumentation/MongoDB/.php-cs-fixer.php
@@ -1,0 +1,43 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->exclude('var/cache')
+    ->in(__DIR__);
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+    'concat_space' => ['spacing' => 'one'],
+    'declare_equal_normalize' => ['space' => 'none'],
+    'is_null' => true,
+    'modernize_types_casting' => true,
+    'ordered_imports' => true,
+    'php_unit_construct' => true,
+    'single_line_comment_style' => true,
+    'yoda_style' => false,
+    '@PSR2' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'blank_line_after_opening_tag' => true,
+    'blank_line_before_statement' => true,
+    'cast_spaces' => true,
+    'declare_strict_types' => true,
+    'function_typehint_space' => true,
+    'include' => true,
+    'lowercase_cast' => true,
+    'new_with_braces' => true,
+    'no_extra_blank_lines' => true,
+    'no_leading_import_slash' => true,
+    'echo_tag_syntax' => true,
+    'no_unused_imports' => true,
+    'no_useless_else' => true,
+    'no_useless_return' => true,
+    'phpdoc_order' => true,
+    'phpdoc_scalar' => true,
+    'phpdoc_types' => true,
+    'short_scalar_cast' => true,
+    'single_blank_line_before_namespace' => true,
+    'single_quote' => true,
+    'trailing_comma_in_multiline' => true,
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder($finder);
+

--- a/src/Instrumentation/MongoDB/README.md
+++ b/src/Instrumentation/MongoDB/README.md
@@ -1,14 +1,15 @@
 # OpenTelemetry MongoDB auto-instrumentation
 
 **Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [MongoDB](#Installation-via-composer)**
+**To run only this instrumentation, [install via composer](#Installation-via-composer)**
 
 ## Requirements
 
-* OpenTelemetry extension
-* OpenTelemetry SDK and exporters (required to actually export traces)
+-   OpenTelemetry extension
+-   OpenTelemetry SDK and exporters (required to actually export traces)
 
 ## Overview
+
 Auto-instrumentation hooks are registered via composer, and spans will automatically be created for all MongoDB
 operations like `find` or `aggregate`.
 
@@ -56,8 +57,8 @@ $ ./vendor/bin/phpunit tests
 Parts of this auto-instrumentation library can be configured, more options are available throught the
 [General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
 
-| Name                                | Default value | Values                  | Example | Description                                                                     |
-|-------------------------------------|---------------|-------------------------|---------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | mongodb | Disable one or more installed auto-instrumentations, names are comma seperated. |
+| Name                               | Default value | Values                  | Example | Description                                                                     |
+| ---------------------------------- | ------------- | ----------------------- | ------- | ------------------------------------------------------------------------------- |
+| OTEL_PHP_DISABLED_INSTRUMENTATIONS | []            | Instrumentation name(s) | mongodb | Disable one or more installed auto-instrumentations, names are comma seperated. |
 
 Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)

--- a/src/Instrumentation/MongoDB/README.md
+++ b/src/Instrumentation/MongoDB/README.md
@@ -1,0 +1,63 @@
+# OpenTelemetry MongoDB auto-instrumentation
+
+**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
+**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [MongoDB](#Installation-via-composer)**
+
+## Requirements
+
+* OpenTelemetry extension
+* OpenTelemetry SDK and exporters (required to actually export traces)
+
+## Overview
+Auto-instrumentation hooks are registered via composer, and spans will automatically be created for all MongoDB
+operations like `find` or `aggregate`.
+
+To export spans, you will need to create and register a `TracerProvider` early in your application's
+lifecycle. This can be done either manually or using SDK autoloading.
+
+### Using SDK autoloading
+
+See https://github.com/open-telemetry/opentelemetry-php#sdk-autoloading
+
+### Manual setup
+
+```php
+<?php
+require_once 'vendor/autoload.php';
+
+$tracerProvider = /*create tracer provider*/;
+$scope = \OpenTelemetry\API\Instrumentation\Configurator::create()
+    ->withTracerProvider($tracerProvider)
+    ->activate();
+
+//your application runs here
+
+$scope->detach();
+$tracerProvider->shutdown();
+```
+
+## Installation via composer
+
+```bash
+$ composer require open-telemetry/opentelemetry-auto-mongodb
+```
+
+## Installing dependencies and executing tests
+
+From MongoDB subdirectory:
+
+```bash
+$ composer install
+$ ./vendor/bin/phpunit tests
+```
+
+## Configuration
+
+Parts of this auto-instrumentation library can be configured, more options are available throught the
+[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+
+| Name                                | Default value | Values                  | Example | Description                                                                     |
+|-------------------------------------|---------------|-------------------------|---------|---------------------------------------------------------------------------------|
+| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | mongodb | Disable one or more installed auto-instrumentations, names are comma seperated. |
+
+Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)

--- a/src/Instrumentation/MongoDB/_register.php
+++ b/src/Instrumentation/MongoDB/_register.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenTelemetry\Contrib\Instrumentation\MongoDB\MongoDBInstrumentation;
+use OpenTelemetry\SDK\Sdk;
+
+if (class_exists(Sdk::class) && Sdk::isInstrumentationDisabled(MongoDBInstrumentation::NAME) === true) {
+    return;
+}
+
+MongoDBInstrumentation::register();

--- a/src/Instrumentation/MongoDB/composer.json
+++ b/src/Instrumentation/MongoDB/composer.json
@@ -8,8 +8,9 @@
   "license": "Apache-2.0",
   "minimum-stability": "dev",
   "require": {
-    "php": "^8.2",
+    "php": ">=7.4",
     "ext-mongodb": "*",
+    "ext-json": "*",
     "mongodb/mongodb": "^1.15",
     "open-telemetry/api": "^1.0.0beta10",
     "open-telemetry/sem-conv": "^1"

--- a/src/Instrumentation/MongoDB/composer.json
+++ b/src/Instrumentation/MongoDB/composer.json
@@ -18,7 +18,6 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",
     "phan/phan": "^5.0",
-    "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.16",

--- a/src/Instrumentation/MongoDB/composer.json
+++ b/src/Instrumentation/MongoDB/composer.json
@@ -1,0 +1,46 @@
+{
+  "name": "open-telemetry/opentelemetry-auto-mongodb",
+  "description": "OpenTelemetry auto-instrumentation for MongoDB",
+  "keywords": ["opentelemetry", "otel", "open-telemetry", "tracing", "mongodb", "mongo", "instrumentation"],
+  "type": "library",
+  "homepage": "https://opentelemetry.io/docs/php",
+  "readme": "./README.md",
+  "license": "Apache-2.0",
+  "minimum-stability": "dev",
+  "require": {
+    "php": "^8.2",
+    "ext-mongodb": "*",
+    "mongodb/mongodb": "^1.15",
+    "open-telemetry/api": "^1.0.0beta10",
+    "open-telemetry/sem-conv": "^1"
+  },
+  "require-dev": {
+    "friendsofphp/php-cs-fixer": "^3",
+    "phan/phan": "^5.0",
+    "php-http/mock-client": "*",
+    "phpstan/phpstan": "^1.1",
+    "phpstan/phpstan-phpunit": "^1.0",
+    "psalm/plugin-phpunit": "^0.16",
+    "open-telemetry/sdk": "^1.0",
+    "phpunit/phpunit": "^9.5",
+    "vimeo/psalm": "^4.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "OpenTelemetry\\Contrib\\Instrumentation\\MongoDB\\": "src/"
+    },
+    "files": [
+      "_register.php"
+    ]
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "OpenTelemetry\\Tests\\Instrumentation\\MongoDB\\": "tests/"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": false
+    }
+  }
+}

--- a/src/Instrumentation/MongoDB/phpstan.neon.dist
+++ b/src/Instrumentation/MongoDB/phpstan.neon.dist
@@ -1,0 +1,9 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+
+parameters:
+    tmpDir: var/cache/phpstan
+    level: 9
+    paths:
+        - src
+        - tests

--- a/src/Instrumentation/MongoDB/phpunit.xml.dist
+++ b/src/Instrumentation/MongoDB/phpunit.xml.dist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    cacheResult="false"
+    colors="false"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    forceCoversAnnotation="false"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    stopOnRisky="false"
+    timeoutForSmallTests="1"
+    timeoutForMediumTests="10"
+    timeoutForLargeTests="60"
+    verbose="true">
+
+    <coverage processUncoveredFiles="true" disableCodeCoverageIgnore="false">
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
+
+    <php>
+        <ini name="date.timezone" value="UTC" />
+        <ini name="display_errors" value="On" />
+        <ini name="display_startup_errors" value="On" />
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
+
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/src/Instrumentation/MongoDB/psalm.baseline.xml
+++ b/src/Instrumentation/MongoDB/psalm.baseline.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.x-dev@f630a0dc399170e5c7e8bd57ee28c2f5d01505e6">
+  <file src="vendor/phpunit/phpunit/src/Framework/TestCase.php">
+    <MissingConstructor occurrences="2">
+      <code>$backupStaticAttributes</code>
+      <code>$runTestInSeparateProcess</code>
+    </MissingConstructor>
+  </file>
+</files>

--- a/src/Instrumentation/MongoDB/psalm.xml.dist
+++ b/src/Instrumentation/MongoDB/psalm.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    cacheDirectory="var/cache/psalm"
+    errorBaseline="psalm.baseline.xml"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="tests"/>
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/Instrumentation/MongoDB/src/MongoDBCollectionExtractor.php
+++ b/src/Instrumentation/MongoDB/src/MongoDBCollectionExtractor.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\MongoDB;
+
+final class MongoDBCollectionExtractor
+{
+    public static function extract(object $command): ?string
+    {
+        /** @var mixed $maybeCollectionName */
+        $maybeCollectionName = array_values((array) $command)[0] ?? null;
+
+        // Special case for getMore
+        /** @var mixed $maybeCollectionName */
+        $maybeCollectionName = is_array($maybeCollectionName)
+            ? $maybeCollectionName['collection'] ?? null
+            : $maybeCollectionName;
+
+        return is_string($maybeCollectionName) ? $maybeCollectionName : null;
+    }
+}

--- a/src/Instrumentation/MongoDB/src/MongoDBInstrumentation.php
+++ b/src/Instrumentation/MongoDB/src/MongoDBInstrumentation.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\MongoDB;
+
+use function MongoDB\Driver\Monitoring\addSubscriber;
+use OpenTelemetry\API\Common\Instrumentation\CachedInstrumentation;
+
+final class MongoDBInstrumentation
+{
+    public const NAME = 'mongodb';
+
+    /**
+     * @param callable(object):?string $commandSerializer
+     */
+    public static function register(callable $commandSerializer = null): void
+    {
+        $instrumentation = new CachedInstrumentation('io.opentelemetry.contrib.php.mongodb');
+        $commandSerializer ??= self::defaultCommandSerializer();
+        /** @psalm-suppress UnusedFunctionCall */
+        addSubscriber(new MongoDBInstrumentationSubscriber($instrumentation, $commandSerializer));
+    }
+
+    /**
+     * @return callable(object):?string
+     */
+    private static function defaultCommandSerializer(): callable
+    {
+        return static fn (object $command): string => json_encode($command, JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Instrumentation/MongoDB/src/MongoDBInstrumentationSubscriber.php
+++ b/src/Instrumentation/MongoDB/src/MongoDBInstrumentationSubscriber.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\MongoDB;
+
+use Closure;
+use MongoDB\Driver\Monitoring\CommandFailedEvent;
+use MongoDB\Driver\Monitoring\CommandStartedEvent;
+use MongoDB\Driver\Monitoring\CommandSubscriber;
+use MongoDB\Driver\Monitoring\CommandSucceededEvent;
+use OpenTelemetry\API\Common\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\SpanBuilderInterface;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\SemConv\TraceAttributes;
+use Throwable;
+
+final class MongoDBInstrumentationSubscriber implements CommandSubscriber
+{
+    private CachedInstrumentation $instrumentation;
+    /**
+     * @var Closure(object):?string
+     */
+    private Closure $commandSerializer;
+
+    /**
+     * @param (callable(object):?string) $commandSerializer
+     */
+    public function __construct(CachedInstrumentation $instrumentation, callable $commandSerializer)
+    {
+        $this->instrumentation = $instrumentation;
+        $this->commandSerializer = static function (object $command) use ($commandSerializer): ?string {
+            try {
+                return $commandSerializer($command);
+            } catch (Throwable $exception) {
+                return null;
+            }
+        };
+    }
+
+    public function commandStarted(CommandStartedEvent $event): void
+    {
+        $command = $event->getCommand();
+        $collectionName = MongoDBCollectionExtractor::extract($command);
+        $databaseName = $event->getDatabaseName();
+        $commandName = $event->getCommandName();
+        $server = $event->getServer();
+        $info = $server->getInfo();
+        $port = $server->getPort();
+        $host = $server->getHost();
+        $isSocket = str_starts_with($host, '/');
+        $connectionString = self::getConnectionString($host, $port, $databaseName);
+        $scopedCommand = ($collectionName ? $collectionName . '.' : '') . $commandName;
+
+        $builder = self::startSpan($this->instrumentation, 'MongoDB ' . $scopedCommand)
+            ->setSpanKind(SpanKind::KIND_CLIENT)
+            ->setAttribute(TraceAttributes::DB_SYSTEM, 'mongodb')
+            ->setAttribute(TraceAttributes::DB_NAME, $databaseName)
+            ->setAttribute(TraceAttributes::DB_CONNECTION_STRING, $connectionString)
+            ->setAttribute(TraceAttributes::DB_OPERATION, $commandName)
+            ->setAttribute(TraceAttributes::NET_PEER_NAME, $isSocket ? null : $host)
+            ->setAttribute(TraceAttributes::NET_PEER_PORT, $isSocket ? null : $port)
+            ->setAttribute(TraceAttributes::NET_TRANSPORT, $isSocket ? 'unix' : 'tcp')
+            ->setAttribute(TraceAttributes::DB_STATEMENT, ($this->commandSerializer)($command))
+            ->setAttribute(TraceAttributes::DB_MONGODB_COLLECTION, $collectionName)
+            ->setAttribute(MongoDBTraceAttributes::DB_MONGODB_MASTER, $info['ismaster'] ?? null)
+            ->setAttribute(MongoDBTraceAttributes::DB_MONGODB_READ_ONLY, $info['readOnly'] ?? null)
+            ->setAttribute(MongoDBTraceAttributes::DB_MONGODB_CONNECTION_ID, $info['connectionId'] ?? null)
+            ->setAttribute(MongoDBTraceAttributes::DB_MONGODB_REQUEST_ID, $event->getRequestId())
+            ->setAttribute(MongoDBTraceAttributes::DB_MONGODB_OPERATION_ID, $event->getOperationId())
+            ->setAttribute(MongoDBTraceAttributes::DB_MONGODB_MAX_WIRE_VERSION, $info['maxWireVersion'] ?? null)
+            ->setAttribute(MongoDBTraceAttributes::DB_MONGODB_MIN_WIRE_VERSION, $info['minWireVersion'] ?? null)
+            ->setAttribute(MongoDBTraceAttributes::DB_MONGODB_MAX_BSON_OBJECT_SIZE_BYTES, $info['maxBsonObjectSize'] ?? null)
+            ->setAttribute(MongoDBTraceAttributes::DB_MONGODB_MAX_MESSAGE_SIZE_BYTES, $info['maxMessageSizeBytes'] ?? null)
+            ->setAttribute(MongoDBTraceAttributes::DB_MONGODB_MAX_WRITE_BATCH_SIZE, $info['maxWriteBatchSize'] ?? null);
+
+        $parent = Context::getCurrent();
+        $span = $builder->startSpan();
+        Context::storage()->attach($span->storeInContext($parent));
+    }
+
+    public function commandSucceeded(CommandSucceededEvent $event): void
+    {
+        self::endSpan();
+    }
+
+    public function commandFailed(CommandFailedEvent $event): void
+    {
+        self::endSpan($event->getError());
+    }
+
+    /**
+     * @param non-empty-string $name
+     */
+    private static function startSpan(CachedInstrumentation $instrumentation, string $name): SpanBuilderInterface
+    {
+        return $instrumentation->tracer()
+            ->spanBuilder($name);
+    }
+
+    private static function endSpan(?Throwable $exception = null): void
+    {
+        $scope = Context::storage()->scope();
+        if ($scope === null) {
+            return;
+        }
+
+        $scope->detach();
+        $span = Span::fromContext($scope->context());
+        if ($exception) {
+            $span->recordException($exception, [
+                TraceAttributes::EXCEPTION_ESCAPED => true,
+            ]);
+            $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
+        }
+
+        $span->end();
+    }
+
+    private static function getConnectionString(?string $host, ?int $port, string $databaseName): ?string
+    {
+        return $host && $port ? sprintf('mongodb://%s:%d/%s', $host, $port, $databaseName) : null;
+    }
+}

--- a/src/Instrumentation/MongoDB/src/MongoDBTraceAttributes.php
+++ b/src/Instrumentation/MongoDB/src/MongoDBTraceAttributes.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\MongoDB;
+
+interface MongoDBTraceAttributes
+{
+    public const DB_MONGODB_MASTER = 'db.mongodb.master';
+    public const DB_MONGODB_READ_ONLY = 'db.mongodb.read_only';
+    public const DB_MONGODB_CONNECTION_ID = 'db.mongodb.connection_id';
+    public const DB_MONGODB_REQUEST_ID = 'db.mongodb.request_id';
+    public const DB_MONGODB_OPERATION_ID = 'db.mongodb.operation_id';
+    public const DB_MONGODB_MAX_WIRE_VERSION = 'db.mongodb.max_wire_version';
+    public const DB_MONGODB_MIN_WIRE_VERSION = 'db.mongodb.min_wire_version';
+    public const DB_MONGODB_MAX_WRITE_BATCH_SIZE = 'db.mongodb.max_write_batch_size';
+    public const DB_MONGODB_MAX_BSON_OBJECT_SIZE_BYTES = 'db.mongodb.max_bson_object_size_bytes';
+    public const DB_MONGODB_MAX_MESSAGE_SIZE_BYTES = 'db.mongodb.max_message_size_bytes';
+}

--- a/src/Instrumentation/MongoDB/tests/Integration/MongoDBInstrumentationTest.php
+++ b/src/Instrumentation/MongoDB/tests/Integration/MongoDBInstrumentationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Instrumentation\MongoDB\tests\Integration;
 
 use ArrayObject;
+use MongoDB\Driver\Exception\ConnectionException;
 use MongoDB\Driver\Exception\ServerException;
 use MongoDB\Driver\Manager;
 use MongoDB\Operation\FindOne;
@@ -56,7 +57,7 @@ class MongoDBInstrumentationTest extends TestCase
 
         try {
             $find->execute($manager->selectServer());
-        } catch (ServerException $e) {
+        } catch (ServerException|ConnectionException $e) {
         }
 
         $this->assertCount(1, $this->storage);

--- a/src/Instrumentation/MongoDB/tests/Integration/MongoDBInstrumentationTest.php
+++ b/src/Instrumentation/MongoDB/tests/Integration/MongoDBInstrumentationTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Instrumentation\MongoDB\tests\Integration;
 
 use ArrayObject;
-use MongoDB\Driver\Exception\ConnectionException;
-use MongoDB\Driver\Exception\ServerException;
 use MongoDB\Driver\Manager;
 use MongoDB\Operation\FindOne;
 use OpenTelemetry\API\Instrumentation\Configurator;
@@ -51,14 +49,11 @@ class MongoDBInstrumentationTest extends TestCase
 
     public function test_mongodb_find_one(): void
     {
-        $manager = new Manager();
+        $manager = new Manager('mongodb://127.0.0.1:27017');
 
         $find = new FindOne(self::DATABASE_NAME, self::COLLECTION_NAME, ['a' => 'b']);
 
-        try {
-            $find->execute($manager->selectServer());
-        } catch (ServerException|ConnectionException $e) {
-        }
+        $find->execute($manager->selectServer());
 
         $this->assertCount(1, $this->storage);
         $this->span = $this->storage->offsetGet(0);

--- a/src/Instrumentation/MongoDB/tests/Integration/MongoDBInstrumentationTest.php
+++ b/src/Instrumentation/MongoDB/tests/Integration/MongoDBInstrumentationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Instrumentation\MongoDB\tests\Integration;
 
 use ArrayObject;
-use MongoDB\Driver\Exception\CommandException;
+use MongoDB\Driver\Exception\ServerException;
 use MongoDB\Driver\Manager;
 use MongoDB\Operation\FindOne;
 use OpenTelemetry\API\Instrumentation\Configurator;
@@ -19,7 +19,7 @@ use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\SemConv\TraceAttributes;
 use PHPUnit\Framework\TestCase;
 
-class IOInstrumentationTest extends TestCase
+class MongoDBInstrumentationTest extends TestCase
 {
     private const DATABASE_NAME = 'db';
     private const COLLECTION_NAME = 'coll';
@@ -56,7 +56,7 @@ class IOInstrumentationTest extends TestCase
 
         try {
             $find->execute($manager->selectServer());
-        } catch (CommandException $e) {
+        } catch (ServerException $e) {
         }
 
         $this->assertCount(1, $this->storage);

--- a/src/Instrumentation/MongoDB/tests/Integration/MongoDBInstrumentationTest.php
+++ b/src/Instrumentation/MongoDB/tests/Integration/MongoDBInstrumentationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Instrumentation\MongoDB\tests\Integration;
+
+use ArrayObject;
+use MongoDB\Driver\Exception\CommandException;
+use MongoDB\Driver\Manager;
+use MongoDB\Operation\FindOne;
+use OpenTelemetry\API\Instrumentation\Configurator;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\Contrib\Instrumentation\MongoDB\MongoDBTraceAttributes;
+use OpenTelemetry\SDK\Trace\ImmutableSpan;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\SemConv\TraceAttributes;
+use PHPUnit\Framework\TestCase;
+
+class IOInstrumentationTest extends TestCase
+{
+    private const DATABASE_NAME = 'db';
+    private const COLLECTION_NAME = 'coll';
+    private ScopeInterface $scope;
+    /** @var ArrayObject<int,ImmutableSpan> */
+    private ArrayObject $storage;
+    private ?ImmutableSpan $span = null;
+
+    public function setUp(): void
+    {
+        /** @psalm-suppress MixedPropertyTypeCoercion */
+        $this->storage = new ArrayObject();
+        $tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($this->storage)
+            )
+        );
+
+        $this->scope = Configurator::create()
+            ->withTracerProvider($tracerProvider)
+            ->activate();
+    }
+
+    public function tearDown(): void
+    {
+        $this->scope->detach();
+    }
+
+    public function test_mongodb_find_one(): void
+    {
+        $manager = new Manager();
+
+        $find = new FindOne(self::DATABASE_NAME, self::COLLECTION_NAME, ['a' => 'b']);
+
+        try {
+            $find->execute($manager->selectServer());
+        } catch (CommandException $e) {
+        }
+
+        $this->assertCount(1, $this->storage);
+        $this->span = $this->storage->offsetGet(0);
+
+        /** @psalm-suppress RedundantConditionGivenDocblockType */
+        self::assertNotNull($this->span);
+        self::assertSame('MongoDB coll.find', $this->span->getName());
+        self::assertSame(SpanKind::KIND_CLIENT, $this->span->getKind());
+        $attributes = $this->span->getAttributes();
+        self::assertSame('mongodb', $attributes->get(TraceAttributes::DB_SYSTEM));
+        self::assertSame(self::DATABASE_NAME, $attributes->get(TraceAttributes::DB_NAME));
+        self::assertSame('mongodb://127.0.0.1:27017/db', $attributes->get(TraceAttributes::DB_CONNECTION_STRING));
+        self::assertSame('find', $attributes->get(TraceAttributes::DB_OPERATION));
+        self::assertSame(self::COLLECTION_NAME, $attributes->get(TraceAttributes::DB_MONGODB_COLLECTION));
+        self::assertSame('127.0.0.1', $attributes->get(TraceAttributes::NET_PEER_NAME));
+        self::assertSame(27017, $attributes->get(TraceAttributes::NET_PEER_PORT));
+        self::assertSame('tcp', $attributes->get(TraceAttributes::NET_TRANSPORT));
+        self::assertTrue($attributes->get(MongoDBTraceAttributes::DB_MONGODB_MASTER));
+        self::assertFalse($attributes->get(MongoDBTraceAttributes::DB_MONGODB_READ_ONLY));
+        self::assertIsNumeric($attributes->get(MongoDBTraceAttributes::DB_MONGODB_CONNECTION_ID));
+        self::assertIsNumeric($attributes->get(MongoDBTraceAttributes::DB_MONGODB_REQUEST_ID));
+        self::assertIsNumeric($attributes->get(MongoDBTraceAttributes::DB_MONGODB_OPERATION_ID));
+        self::assertIsNumeric($attributes->get(MongoDBTraceAttributes::DB_MONGODB_MAX_WIRE_VERSION));
+        self::assertIsNumeric($attributes->get(MongoDBTraceAttributes::DB_MONGODB_MIN_WIRE_VERSION));
+        self::assertIsNumeric($attributes->get(MongoDBTraceAttributes::DB_MONGODB_MAX_BSON_OBJECT_SIZE_BYTES));
+        self::assertIsNumeric($attributes->get(MongoDBTraceAttributes::DB_MONGODB_MAX_MESSAGE_SIZE_BYTES));
+        self::assertIsNumeric($attributes->get(MongoDBTraceAttributes::DB_MONGODB_MAX_WRITE_BATCH_SIZE));
+    }
+}

--- a/src/Instrumentation/MongoDB/tests/Unit/MongoDBCollectionExtractorTest.php
+++ b/src/Instrumentation/MongoDB/tests/Unit/MongoDBCollectionExtractorTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Instrumentation\MongoDB\tests\Unit;
+
+use OpenTelemetry\Contrib\Instrumentation\MongoDB\MongoDBCollectionExtractor;
+use PHPUnit\Framework\TestCase;
+
+class MongoDBCollectionExtractorTest extends TestCase
+{
+    public function test_extract_collection_name(): void
+    {
+        self::assertSame('coll', MongoDBCollectionExtractor::extract((object) ['aggregate' => 'coll', 'find' => 'coll2']));
+    }
+
+    public function test_extract_collection_name_getMore(): void
+    {
+        self::assertSame('coll', MongoDBCollectionExtractor::extract((object) ['getMore' => ['getMore' => 123, 'collection' => 'coll', 'batchSize' => 10], 'find' => 'coll2']));
+    }
+}


### PR DESCRIPTION
Uses the MongoDB APM subscriber infrastructure instead of hooks, so it doesn’t even require the `opentelemetry` extension.

The sub-project setup was blatantly stolen from the PDO module so I am 100% I am missing something.