### PR TITLE
 Refactor symfony namespaces

### DIFF
--- a/src/Symfony/README.md
+++ b/src/Symfony/README.md
@@ -1,7 +1,3 @@
 # OpenTelemetry Symfony bundle
 
-## Installation
-
-```shell
-composer require open-telemetry/contrib-symfony-instrumentation-bundle
-```
+Installation and configuration instructions can be found in the [OtelSdkBundle subdirectory's README.md](src/OtelSdkBundle/README.md).

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "open-telemetry/contrib-sdk-bundle",
+    "name": "open-telemetry/symfony-sdk-bundle",
     "description": "OpenTelemetry Symfony integration",
     "type": "library",
     "license": "Apache-2.0",

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -20,12 +20,12 @@
     },
     "autoload": {
         "psr-4": {
-            "OpenTelemetry\\Symfony\\": "src"
+            "OpenTelemetry\\Contrib\\Symfony\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "OpenTelemetry\\Tests\\Symfony\\": "tests"
+            "OpenTelemetry\\Tests\\Contrib\\Symfony\\": "tests"
         }
     },
     "require-dev": {

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "open-telemetry/contrib-symfony-instrumentation-bundle",
+    "name": "open-telemetry/contrib-sdk-bundle",
     "description": "OpenTelemetry Symfony integration",
     "type": "library",
     "license": "Apache-2.0",

--- a/src/Symfony/src/OtelBundle/Console/ConsoleListener.php
+++ b/src/Symfony/src/OtelBundle/Console/ConsoleListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelBundle\Console;
+namespace OpenTelemetry\Contrib\Symfony\OtelBundle\Console;
 
 use function get_class;
 use OpenTelemetry\API\Trace\AbstractSpan as Span;
@@ -10,8 +10,8 @@ use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\OtelBundle;
 use OpenTelemetry\SemConv\TraceAttributes;
-use OpenTelemetry\Symfony\OtelBundle\OtelBundle;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;

--- a/src/Symfony/src/OtelBundle/DependencyInjection/Compiler/SetAliasIfNotDefinedCompilerPass.php
+++ b/src/Symfony/src/OtelBundle/DependencyInjection/Compiler/SetAliasIfNotDefinedCompilerPass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelBundle\DependencyInjection\Compiler;
+namespace OpenTelemetry\Contrib\Symfony\OtelBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Symfony/src/OtelBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/src/OtelBundle/DependencyInjection/Configuration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelBundle\DependencyInjection;
 
 use function class_exists;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;

--- a/src/Symfony/src/OtelBundle/DependencyInjection/OtelExtension.php
+++ b/src/Symfony/src/OtelBundle/DependencyInjection/OtelExtension.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelBundle\DependencyInjection;
 
 use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
-use OpenTelemetry\Symfony\OtelBundle\HttpKernel\RequestListener;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\HttpKernel\RequestListener;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Symfony/src/OtelBundle/HttpKernel/HeadersPropagator.php
+++ b/src/Symfony/src/OtelBundle/HttpKernel/HeadersPropagator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelBundle\HttpKernel;
+namespace OpenTelemetry\Contrib\Symfony\OtelBundle\HttpKernel;
 
 use function count;
 use function implode;

--- a/src/Symfony/src/OtelBundle/HttpKernel/RequestListener.php
+++ b/src/Symfony/src/OtelBundle/HttpKernel/RequestListener.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelBundle\HttpKernel;
+namespace OpenTelemetry\Contrib\Symfony\OtelBundle\HttpKernel;
 
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;
@@ -13,8 +13,8 @@ use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\Propagation\PropagationGetterInterface;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
 use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\OtelBundle;
 use OpenTelemetry\SemConv\TraceAttributes;
-use OpenTelemetry\Symfony\OtelBundle\OtelBundle;
 use function sprintf;
 use function strtolower;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/src/Symfony/src/OtelBundle/OtelBundle.php
+++ b/src/Symfony/src/OtelBundle/OtelBundle.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelBundle;
+namespace OpenTelemetry\Contrib\Symfony\OtelBundle;
 
 use function class_exists;
 use Composer\InstalledVersions;
@@ -12,7 +12,7 @@ use OpenTelemetry\API\Trace\NoopTracerProvider;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
-use OpenTelemetry\Symfony\OtelBundle\DependencyInjection\Compiler\SetAliasIfNotDefinedCompilerPass;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\DependencyInjection\Compiler\SetAliasIfNotDefinedCompilerPass;
 use OutOfBoundsException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/src/Symfony/src/OtelBundle/Resources/services_console.php
+++ b/src/Symfony/src/OtelBundle/Resources/services_console.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use OpenTelemetry\API\Trace\TracerProviderInterface;
-use OpenTelemetry\Symfony\OtelBundle\Console\ConsoleListener;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\Console\ConsoleListener;
 
 return static function (ContainerConfigurator $configurator): void {
     $configurator->services()->set(ConsoleListener::class)

--- a/src/Symfony/src/OtelBundle/Resources/services_kernel.php
+++ b/src/Symfony/src/OtelBundle/Resources/services_kernel.php
@@ -6,7 +6,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use OpenTelemetry\API\Trace\TracerProviderInterface;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
-use OpenTelemetry\Symfony\OtelBundle\HttpKernel\RequestListener;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\HttpKernel\RequestListener;
 
 return function (ContainerConfigurator $configurator): void {
     $configurator->services()->set(RequestListener::class)

--- a/src/Symfony/src/OtelSdkBundle/DataCollector/OtelDataCollector.php
+++ b/src/Symfony/src/OtelSdkBundle/DataCollector/OtelDataCollector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DataCollector;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DataCollector;
 
 use OpenTelemetry\API\Instrumentation\InstrumentationInterface;
 use OpenTelemetry\API\Instrumentation\InstrumentationTrait;

--- a/src/Symfony/src/OtelSdkBundle/Debug/TraceableSpanProcessor.php
+++ b/src/Symfony/src/OtelSdkBundle/Debug/TraceableSpanProcessor.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Debug;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Debug;
 
 use OpenTelemetry\Context\ContextInterface;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
 use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
 use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
-use OpenTelemetry\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
 
 /** @phan-file-suppress PhanUndeclaredInterface */
 /** @phan-file-suppress PhanUndeclaredTypeProperty */

--- a/src/Symfony/src/OtelSdkBundle/Debug/TraceableTracerProvider.php
+++ b/src/Symfony/src/OtelSdkBundle/Debug/TraceableTracerProvider.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Debug;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Debug;
 
 use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
-use OpenTelemetry\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
 
 /** @phan-file-suppress PhanUndeclaredInterface */
 /** @phan-file-suppress PhanUndeclaredTypeProperty */

--- a/src/Symfony/src/OtelSdkBundle/DependencyInjection/ConfigMappings.php
+++ b/src/Symfony/src/OtelSdkBundle/DependencyInjection/ConfigMappings.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection;
 
 interface ConfigMappings
 {

--- a/src/Symfony/src/OtelSdkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/src/OtelSdkBundle/DependencyInjection/Configuration.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection;
 
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ExporterDsnParser;
 use OpenTelemetry\SDK\Trace\SpanExporter\SpanExporterFactoryInterface;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ExporterDsnParser;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;

--- a/src/Symfony/src/OtelSdkBundle/DependencyInjection/ConfigurationException.php
+++ b/src/Symfony/src/OtelSdkBundle/DependencyInjection/ConfigurationException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection;
 
 use UnexpectedValueException;
 

--- a/src/Symfony/src/OtelSdkBundle/DependencyInjection/Ids.php
+++ b/src/Symfony/src/OtelSdkBundle/DependencyInjection/Ids.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection;
 
 interface Ids
 {

--- a/src/Symfony/src/OtelSdkBundle/DependencyInjection/OtelSdkExtension.php
+++ b/src/Symfony/src/OtelSdkBundle/DependencyInjection/OtelSdkExtension.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection;
 
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Configuration as Conf;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Trace\ExporterFactory;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Registry;
 use OpenTelemetry\SDK\Trace;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\Configuration as Conf;
-use OpenTelemetry\Symfony\OtelSdkBundle\Trace\ExporterFactory;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;

--- a/src/Symfony/src/OtelSdkBundle/DependencyInjection/Parameters.php
+++ b/src/Symfony/src/OtelSdkBundle/DependencyInjection/Parameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection;
 
 interface Parameters
 {

--- a/src/Symfony/src/OtelSdkBundle/DependencyInjection/Samplers.php
+++ b/src/Symfony/src/OtelSdkBundle/DependencyInjection/Samplers.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection;
 
 use OpenTelemetry\SDK\Trace\Sampler;
 

--- a/src/Symfony/src/OtelSdkBundle/DependencyInjection/SpanExporterFactories.php
+++ b/src/Symfony/src/OtelSdkBundle/DependencyInjection/SpanExporterFactories.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection;
 
 use OpenTelemetry\Contrib;
 

--- a/src/Symfony/src/OtelSdkBundle/DependencyInjection/SpanExporters.php
+++ b/src/Symfony/src/OtelSdkBundle/DependencyInjection/SpanExporters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection;
 
 use OpenTelemetry\Contrib;
 

--- a/src/Symfony/src/OtelSdkBundle/DependencyInjection/SpanProcessors.php
+++ b/src/Symfony/src/OtelSdkBundle/DependencyInjection/SpanProcessors.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection;
 
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Debug\TraceableSpanProcessor;
 use OpenTelemetry\SDK\Trace\SpanProcessor;
-use OpenTelemetry\Symfony\OtelSdkBundle\Debug\TraceableSpanProcessor;
 
 /** @phan-file-suppress PhanUndeclaredClassReference */
 interface SpanProcessors

--- a/src/Symfony/src/OtelSdkBundle/Factory/GenericFactoryInterface.php
+++ b/src/Symfony/src/OtelSdkBundle/Factory/GenericFactoryInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Factory;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Factory;
 
 use ReflectionClass;
 use Symfony\Component\OptionsResolver\OptionsResolver;

--- a/src/Symfony/src/OtelSdkBundle/Factory/GenericFactoryTrait.php
+++ b/src/Symfony/src/OtelSdkBundle/Factory/GenericFactoryTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Factory;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Factory;
 
 use InvalidArgumentException;
 use ReflectionClass;

--- a/src/Symfony/src/OtelSdkBundle/OtelSdkBundle.php
+++ b/src/Symfony/src/OtelSdkBundle/OtelSdkBundle.php
@@ -4,7 +4,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/src/Symfony/src/OtelSdkBundle/README.md
+++ b/src/Symfony/src/OtelSdkBundle/README.md
@@ -77,7 +77,7 @@ If you have symfony/flex installed in your project, the bundle should be automat
 
 return [
     // ...
-    OpenTelemetry\Symfony\OtelSdkBundle\OtelSdkBundle::class => ['all' => true],
+    OpenTelemetry\Contrib\Symfony\OtelSdkBundle\OtelSdkBundle::class => ['all' => true],
     // ...
 ];
 ````

--- a/src/Symfony/src/OtelSdkBundle/README.md
+++ b/src/Symfony/src/OtelSdkBundle/README.md
@@ -143,14 +143,14 @@ The bundle comes with advanced configuration for (almost) all user facing parts 
 [OpenTelemetry php SDK](https://github.com/open-telemetry/opentelemetry-php-contrib), which will be documented here, soon.
 For now, please refer to the configurations the bundle is tested against:
 
-- [minimal](/tests/Integration/Symfony/OtelSdkBundle/DependencyInjection/config/minimal/config.yaml)
-- [simple](/tests/Integration/Symfony/OtelSdkBundle/DependencyInjection/config/simple/config.yaml)
-- [resource](/tests/Integration/Symfony/OtelSdkBundle/DependencyInjection/config/resource/config.yaml)
-- [samplers](/tests/Integration/Symfony/OtelSdkBundle/DependencyInjection/config/sampler/config.yaml)
-- [span](/tests/Integration/Symfony/OtelSdkBundle/DependencyInjection/config/span/config.yaml)
-- [exporters](/tests/Integration/Symfony/OtelSdkBundle/DependencyInjection/config/exporters/config.yaml)
-- [full](/tests/Integration/Symfony/OtelSdkBundle/DependencyInjection/config/full/config.yaml)
-- [disabled](/tests/Integration/Symfony/OtelSdkBundle/DependencyInjection/config/disabled/config.yaml)
+- [minimal](../../tests/Integration/OtelSdkBundle/DependencyInjection/config/minimal/config.yaml)
+- [simple](../../tests/Integration/OtelSdkBundle/DependencyInjection/config/simple/config.yaml)
+- [resource](../../tests/Integration/OtelSdkBundle/DependencyInjection/config/resource/config.yaml)
+- [samplers](../../tests/Integration/OtelSdkBundle/DependencyInjection/config/sampler/config.yaml)
+- [span](../../tests/Integration/OtelSdkBundle/DependencyInjection/config/span/config.yaml)
+- [exporters](../../tests/Integration/OtelSdkBundle/DependencyInjection/config/exporters/config.yaml)
+- [full](../../tests/Integration/OtelSdkBundle/DependencyInjection/config/full/config.yaml)
+- [disabled](../../tests/Integration/OtelSdkBundle/DependencyInjection/config/disabled/config.yaml)
 
 ## 3. Usage
 

--- a/src/Symfony/src/OtelSdkBundle/Resources/config/sdk.php
+++ b/src/Symfony/src/OtelSdkBundle/Resources/config/sdk.php
@@ -2,9 +2,14 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Resources;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Resources;
 
 use OpenTelemetry\API;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Ids;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Parameters;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ConfigHelper;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServiceHelper;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServicesConfiguratorHelper;
 use OpenTelemetry\SDK;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Time\SystemClock;
@@ -12,11 +17,6 @@ use OpenTelemetry\SDK\Resource;
 use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Sampler;
 use OpenTelemetry\SDK\Trace\SpanProcessor;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\Ids;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\Parameters;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ConfigHelper;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ServiceHelper;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ServicesConfiguratorHelper;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 /** @phan-file-suppress PhanUndeclaredClassReference */

--- a/src/Symfony/src/OtelSdkBundle/Resources/config/tracer_debug.php
+++ b/src/Symfony/src/OtelSdkBundle/Resources/config/tracer_debug.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Resources;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Resources;
 
-use OpenTelemetry\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
-use OpenTelemetry\Symfony\OtelSdkBundle\Debug\TraceableSpanProcessor;
-use OpenTelemetry\Symfony\OtelSdkBundle\Debug\TraceableTracerProvider;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ConfigHelper;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Debug\TraceableSpanProcessor;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Debug\TraceableTracerProvider;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ConfigHelper;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $container) {

--- a/src/Symfony/src/OtelSdkBundle/Trace/ExporterFactory.php
+++ b/src/Symfony/src/OtelSdkBundle/Trace/ExporterFactory.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Trace;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Trace;
 
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Factory;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
-use OpenTelemetry\Symfony\OtelSdkBundle\Factory;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;

--- a/src/Symfony/src/OtelSdkBundle/Util/ConfigHelper.php
+++ b/src/Symfony/src/OtelSdkBundle/Util/ConfigHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Util;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util;
 
 use Symfony\Component\DependencyInjection\Reference;
 

--- a/src/Symfony/src/OtelSdkBundle/Util/ContainerConfiguratorHelper.php
+++ b/src/Symfony/src/OtelSdkBundle/Util/ContainerConfiguratorHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Util;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util;
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ServiceConfigurator;

--- a/src/Symfony/src/OtelSdkBundle/Util/ExporterDsn.php
+++ b/src/Symfony/src/OtelSdkBundle/Util/ExporterDsn.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Util;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util;
 
 use InvalidArgumentException;
 

--- a/src/Symfony/src/OtelSdkBundle/Util/ExporterDsnParser.php
+++ b/src/Symfony/src/OtelSdkBundle/Util/ExporterDsnParser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Util;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util;
 
 use InvalidArgumentException;
 

--- a/src/Symfony/src/OtelSdkBundle/Util/ServiceHelper.php
+++ b/src/Symfony/src/OtelSdkBundle/Util/ServiceHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Util;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util;
 
 class ServiceHelper
 {

--- a/src/Symfony/src/OtelSdkBundle/Util/ServicesConfiguratorHelper.php
+++ b/src/Symfony/src/OtelSdkBundle/Util/ServicesConfiguratorHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\OtelSdkBundle\Util;
+namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util;
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ServiceConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ServicesConfigurator;

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/ConfigurationTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\DependencyInjection;
 
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\Configuration;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\ConfigurationException;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Configuration;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\ConfigurationException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\NodeInterface;
 use Symfony\Component\Yaml\Parser;

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/OtelSdkExtensionTest.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/OtelSdkExtensionTest.php
@@ -2,23 +2,23 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\DependencyInjection;
 
 use Exception;
 use OpenTelemetry\Contrib\Otlp\SpanExporterFactory as OtlpExporterFactory;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Parameters;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Samplers;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\SpanProcessors;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ConfigHelper;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use OpenTelemetry\Contrib\Zipkin\SpanExporterFactory as ZipkinSpanExporterFactory;
 use OpenTelemetry\SDK;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Time\SystemClock;
 use OpenTelemetry\SDK\Trace\SpanProcessor;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\Parameters;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\Samplers;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\SpanProcessors;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ConfigHelper;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ServiceHelper;
-use OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock;
-use OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory as MockSpanExporterFactory;
+use OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock;
+use OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory as MockSpanExporterFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/_exceptions/custom_no_interface.yaml
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/_exceptions/custom_no_interface.yaml
@@ -6,6 +6,6 @@ trace:
     exporters:
       - type: custom
         # Class does not implement SpanExporterInterface
-        class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\InvalidSpanExporter
+        class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\InvalidSpanExporter
         options:
           foo: bar

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/exporters/config.yaml
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/exporters/config.yaml
@@ -18,7 +18,7 @@ trace:
     exporter3:
       type: custom
       processor: default
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
+      class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
     exporter4:
       type: custom
       processor: batch

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/exporters/expected.yaml
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/exporters/expected.yaml
@@ -18,7 +18,7 @@ trace:
     exporter3:
       type: custom
       processor: default
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
+      class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
       options: [ ]
     exporter4:
       type: custom

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/full/config.yaml
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/full/config.yaml
@@ -17,7 +17,7 @@ trace:
   sampler:
     root:
       type: custom
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\Sampler
+      class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\Sampler
       options:
         foo: bar
     remote:
@@ -45,7 +45,7 @@ trace:
         type: noop
       processor4:
         type: custom
-        class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanProcessor
+        class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\SpanProcessor
         options:
           foo: bar
       processor5:
@@ -68,7 +68,7 @@ trace:
     exporter3:
       type: custom
       processor: processor4
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
+      class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
     exporter4:
       type: custom
       processor: processor5

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/full/expected.yaml
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/full/expected.yaml
@@ -17,7 +17,7 @@ trace:
   sampler:
     root:
       type: custom
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\Sampler
+      class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\Sampler
       options:
         foo: bar
     remote:
@@ -57,7 +57,7 @@ trace:
         options: []
       processor4:
         type: custom
-        class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanProcessor
+        class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\SpanProcessor
         options:
           foo: bar
       processor5:
@@ -80,7 +80,7 @@ trace:
     exporter3:
       type: custom
       processor: processor4
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
+      class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
       options: []
     exporter4:
       type: custom

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/sampler/config.yaml
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/sampler/config.yaml
@@ -6,7 +6,7 @@ trace:
   sampler:
     root:
       type: custom
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\Sampler
+      class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\Sampler
       options:
         foo: bar
     remote:

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/sampler/expected.yaml
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/sampler/expected.yaml
@@ -7,7 +7,7 @@ trace:
   sampler:
     root:
       type: custom
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\Sampler
+      class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\Sampler
       options:
         foo: bar
     remote:

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/span/config.yaml
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/span/config.yaml
@@ -18,7 +18,7 @@ trace:
         type: noop
       processor4:
         type: custom
-        class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanProcessor
+        class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\SpanProcessor
         options:
           foo: bar
       processor5:

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/span/expected.yaml
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/config/span/expected.yaml
@@ -25,7 +25,7 @@ trace:
         options: []
       processor4:
         type: custom
-        class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanProcessor
+        class: OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\SpanProcessor
         options:
           foo: bar
       processor5:

--- a/src/Symfony/tests/Integration/OtelSdkBundle/Mock/InvalidSpanExporter.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/Mock/InvalidSpanExporter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock;
 
 class InvalidSpanExporter
 {

--- a/src/Symfony/tests/Integration/OtelSdkBundle/Mock/Sampler.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/Mock/Sampler.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock;
 
 class Sampler
 {

--- a/src/Symfony/tests/Integration/OtelSdkBundle/Mock/SpanExporter.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/Mock/SpanExporter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock;
 
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Common\Future\CompletedFuture;

--- a/src/Symfony/tests/Integration/OtelSdkBundle/Mock/SpanExporterFactory.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/Mock/SpanExporterFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock;
 
 use OpenTelemetry\SDK\Trace\SpanExporter\SpanExporterFactoryInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;

--- a/src/Symfony/tests/Integration/OtelSdkBundle/Mock/SpanProcessor.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/Mock/SpanProcessor.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock;
 
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 

--- a/src/Symfony/tests/Integration/OtelSdkBundle/OtelSdkBundleTest.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/OtelSdkBundleTest.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle;
 
 use Exception;
 use OpenTelemetry\API;
 use OpenTelemetry\Contrib;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\OtelSdkBundle;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use OpenTelemetry\Contrib\Zipkin\Exporter;
 use OpenTelemetry\SDK;
 use OpenTelemetry\SDK\Common\Export\Http\PsrTransport;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
-use OpenTelemetry\Symfony\OtelSdkBundle\OtelSdkBundle;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Symfony/tests/Integration/OtelSdkBundle/Resources/SdkConfigTest.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/Resources/SdkConfigTest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Resources;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Resources;
 
 use Exception;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Parameters;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Time\SystemClock;
 use OpenTelemetry\SDK\Resource;
 use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Sampler;
 use OpenTelemetry\SDK\Trace\SpanProcessor;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\Parameters;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Symfony/tests/Unit/OtelBundle/Console/ConsoleListenerTest.php
+++ b/src/Symfony/tests/Unit/OtelBundle/Console/ConsoleListenerTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\Test\Unit\OtelBundle\Console;
+namespace OpenTelemetry\Contrib\Symfony\Test\Unit\OtelBundle\Console;
 
 use OpenTelemetry\API\Trace\NoopTracerProvider;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\Console\ConsoleListener;
 use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
-use OpenTelemetry\Symfony\OtelBundle\Console\ConsoleListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;

--- a/src/Symfony/tests/Unit/OtelBundle/DependencyInjection/Compiler/SetAliasIfNotDefinedCompilerPassTest.php
+++ b/src/Symfony/tests/Unit/OtelBundle/DependencyInjection/Compiler/SetAliasIfNotDefinedCompilerPassTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\Test\Unit\OtelBundle\DependencyInjection\Compiler;
+namespace OpenTelemetry\Contrib\Symfony\Test\Unit\OtelBundle\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
-use OpenTelemetry\Symfony\OtelBundle\DependencyInjection\Compiler\SetAliasIfNotDefinedCompilerPass;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\DependencyInjection\Compiler\SetAliasIfNotDefinedCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class SetAliasIfNotDefinedCompilerPassTest extends AbstractCompilerPassTestCase

--- a/src/Symfony/tests/Unit/OtelBundle/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/tests/Unit/OtelBundle/DependencyInjection/ConfigurationTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\Test\Unit\OtelBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\Test\Unit\OtelBundle\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
-use OpenTelemetry\Symfony\OtelBundle\DependencyInjection\Configuration;
-use OpenTelemetry\Symfony\OtelBundle\DependencyInjection\OtelExtension;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\DependencyInjection\Configuration;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\DependencyInjection\OtelExtension;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
- * @covers \OpenTelemetry\Symfony\OtelBundle\DependencyInjection\Configuration
+ * @covers \OpenTelemetry\Contrib\Symfony\OtelBundle\DependencyInjection\Configuration
  */
 final class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 {

--- a/src/Symfony/tests/Unit/OtelBundle/DependencyInjection/OtelExtensionTest.php
+++ b/src/Symfony/tests/Unit/OtelBundle/DependencyInjection/OtelExtensionTest.php
@@ -2,20 +2,20 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\Test\Unit\OtelBundle\DependencyInjection;
+namespace OpenTelemetry\Contrib\Symfony\Test\Unit\OtelBundle\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use OpenTelemetry\API\Metrics\Noop\NoopMeterProvider;
 use OpenTelemetry\API\Trace\NoopTracerProvider;
 use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
-use OpenTelemetry\Symfony\OtelBundle\Console\ConsoleListener;
-use OpenTelemetry\Symfony\OtelBundle\DependencyInjection\OtelExtension;
-use OpenTelemetry\Symfony\OtelBundle\HttpKernel\RequestListener;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\Console\ConsoleListener;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\DependencyInjection\OtelExtension;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\HttpKernel\RequestListener;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * @covers \OpenTelemetry\Symfony\OtelBundle\DependencyInjection\OtelExtension
+ * @covers \OpenTelemetry\Contrib\Symfony\OtelBundle\DependencyInjection\OtelExtension
  */
 final class OtelExtensionTest extends AbstractExtensionTestCase
 {

--- a/src/Symfony/tests/Unit/OtelBundle/HttpKernel/HeadersPropagatorTest.php
+++ b/src/Symfony/tests/Unit/OtelBundle/HttpKernel/HeadersPropagatorTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\Test\Unit\OtelBundle\HttpKernel;
+namespace OpenTelemetry\Contrib\Symfony\Test\Unit\OtelBundle\HttpKernel;
 
-use OpenTelemetry\Symfony\OtelBundle\HttpKernel\HeadersPropagator;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\HttpKernel\HeadersPropagator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @covers \OpenTelemetry\Symfony\OtelBundle\HttpKernel\HeadersPropagator
+ * @covers \OpenTelemetry\Contrib\Symfony\OtelBundle\HttpKernel\HeadersPropagator
  */
 final class HeadersPropagatorTest extends TestCase
 {

--- a/src/Symfony/tests/Unit/OtelBundle/HttpKernel/RequestListenerTest.php
+++ b/src/Symfony/tests/Unit/OtelBundle/HttpKernel/RequestListenerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\Test\Unit\OtelBundle\HttpKernel;
+namespace OpenTelemetry\Contrib\Symfony\Test\Unit\OtelBundle\HttpKernel;
 
 use Exception;
 use OpenTelemetry\API\Trace\NoopTracerProvider;
@@ -11,10 +11,10 @@ use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\HttpKernel\RequestListener;
 use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
-use OpenTelemetry\Symfony\OtelBundle\HttpKernel\RequestListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Throwable;
 
 /**
- * @covers \OpenTelemetry\Symfony\OtelBundle\HttpKernel\RequestListener
+ * @covers \OpenTelemetry\Contrib\Symfony\OtelBundle\HttpKernel\RequestListener
  */
 final class RequestListenerTest extends TestCase
 {

--- a/src/Symfony/tests/Unit/OtelBundle/OtelBundleTest.php
+++ b/src/Symfony/tests/Unit/OtelBundle/OtelBundleTest.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\Test\Unit\OtelBundle;
+namespace OpenTelemetry\Contrib\Symfony\Test\Unit\OtelBundle;
 
 use function dirname;
 use function file_get_contents;
 use function json_decode;
-use OpenTelemetry\Symfony\OtelBundle\OtelBundle;
+use OpenTelemetry\Contrib\Symfony\OtelBundle\OtelBundle;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
- * @covers \OpenTelemetry\Symfony\OtelBundle\OtelBundle
+ * @covers \OpenTelemetry\Contrib\Symfony\OtelBundle\OtelBundle
  */
 final class OtelBundleTest extends TestCase
 {

--- a/src/Symfony/tests/Unit/OtelSdkBundle/DataCollector/OtelDataCollectorTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/DataCollector/OtelDataCollectorTest.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\Test\Unit\OtelSdkBundle\DataCollector;
+namespace OpenTelemetry\Contrib\Symfony\Test\Unit\OtelSdkBundle\DataCollector;
 
 use OpenTelemetry\Contrib\Otlp\SpanExporter;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
 use OpenTelemetry\Contrib\Zipkin\Exporter as ZipkinExporter;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
@@ -17,7 +18,6 @@ use OpenTelemetry\SDK\Trace\SpanLimitsBuilder;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\SDK\Trace\TracerSharedState;
-use OpenTelemetry\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\VarDumper\Cloner\Data;

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Debug/TraceableSpanProcessorTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Debug/TraceableSpanProcessorTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\Test\Unit\OtelSdkBundle\Debug;
+namespace OpenTelemetry\Contrib\Symfony\Test\Unit\OtelSdkBundle\Debug;
 
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Debug\TraceableSpanProcessor;
 use OpenTelemetry\SDK\Common\Time\ClockInterface;
 use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
 use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
@@ -12,8 +14,6 @@ use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
-use OpenTelemetry\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
-use OpenTelemetry\Symfony\OtelSdkBundle\Debug\TraceableSpanProcessor;
 use PHPUnit\Framework\TestCase;
 
 class TraceableSpanProcessorTest extends TestCase

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Debug/TraceableTracerProviderTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Debug/TraceableTracerProviderTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Symfony\Test\Unit\OtelSdkBundle\Debug;
+namespace OpenTelemetry\Contrib\Symfony\Test\Unit\OtelSdkBundle\Debug;
 
 use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Debug\TraceableTracerProvider;
 use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 use OpenTelemetry\SDK\Trace\RandomIdGenerator;
 use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
@@ -13,8 +15,6 @@ use OpenTelemetry\SDK\Trace\SpanLimitsBuilder;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
-use OpenTelemetry\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
-use OpenTelemetry\Symfony\OtelSdkBundle\Debug\TraceableTracerProvider;
 use PHPUnit\Framework\TestCase;
 
 class TraceableTracerProviderTest extends TestCase

--- a/src/Symfony/tests/Unit/OtelSdkBundle/DependencyInjection/ConfigurationExceptionTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/DependencyInjection/ConfigurationExceptionTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle\DependencyInjection;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Unit\OtelSdkBundle\DependencyInjection;
 
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\ConfigurationException;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\ConfigurationException;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationExceptionTest extends TestCase

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Factory/GenericFactoryTraitTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Factory/GenericFactoryTraitTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle\Factory;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Unit\OtelSdkBundle\Factory;
 
 use DG\BypassFinals;
 use InvalidArgumentException;
-use OpenTelemetry\Symfony\OtelSdkBundle\Factory\GenericFactoryInterface;
-use OpenTelemetry\Symfony\OtelSdkBundle\Factory\GenericFactoryTrait;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Factory\GenericFactoryInterface;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Factory\GenericFactoryTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;

--- a/src/Symfony/tests/Unit/OtelSdkBundle/OtelSdkBundleTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/OtelSdkBundleTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Unit\OtelSdkBundle;
 
-use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
-use OpenTelemetry\Symfony\OtelSdkBundle\OtelSdkBundle;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\OtelSdkBundle;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Trace/ExporterFactoryTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Trace/ExporterFactoryTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle\Trace;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Unit\OtelSdkBundle\Trace;
 
 use OpenTelemetry\Contrib;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Trace\ExporterFactory;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Common\Future\CompletedFuture;
 use OpenTelemetry\SDK\Common\Future\FutureInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
-use OpenTelemetry\Symfony\OtelSdkBundle\Trace\ExporterFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Client\ClientInterface;

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Util/ConfigHelperTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Util/ConfigHelperTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle\Util;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Unit\OtelSdkBundle\Util;
 
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ConfigHelper;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ConfigHelper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Reference;
 

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Util/ContainerConfiguratorHelperTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Util/ContainerConfiguratorHelperTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle\Util;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Unit\OtelSdkBundle\Util;
 
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ContainerConfiguratorHelper;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ContainerConfiguratorHelper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ServiceConfigurator;

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Util/ExporterDsnParserTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Util/ExporterDsnParserTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle\Util;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Unit\OtelSdkBundle\Util;
 
 use InvalidArgumentException;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ExporterDsn;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ExporterDsnParser;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ExporterDsn;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ExporterDsnParser;
 use PHPUnit\Framework\TestCase;
 
 class ExporterDsnParserTest extends TestCase

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Util/ExporterDsnTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Util/ExporterDsnTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle\Util;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Unit\OtelSdkBundle\Util;
 
 use InvalidArgumentException;
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ExporterDsn;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ExporterDsn;
 use PHPUnit\Framework\TestCase;
 
 class ExporterDsnTest extends TestCase

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Util/ServiceHelperTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Util/ServiceHelperTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle\Util;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Unit\OtelSdkBundle\Util;
 
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ServiceHelper;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use PHPUnit\Framework\TestCase;
 
 class ServiceHelperTest extends TestCase
@@ -12,7 +12,7 @@ class ServiceHelperTest extends TestCase
     public function testClassToId()
     {
         $this->assertSame(
-            'open_telemetry.symfony.otel_sdk_bundle.util.service_helper',
+            'open_telemetry.contrib.symfony.otel_sdk_bundle.util.service_helper',
             ServiceHelper::classToId(ServiceHelper::class)
         );
     }

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Util/ServicesConfiguratorHelperTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Util/ServicesConfiguratorHelperTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle\Util;
+namespace OpenTelemetry\Tests\Contrib\Symfony\Unit\OtelSdkBundle\Util;
 
-use OpenTelemetry\Symfony\OtelSdkBundle\Util\ServicesConfiguratorHelper;
+use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServicesConfiguratorHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;


### PR DESCRIPTION
Refactor Symfony bundle to be within the `OpenTelemetry\Contrib` namespace, in common with the other bundles and in line with the namespace in the main project.

Update documentation and make example configuration links relative so they work again 