### PR TITLE
Laravel contrib: packaging preparation.

### DIFF
--- a/src/Instrumentation/Laravel/.gitattributes
+++ b/src/Instrumentation/Laravel/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto
+
+*.md diff=markdown
+*.php diff=php
+
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php-cs-fixer.php export-ignore
+/docker-compose.yml export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml.dist export-ignore
+/psalm.xml.dist export-ignore
+/tests export-ignore

--- a/src/Instrumentation/Laravel/.gitignore
+++ b/src/Instrumentation/Laravel/.gitignore
@@ -1,0 +1,3 @@
+/tests/bootstrap/cache/
+/tests/storage/
+/vendor/


### PR DESCRIPTION
Test export-ignore git attributes for packaging of Laravel instrumentation.

```bash
cd src/Instrumentation/Laravel
git archive --format=tar HEAD | tar t
README.md
_register.php
composer.json
src/
src/CacheWatcher.php
src/ClientRequestWatcher.php
src/ExceptionWatcher.php
src/HeadersPropagator.php
src/LaravelInstrumentation.php
src/LogWatcher.php
src/QueryWatcher.php
src/Watcher.php
```