### PR TITLE
adding psr4 and replace to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,59 @@
   "autoload": {
     "psr-4": {
       "OpenTelemetry\\Contrib\\Aws\\": "src/Aws/src",
-      "OpenTelemetry\\Contrib\\Symfony\\": "src/Symfony/src",
+      "OpenTelemetry\\Contrib\\Context\\Swoole\\": "src/Context/Swoole/src",
+      "OpenTelemetry\\Contrib\\Instrumentation\\Laravel\\": "src/Instrumentation/Laravel/src",
+      "OpenTelemetry\\Contrib\\Instrumentation\\HttpAsyncClient\\": "src/Instrumentation/HttpAsyncClient/src",
+      "OpenTelemetry\\Contrib\\Instrumentation\\IO\\": "src/Instrumentation/IO/src",
+      "OpenTelemetry\\Contrib\\Instrumentation\\MongoDB\\": "src/Instrumentation/MongoDB/src",
+      "OpenTelemetry\\Contrib\\Instrumentation\\PDO\\": "src/Instrumentation/PDO/src",
+      "OpenTelemetry\\Contrib\\Instrumentation\\Psr3\\": "src/Instrumentation/Psr3/src",
       "OpenTelemetry\\Contrib\\Instrumentation\\Psr15\\": "src/Instrumentation/Psr15/src",
+      "OpenTelemetry\\Contrib\\Instrumentation\\Psr18\\": "src/Instrumentation/Psr18/src",
       "OpenTelemetry\\Contrib\\Instrumentation\\Slim\\": "src/Instrumentation/Slim/src",
+      "OpenTelemetry\\Contrib\\Instrumentation\\Symfony\\": "src/Instrumentation/Symfony/src",
       "OpenTelemetry\\Contrib\\Instrumentation\\Wordpress\\": "src/Instrumentation/Wordpress/src",
-      "OpenTelemetry\\Contrib\\Propagation\\TraceResponse\\": "src/Propagation/TraceResponse/src"
-    }
+      "OpenTelemetry\\Contrib\\Logs\\Monolog\\": "src/Logs/Monolog/src",
+      "OpenTelemetry\\Contrib\\Propagation\\TraceResponse\\": "src/Propagation/TraceResponse/src",
+      "OpenTelemetry\\Contrib\\Resource\\Detector\\Container\\": "src/ResourceDetectors/Container/src",
+      "OpenTelemetry\\Contrib\\Shim\\OpenTracing\\": "src/Shims/OpenTracing/src",
+      "OpenTelemetry\\Contrib\\Symfony\\": "src/Symfony/src"
+    },
+    "files": [
+      "src/Instrumentation/HttpAsyncClient/_register.php",
+      "src/Instrumentation/IO/_register.php",
+      "src/Instrumentation/Laravel/_register.php",
+      "src/Instrumentation/MongoDB/_register.php",
+      "src/Instrumentation/PDO/_register.php",
+      "src/Instrumentation/Psr3/_register.php",
+      "src/Instrumentation/Psr15/_register.php",
+      "src/Instrumentation/Psr18/_register.php",
+      "src/Instrumentation/Slim/_register.php",
+      "src/Instrumentation/Symfony/_register.php",
+      "src/Instrumentation/Wordpress/_register.php",
+      "src/ResourceDetectors/Container/_register.php"
+    ]
+  },
+  "replace": {
+    "open-telemetry/contrib-aws": "self.version",
+    "open-telemetry/contrib-sdk-bundle": "self.version",
+    "open-telemetry/context-swoole": "self.version",
+    "open-telemetry/opentelemetry-auto-laravel": "self.version",
+    "open-telemetry/opentelemetry-auto-http-async": "self.version",
+    "open-telemetry/opentelemetry-auto-io": "self.version",
+    "open-telemetry/opentelemetry-auto-mongodb": "self.version",
+    "open-telemetry/opentelemetry-auto-pdo": "self.version",
+    "open-telemetry/opentelemetry-auto-psr3": "self.version",
+    "open-telemetry/opentelemetry-auto-psr15": "self.version",
+    "open-telemetry/opentelemetry-auto-psr18": "self.version",
+    "open-telemetry/opentelemetry-auto-slim": "self.version",
+    "open-telemetry/opentelemetry-auto-symfony": "self.version",
+    "open-telemetry/opentelemetry-auto-wordpress": "self.version",
+    "open-telemetry/opentelemetry-propagation-traceresponse": "self.version",
+    "open-telemetry/opentelemetry-logger-monolog": "self.version",
+    "open-telemetry/detector-container": "self.version",
+    "open-telemetry/symfony-sdk-bundle": "self.version",
+    "open-telemetry/opentracing-shim": "self.version"
   },
   "config": {
     "sort-packages": true,


### PR DESCRIPTION
when developing/testing, it's very useful to be able to install the entire contrib monorepo, eg to enable installing a branch via a custom repository via composer - we can do this for the core repo.
Add missing psr4 namespaces and a replace section. Add autoload->files so that autoinstrumentation etc work when the monorepo is installed.