### PR TITLE
remove globals config resolver usage

### DIFF
--- a/src/Instrumentation/Psr3/composer.json
+++ b/src/Instrumentation/Psr3/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": "^8.0",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": ">=1.0.0beta11",
+    "open-telemetry/api": ">=1.0.0RC2",
     "open-telemetry/sem-conv": "^1",
     "psr/log": "^1 || ^2 || ^3"
   },

--- a/src/Instrumentation/Psr3/src/Psr3Instrumentation.php
+++ b/src/Instrumentation/Psr3/src/Psr3Instrumentation.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Contrib\Instrumentation\Psr3;
 
-use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Instrumentation\ConfigurationResolver;
 use OpenTelemetry\API\Logs as API;
 use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\Context\Context;
@@ -89,7 +89,7 @@ class Psr3Instrumentation
 
     private static function getMode(): string
     {
-        $resolver = Globals::configurationResolver();
+        $resolver = new ConfigurationResolver();
         if ($resolver->has(self::OTEL_PHP_PSR3_MODE)) {
             $val = $resolver->getString(self::OTEL_PHP_PSR3_MODE);
             if ($val && in_array($val, self::MODES)) {


### PR DESCRIPTION
has been removed from api/sdk RC2, and replaced by an API ConfigurationResolver.