### PR TITLE
Set required attribute of DB_SYSTEM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/*.iml
 composer.phar
 composer.lock
 var

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN chmod +x /usr/local/bin/install-php-extensions \
         pcntl \
         intl \
         @composer \
-        open-telemetry/opentelemetry-php-instrumentation@main \
+        opentelemetry-beta \
      \
     # strip debug symbols from extensions to reduce size
     && find /usr/local/lib/php/extensions -name "*.so" -exec strip --strip-debug {} \;

--- a/src/Instrumentation/PDO/composer.json
+++ b/src/Instrumentation/PDO/composer.json
@@ -9,6 +9,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": "^8.2",
+    "ext-pdo": "*",
     "ext-opentelemetry": "*",
     "open-telemetry/api": "^1.0.0beta10",
     "open-telemetry/sem-conv": "^1"

--- a/src/Instrumentation/PDO/src/PDOAttributeTracker.php
+++ b/src/Instrumentation/PDO/src/PDOAttributeTracker.php
@@ -86,7 +86,7 @@ final class PDOAttributeTracker
         return match ($driverName) {
             'mysql' => 'mysql',
             'pgsql' => 'postgresql',
-            'sqlite' => $driverName,
+            'sqlite' => 'sqlite',
             'sqlsrv' => 'mssql',
             'oci' => 'oracle',
             'ibm' => 'db2',

--- a/src/Instrumentation/PDO/src/PDOAttributeTracker.php
+++ b/src/Instrumentation/PDO/src/PDOAttributeTracker.php
@@ -38,9 +38,6 @@ final class PDOAttributeTracker
      */
     public function trackedAttributesForStatement(\PDOStatement $statement): iterable
     {
-        if (!$this->statementMapToPdoMap->offsetExists($statement)) {
-            return [];
-        }
 
         $pdo = ($this->statementMapToPdoMap[$statement] ?? null)?->get();
         if ($pdo === null) {

--- a/src/Instrumentation/PDO/src/PDOAttributeTracker.php
+++ b/src/Instrumentation/PDO/src/PDOAttributeTracker.php
@@ -86,21 +86,14 @@ final class PDOAttributeTracker
      */
     private static function mapDriverNameToAttribute(?string $driverName): string
     {
-        switch ($driverName) {
-            case 'mysql':
-                return 'mysql';
-            case 'pgsql':
-                return 'postgresql';
-            case 'sqlite':
-                return $driverName;
-            case 'sqlsrv':
-                return 'mssql';
-            case 'oci':
-                return 'oracle';
-            case 'ibm':
-                return 'db2';
-            default:
-                return 'other_sql';
-        }
+        return match ($driverName) {
+            'mysql' => 'mysql',
+            'pgsql' => 'postgresql',
+            'sqlite' => $driverName,
+            'sqlsrv' => 'mssql',
+            'oci' => 'oracle',
+            'ibm' => 'db2',
+            default => 'other_sql',
+        };
     }
 }

--- a/src/Instrumentation/PDO/src/PDOAttributeTracker.php
+++ b/src/Instrumentation/PDO/src/PDOAttributeTracker.php
@@ -71,7 +71,7 @@ final class PDOAttributeTracker
     {
         $key = spl_object_id($pdo);
 
-        return array_key_exists($key, $this->pdoToAttributesMap) ? $this->pdoToAttributesMap[$key] : [];
+        return $this->pdoToAttributesMap[$key] ?? [];
     }
 
     /**

--- a/src/Instrumentation/PDO/src/PDOAttributeTracker.php
+++ b/src/Instrumentation/PDO/src/PDOAttributeTracker.php
@@ -64,9 +64,7 @@ final class PDOAttributeTracker
             $attributes[TraceAttributes::DB_SYSTEM] = 'other_sql';
         }
 
-        $this->pdoToAttributesMap[spl_object_id($pdo)] = $attributes;
-
-        return $this->pdoToAttributesMap[spl_object_id($pdo)];
+        return $this->pdoToAttributesMap[spl_object_id($pdo)] = $attributes;
     }
 
     public function trackedAttributesForPdo(\PDO $pdo)

--- a/src/Instrumentation/PDO/src/PDOAttributeTracker.php
+++ b/src/Instrumentation/PDO/src/PDOAttributeTracker.php
@@ -24,10 +24,7 @@ final class PDOAttributeTracker
 
     public function removeMapping(\PDOStatement $statement)
     {
-        $key = spl_object_id($statement);
-        if (array_key_exists($key, $this->statementMapToPdoMap)) {
-            unset($this->statementMapToPdoMap[$key]);
-        }
+        unset($this->statementMapToPdoMap[spl_object_id($statement)]);
     }
 
     /**

--- a/src/Instrumentation/PDO/src/PDOAttributeTracker.php
+++ b/src/Instrumentation/PDO/src/PDOAttributeTracker.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\PDO;
+
+use OpenTelemetry\SemConv\TraceAttributes;
+
+final class PDOAttributeTracker
+{
+    private $pdoToAttributesMap;
+    private $statementMapToPdoMap;
+
+    public function __construct()
+    {
+        $this->pdoToAttributesMap = [];
+        $this->statementMapToPdoMap = [];
+    }
+
+    public function trackStatementToPdoMapping(\PDOStatement $statement, \PDO $pdo)
+    {
+        $this->statementMapToPdoMap[spl_object_id($statement)] = spl_object_id($pdo);
+    }
+
+    public function removeMapping(\PDOStatement $statement)
+    {
+        $key = spl_object_id($statement);
+        if (array_key_exists($key, $this->statementMapToPdoMap)) {
+            unset($this->statementMapToPdoMap[$key]);
+        }
+    }
+
+    /**
+     * Maps a statement back to the connection attributes.
+     *
+     * @param \PDOStatement $statement
+     * @return iterable<non-empty-string, bool|int|float|string|array|null>
+     */
+    public function trackedAttributesForStatement(\PDOStatement $statement): iterable
+    {
+        $statementKey = spl_object_id($statement);
+        if (!array_key_exists($statementKey, $this->statementMapToPdoMap)) {
+            return [];
+        }
+
+        $pdoKey = $this->statementMapToPdoMap[$statementKey];
+        if (!array_key_exists($pdoKey, $this->pdoToAttributesMap)) {
+            return [];
+        }
+
+        return $this->pdoToAttributesMap[$pdoKey];
+    }
+
+    /**
+     * @param \PDO $pdo
+     * @return iterable<non-empty-string, bool|int|float|string|array|null>
+     */
+    public function trackPdoAttributes(\PDO $pdo): iterable
+    {
+        $attributes = [];
+
+        try {
+            $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+            $attributes[TraceAttributes::DB_SYSTEM] = self::mapDriverNameToAttribute($dbSystem);
+        } catch (\Error $e) {
+            // if we catched an exception, the driver is likely not supporting the operation, default to "other"
+            $attributes[TraceAttributes::DB_SYSTEM] = 'other_sql';
+        }
+
+        $this->pdoToAttributesMap[spl_object_id($pdo)] = $attributes;
+
+        return $this->pdoToAttributesMap[spl_object_id($pdo)];
+    }
+
+    public function trackedAttributesForPdo(\PDO $pdo)
+    {
+        $key = spl_object_id($pdo);
+
+        return array_key_exists($key, $this->pdoToAttributesMap) ? $this->pdoToAttributesMap[$key] : [];
+    }
+
+    /**
+     * Mapping to known values
+     *
+     * @link https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#notes-and-well-known-identifiers-for-dbsystem
+     * @param string|null $driverName
+     * @return string
+     */
+    private static function mapDriverNameToAttribute(?string $driverName): string
+    {
+        switch ($driverName) {
+            case 'mysql':
+                return 'mysql';
+            case 'pgsql':
+                return 'postgresql';
+            case 'sqlite':
+                return $driverName;
+            case 'sqlsrv':
+                return 'mssql';
+            case 'oci':
+                return 'oracle';
+            case 'ibm':
+                return 'db2';
+            default:
+                return 'other_sql';
+        }
+    }
+}

