### PR TITLE
check for mongo extension

### DIFF
--- a/src/Instrumentation/MongoDB/_register.php
+++ b/src/Instrumentation/MongoDB/_register.php
@@ -8,5 +8,8 @@ use OpenTelemetry\SDK\Sdk;
 if (class_exists(Sdk::class) && Sdk::isInstrumentationDisabled(MongoDBInstrumentation::NAME) === true) {
     return;
 }
+if (!extension_loaded('mongodb')) {
+    return;
+}
 
 MongoDBInstrumentation::register();


### PR DESCRIPTION
if platform requirements are ignored, then trying to load this module causes a fatal error. that's particularly bad because it happens during composer autoloading, so add an extra check and do not try to run without the extension.