### PR TITLE
tidy and test coverage for http-async-client

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -122,7 +122,7 @@ jobs:
 
     - name: Run PHPUnit
       working-directory: src/${{ matrix.project }}
-      run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+      run: vendor/bin/phpunit --testsuite integration --testsuite unit --coverage-text --coverage-clover=coverage.clover
 
     - name: Code Coverage
       working-directory: src/${{ matrix.project }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -113,10 +113,6 @@ jobs:
       working-directory: src/${{ matrix.project }}
       run: vendor/bin/phpstan analyse --error-format=github
 
-    - name: Run PHPUnit (unit tests)
-      working-directory: src/${{ matrix.project }}
-      run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover --testsuite unit
-
     - name: Start MongoDB
       uses: supercharge/mongodb-github-action@1.8.0
       if: ${{ matrix.project == 'Instrumentation/MongoDB' }}
@@ -124,9 +120,9 @@ jobs:
         mongodb-version: 6.0
         mongodb-replica-set: otel-php
 
-    - name: Run PHPUnit (integration tests)
+    - name: Run PHPUnit
       working-directory: src/${{ matrix.project }}
-      run: vendor/bin/phpunit --testsuite integration
+      run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
     - name: Code Coverage
       working-directory: src/${{ matrix.project }}

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test-unit: ## Run unit tests
 test-integration: ## Run integration tests
 	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor/bin/phpunit --testsuite integration  --testdox --colors=always
 test-coverage: ## Run unit tests and generate coverage
-	$(DC_RUN_PHP) env XDEBUG_MODE=coverage vendor/bin/phpunit --testsuite unit --coverage-html=tests/coverage/html
+	$(DC_RUN_PHP) env XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html=tests/coverage/html
 phan: ## Run phan
 	$(DC_RUN_PHP) env XDEBUG_MODE=off env PHAN_DISABLE_XDEBUG_WARN=1 vendor/bin/phan
 psalm: ## Run psalm

--- a/src/Instrumentation/HttpAsyncClient/composer.json
+++ b/src/Instrumentation/HttpAsyncClient/composer.json
@@ -36,5 +36,10 @@
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "^4.0"
+  },
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": false
+    }
   }
 }

--- a/src/Instrumentation/HttpAsyncClient/src/HttpAsyncClientInstrumentation.php
+++ b/src/Instrumentation/HttpAsyncClient/src/HttpAsyncClientInstrumentation.php
@@ -62,7 +62,6 @@ class HttpAsyncClientInstrumentation
                 foreach ($propagator->fields() as $field) {
                     $request = $request->withoutHeader($field);
                 }
-                //@todo could we use SDK Configuration to retrieve this, and move into a key such as OTEL_PHP_xxx?
                 foreach ((array) (get_cfg_var('otel.instrumentation.http.request_headers') ?: []) as $header) {
                     if ($request->hasHeader($header)) {
                         $spanBuilder->setAttribute(
@@ -84,7 +83,6 @@ class HttpAsyncClientInstrumentation
                 $scope = Context::storage()->scope();
                 $scope?->detach();
 
-                //@todo do we need the second part of this 'or'?
                 if (!$scope || $scope->context() === Context::getCurrent()) {
                     return;
                 }

--- a/src/Instrumentation/HttpAsyncClient/tests/Integration/HttpAsyncClientInstrumentationTest.php
+++ b/src/Instrumentation/HttpAsyncClient/tests/Integration/HttpAsyncClientInstrumentationTest.php
@@ -21,27 +21,30 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
+/**
+ * @covers \OpenTelemetry\Contrib\Instrumentation\HttpAsyncClient\HttpAsyncClientInstrumentation
+ * @covers \OpenTelemetry\Contrib\Instrumentation\HttpAsyncClient\HeadersPropagator
+ */
 class HttpAsyncClientInstrumentationTest extends TestCase
 {
     // @var HttpAsyncClient&MockObject $client
     private $client;
     private ScopeInterface $scope;
     private ArrayObject $storage;
-    private TracerProvider $tracerProvider;
 
     public function setUp(): void
     {
         $this->client = $this->createMock(HttpAsyncClient::class);
 
         $this->storage = new ArrayObject();
-        $this->tracerProvider = new TracerProvider(
+        $tracerProvider = new TracerProvider(
             new SimpleSpanProcessor(
                 new InMemoryExporter($this->storage)
             )
         );
 
         $this->scope = Configurator::create()
-            ->withTracerProvider($this->tracerProvider)
+            ->withTracerProvider($tracerProvider)
             ->withPropagator(TraceContextPropagator::getInstance())
             ->activate();
     }
@@ -63,7 +66,7 @@ class HttpAsyncClientInstrumentationTest extends TestCase
         $this->assertCount(0, $this->storage);
         $this->client->sendAsyncRequest($request);
         $this->client->sendAsyncRequest($request);
-        $this->assertCount(0, $this->storage, 'no spans exporter since promises are not resolved yet');
+        $this->assertCount(0, $this->storage, 'no spans exported since promises are not resolved yet');
 
         //resolve promises
         try {


### PR DESCRIPTION
We don't generate any test coverage for integration tests usually, but since auto-instrumentation only works with integration tests, we should use those for coverage. Remove some todo's and minor code tidy.