--- a/src/Instrumentation/PDO/src/PDOInstrumentation.php
+++ b/src/Instrumentation/PDO/src/PDOInstrumentation.php
@@ -224,4 +224,30 @@ class PDOInstrumentation
 
         $span->end();
     }
+
+    /**
+     * Mapping to known values
+     *
+     * @link https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#notes-and-well-known-identifiers-for-dbsystem
+     * @param string|null $driverName
+     * @return string
+     */
+    private static function mapDriverNameToAttribute(?string $driverName): string {
+        switch ($driverName) {
+            case 'mysql':
+                return 'mysql';
+            case 'pgsql':
+                return 'postgresql';
+            case 'sqlite':
+                return $driverName;
+            case 'sqlsrv':
+                return 'mssql';
+            case 'oci':
+                return 'oracle';
+            case 'ibm':
+                return 'db2';
+            default:
+                return 'other_sql';
+        }
+    }
 }

--- a/src/Instrumentation/PDO/src/PDOInstrumentation.php
+++ b/src/Instrumentation/PDO/src/PDOInstrumentation.php
@@ -47,10 +47,11 @@ class PDOInstrumentation
 
                 try {
                     $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
-                    $span->setAttribute(TraceAttributes::DB_SYSTEM, $dbSystem);
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
                 } catch (\Error $e) {
                     //do nothing
                 }
