### PR TITLE
symfony auto-instrumentation readme

### DIFF
--- a/src/Instrumentation/Symfony/README.md
+++ b/src/Instrumentation/Symfony/README.md
@@ -38,3 +38,11 @@ From Symfony subdirectory:
 $ composer install
 $ ./vendor/bin/phpunit tests
 ```
+
+## Configuration
+
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
+
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=symfony
+```

--- a/src/Instrumentation/Symfony/README.md
+++ b/src/Instrumentation/Symfony/README.md
@@ -1,39 +1,28 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-symfony/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Symfony)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-symfony)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-symfony/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-symfony/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-symfony/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-symfony/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry Symfony auto-instrumentation
 
-**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [Symfony](#Installation-via-composer)**
+This is an OpenTelemetry auto-instrumentation package for Symfony framework applications.
+
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Requirements
 
-* OpenTelemetry extension
+* [OpenTelemetry extension](https://opentelemetry.io/docs/instrumentation/php/automatic/#installation)
 * OpenTelemetry SDK and exporters (required to actually export traces)
 
 ## Overview
-Currently only root span creation is supported (Symfony\Component\HttpKernel\HttpKernel::handle hook).
-
-To export spans, you will need to create and register a `TracerProvider` early in your application's
-lifecycle. This can be done either manually or using SDK autoloading.
-
-### Using SDK autoloading
-
-See https://github.com/open-telemetry/opentelemetry-php#sdk-autoloading
-
-### Manual setup
-
-```php
-<?php
-require_once 'vendor/autoload.php';
-
-$tracerProvider = /*create tracer provider*/;
-$scope = \OpenTelemetry\API\Instrumentation\Configurator::create()
-    ->withTracerProvider($tracerProvider)
-    ->activate();
-
-//your application runs here
-
-$scope->detach();
-$tracerProvider->shutdown();
-```
+The following features are supported:
+* root span creation (`Symfony\Component\HttpKernel\HttpKernel::handle` hook)
+* context propagation
 
 ## Installation via composer
 
@@ -49,14 +38,3 @@ From Symfony subdirectory:
 $ composer install
 $ ./vendor/bin/phpunit tests
 ```
-
-## Configuration
-
-Parts of this auto-instrumentation library can be configured, more options are available throught the
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
-
-| Name                                | Default value | Values                  | Example | Description                                                                     |
-|-------------------------------------|---------------|-------------------------|---------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | symfony | Disable one or more installed auto-instrumentations, names are comma seperated. |
-
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)


### PR DESCRIPTION
removing some content from symfony readme, and directing users to the central docs on opentelemetry.io for most info (since most READMEs are repetitive, and not as good as the central docs)