+
                 self::end($exception);
             }
         );
@@ -67,6 +68,14 @@ class PDOInstrumentation
                 }
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();
+
+                try {
+                    $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
+                } catch (\Error $e) {
+                    //do nothing
+                }
+
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\PDO $pdo, array $params, mixed $statement, ?Throwable $exception) {
@@ -86,6 +95,14 @@ class PDOInstrumentation
                 }
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();
+
+                try {
+                    $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
+                } catch (\Error $e) {
+                    //do nothing
+                }
+
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\PDO $pdo, array $params, mixed $statement, ?Throwable $exception) {
@@ -105,6 +122,14 @@ class PDOInstrumentation
                 }
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();
+
+                try {
+                    $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
+                } catch (\Error $e) {
+                    //do nothing
+                }
+
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\PDO $pdo, array $params, mixed $statement, ?Throwable $exception) {
@@ -121,6 +146,14 @@ class PDOInstrumentation
                     ->setSpanKind(SpanKind::KIND_CLIENT);
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();
+
+                try {
+                    $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
+                } catch (\Error $e) {
+                    //do nothing
+                }
+
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\PDO $pdo, array $params, mixed $statement, ?Throwable $exception) {
@@ -137,6 +170,14 @@ class PDOInstrumentation
                     ->setSpanKind(SpanKind::KIND_CLIENT);
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();
+
+                try {
+                    $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
+                } catch (\Error $e) {
+                    //do nothing
+                }
+
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\PDO $pdo, array $params, mixed $statement, ?Throwable $exception) {
@@ -153,6 +194,14 @@ class PDOInstrumentation
                     ->setSpanKind(SpanKind::KIND_CLIENT);
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();
+
+                try {
+                    $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
+                } catch (\Error $e) {
+                    //do nothing
+                }
+
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\PDO $pdo, array $params, mixed $statement, ?Throwable $exception) {
@@ -169,6 +218,14 @@ class PDOInstrumentation
                     ->setSpanKind(SpanKind::KIND_CLIENT);
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();
+
+                try {
+                    $dbSystem = $statement->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
+                } catch (\Error $e) {
+                    //do nothing
+                }
+
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\PDOStatement $statement, array $params, mixed $retval, ?Throwable $exception) {
@@ -185,6 +242,14 @@ class PDOInstrumentation
                     ->setSpanKind(SpanKind::KIND_CLIENT);
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();
+
+                try {
+                    $dbSystem = $statement->getAttribute(\PDO::ATTR_DRIVER_NAME);
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
+                } catch (\Error $e) {
+                    //do nothing
+                }
+
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\PDOStatement $statement, array $params, mixed $retval, ?Throwable $exception) {
@@ -203,7 +268,6 @@ class PDOInstrumentation
         /** @psalm-suppress ArgumentTypeCoercion */
         return $instrumentation->tracer()
                     ->spanBuilder($name)
-                    ->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql')
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
                     ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)

--- a/src/Instrumentation/PDO/src/PDOInstrumentation.php
+++ b/src/Instrumentation/PDO/src/PDOInstrumentation.php
@@ -203,6 +203,7 @@ class PDOInstrumentation
         /** @psalm-suppress ArgumentTypeCoercion */
         return $instrumentation->tracer()
                     ->spanBuilder($name)
+                    ->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql')
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
                     ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)

--- a/src/Instrumentation/PDO/src/PDOInstrumentation.php
+++ b/src/Instrumentation/PDO/src/PDOInstrumentation.php
@@ -48,8 +48,9 @@ class PDOInstrumentation
                 try {
                     $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
                     $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
-                } catch (\Error $e) {
-                    //do nothing
+                } catch (\PDOException $e) {
+                    // if we catched an exception, the driver is likely not supporting the operation, default to "other"
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql');
                 }
 
                 self::end($exception);
@@ -72,8 +73,9 @@ class PDOInstrumentation
                 try {
                     $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
                     $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
-                } catch (\Error $e) {
-                    //do nothing
+                } catch (\PDOException $e) {
+                    // if we catched an exception, the driver is likely not supporting the operation, default to "other"
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql');
                 }
 
                 Context::storage()->attach($span->storeInContext($parent));
@@ -99,8 +101,9 @@ class PDOInstrumentation
                 try {
                     $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
                     $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
-                } catch (\Error $e) {
-                    //do nothing
+                } catch (\PDOException $e) {
+                    // if we catched an exception, the driver is likely not supporting the operation, default to "other"
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql');
                 }
 
                 Context::storage()->attach($span->storeInContext($parent));
@@ -126,8 +129,9 @@ class PDOInstrumentation
                 try {
                     $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
                     $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
-                } catch (\Error $e) {
-                    //do nothing
+                } catch (\PDOException $e) {
+                    // if we catched an exception, the driver is likely not supporting the operation, default to "other"
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql');
                 }
 
                 Context::storage()->attach($span->storeInContext($parent));
@@ -150,8 +154,9 @@ class PDOInstrumentation
                 try {
                     $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
                     $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
-                } catch (\Error $e) {
-                    //do nothing
+                } catch (\PDOException $e) {
+                    // if we catched an exception, the driver is likely not supporting the operation, default to "other"
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql');
                 }
 
                 Context::storage()->attach($span->storeInContext($parent));
@@ -174,8 +179,9 @@ class PDOInstrumentation
                 try {
                     $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
                     $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
-                } catch (\Error $e) {
-                    //do nothing
+                } catch (\PDOException $e) {
+                    // if we catched an exception, the driver is likely not supporting the operation, default to "other"
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql');
                 }
 
                 Context::storage()->attach($span->storeInContext($parent));
@@ -198,8 +204,9 @@ class PDOInstrumentation
                 try {
                     $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
                     $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
-                } catch (\Error $e) {
-                    //do nothing
+                } catch (\PDOException $e) {
+                    // if we catched an exception, the driver is likely not supporting the operation, default to "other"
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql');
                 }
 
                 Context::storage()->attach($span->storeInContext($parent));
@@ -222,8 +229,9 @@ class PDOInstrumentation
                 try {
                     $dbSystem = $statement->getAttribute(\PDO::ATTR_DRIVER_NAME);
                     $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
-                } catch (\Error $e) {
-                    //do nothing
+                } catch (\PDOException $e) {
+                    // if we catched an exception, the driver is likely not supporting the operation, default to "other"
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql');
                 }
 
                 Context::storage()->attach($span->storeInContext($parent));
@@ -246,8 +254,9 @@ class PDOInstrumentation
                 try {
                     $dbSystem = $statement->getAttribute(\PDO::ATTR_DRIVER_NAME);
                     $span->setAttribute(TraceAttributes::DB_SYSTEM, self::mapDriverNameToAttribute($dbSystem));
-                } catch (\Error $e) {
-                    //do nothing
+                } catch (\PDOException $e) {
+                    // if we catched an exception, the driver is likely not supporting the operation, default to "other"
+                    $span->setAttribute(TraceAttributes::DB_SYSTEM, 'other_sql');
                 }
 
                 Context::storage()->attach($span->storeInContext($parent));

--- a/src/Instrumentation/PDO/tests/Unit/PDOAttributeTrackerTest.php
+++ b/src/Instrumentation/PDO/tests/Unit/PDOAttributeTrackerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Instrumentation\PDO\tests\Unit;
+
+use OpenTelemetry\Contrib\Instrumentation\PDO\PDOAttributeTracker;
+use OpenTelemetry\SemConv\TraceAttributes;
+use PHPUnit\Framework\TestCase;
+
+class PDOAttributeTrackerTest extends TestCase
+{
+    public function testPdoCanBeTracked()
+    {
+        $pdo = new \PDO('sqlite::memory:');
+
+        $objectMap = new PDOAttributeTracker();
+        $objectMap->trackPdoAttributes($pdo);
+        $attributes = $objectMap->trackedAttributesForPdo($pdo);
+
+        $this->assertContains(TraceAttributes::DB_SYSTEM, array_keys($attributes));
+
+        $stmt = $pdo->prepare('SELECT NULL LIMIT 0;');
+        $objectMap->trackStatementToPdoMapping($stmt, $pdo);
+        $attributes = $objectMap->trackedAttributesForStatement($stmt);
+
+        /** @psalm-suppress InvalidArgument */
+        $this->assertContains(TraceAttributes::DB_SYSTEM, array_keys($attributes));
+        /** @psalm-suppress InvalidArrayAccess */
+        $this->assertEquals('sqlite', $attributes[TraceAttributes::DB_SYSTEM]);
+    }
+}


### PR DESCRIPTION
This change introduces a default value for db.system, to satisfy the opentelemetry specification.

It also tracks a statement <-> PDO mapping based on the object ids so we can annotate the correct attributes on statement spans.