### PR TITLE
update readme for contrib packages

### DIFF
--- a/examples/instrumentation/Wordpress/autoinstrumented-wordpress.dockerfile
+++ b/examples/instrumentation/Wordpress/autoinstrumented-wordpress.dockerfile
@@ -5,7 +5,7 @@ RUN composer install --ignore-platform-reqs
 
 FROM wordpress:6.2
 # Install the opentelemetry and protobuf extensions
-RUN pecl install opentelemetry-beta protobuf
+RUN pecl install opentelemetry protobuf
 COPY otel.php.ini $PHP_INI_DIR/conf.d/.
 # Copy in the composer vendor files and autoload.php
 COPY --from=build /app/vendor /var/www/otel

--- a/src/Aws/README.md
+++ b/src/Aws/README.md
@@ -1,3 +1,11 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-aws/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Aws)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-aws)
+[![Latest Version](http://poser.pugx.org/open-telemetry/contrib-aws/v/unstable)](https://packagist.org/packages/open-telemetry/contrib-aws/)
+[![Stable](http://poser.pugx.org/open-telemetry/contrib-aws/v/stable)](https://packagist.org/packages/open-telemetry/contrib-aws/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
 
 ## Installation
 

--- a/src/Context/Swoole/README.md
+++ b/src/Context/Swoole/README.md
@@ -1,1 +1,10 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/context-swoole/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Context/Swoole)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/context-swoole)
+[![Latest Version](http://poser.pugx.org/open-telemetry/context-swoole/v/unstable)](https://packagist.org/packages/open-telemetry/context-swoole/)
+[![Stable](http://poser.pugx.org/open-telemetry/context-swoole/v/stable)](https://packagist.org/packages/open-telemetry/context-swoole/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry Swoole context

--- a/src/Instrumentation/HttpAsyncClient/README.md
+++ b/src/Instrumentation/HttpAsyncClient/README.md
@@ -1,50 +1,29 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-http-async/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/HttpAsyncClient)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-http-async)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-http-async/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-http-async/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-http-async/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-http-async/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry HTTPlug async auto-instrumentation
 
-**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [HttpAsyncClient](#Installation-via-composer)**
-
-## Requirements
-
-* OpenTelemetry extension
-* OpenTelemetry SDK an exporter (required to actually export traces)
-* An HTTPlug async client
-* (optional) OpenTelemetry [SDK Autoloading](https://github.com/open-telemetry/opentelemetry-php/blob/main/examples/autoload_sdk.php) configured
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Overview
 Auto-instrumentation hooks are registered via composer, which will:
 
-* create spans automatically for each async request that is sent
-
-## Manual configuration
-If you are not using SDK autoloading, you will need to create and register a `TracerProvider` early in your application's lifecycle:
-
-```php
-<?php
-require_once 'vendor/autoload.php';
-
-$tracerProvider = /*create tracer provider*/;
-$scope = \OpenTelemetry\API\Instrumentation\Configurator::create()
-    ->withTracerProvider($tracerProvider)
-    ->activate();
-
-$client->sendAsyncRequest($request);
-
-$scope->detach();
-$tracerProvider->shutdown();
-```
-## Installation via composer
-
-```bash
-$ composer require open-telemetry/opentelemetry-auto-http-async
-```
+* create spans automatically for each async HTTP request that is sent
+* add a `traceparent` header to the request to facilitate distributed tracing
 
 ## Configuration
 
-Parts of this auto-instrumentation library can be configured, more options are available throught the 
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
-| Name                                | Default value | Values                  | Example           | Description                                                                     |
-|-------------------------------------|---------------|-------------------------|-------------------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | http-async-client | Disable one or more installed auto-instrumentations, names are comma seperated. |
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=http-async-client
+```
 
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+Request headers can be added as span attributes, if the header's name is found in the `php.ini` variable: `otel.instrumentation.http.request_headers`

--- a/src/Instrumentation/IO/README.md
+++ b/src/Instrumentation/IO/README.md
@@ -1,17 +1,20 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-io/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Io)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-io)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-io/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-io/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-io/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-io/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry IO auto-instrumentation
 
-**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [IO](#Installation-via-composer)**
-
-
-## Requirements in case of manual setup
-
-* OpenTelemetry extension
-* OpenTelemetry SDK and exporters (required to actually export traces)
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Overview
-Auto-instrumentation hooks are registered via composer, and spans will automatically be created for
-folowing functions:
+Auto-instrumentation hooks are registered via composer, and spans will automatically be created for the
+following functions:
 - `fopen`
 - `fwrite`
 - `fread`
@@ -20,52 +23,10 @@ folowing functions:
 - `curl_init`
 - `curl_exec`
 
-To export spans, you will need to create and register a `TracerProvider` early in your application's
-lifecycle. This can be done either manually or using SDK autoloading.
-
-### Using SDK autoloading
-
-See https://github.com/open-telemetry/opentelemetry-php#sdk-autoloading
-
-### Manual setup
-
-```php
-<?php
-require_once 'vendor/autoload.php';
-
-$tracerProvider = /*create tracer provider*/;
-$scope = \OpenTelemetry\API\Instrumentation\Configurator::create()
-    ->withTracerProvider($tracerProvider)
-    ->activate();
-
-//your application runs here
-
-$scope->detach();
-$tracerProvider->shutdown();
-```
-
-## Installation via composer
-
-```bash
-$ composer require open-telemetry/opentelemetry-auto-io
-```
-
-## Installing dependencies and executing tests
-
-From IO subdirectory:
-
-```bash
-$ composer install
-$ ./vendor/bin/phpunit tests
-```
-
 ## Configuration
 
-Parts of this auto-instrumentation library can be configured, more options are available throught the
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
-| Name                                | Default value | Values                  | Example | Description                                                                     |
-|-------------------------------------|---------------|-------------------------|---------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | io      | Disable one or more installed auto-instrumentations, names are comma seperated. |
-
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=io
+```

--- a/src/Instrumentation/Laravel/README.md
+++ b/src/Instrumentation/Laravel/README.md
@@ -1,62 +1,24 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-laravel/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Laravel)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-laravel)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-laravel/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-laravel/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-laravel/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-laravel/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry Laravel auto-instrumentation
 
-**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [Laravel](#Installation-via-composer)**
-
-## Requirements
-
-* OpenTelemetry extension
-* OpenTelemetry SDK and exporters (required to actually export traces)
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Overview
-Currently only root span creation is supported (Illuminate\Foundation\Http\Kernel::handle hook).
-
-To export spans, you will need to create and register a `TracerProvider` early in your application's
-lifecycle. This can be done either manually or using SDK autoloading.
-
-### Using SDK autoloading
-
-See https://github.com/open-telemetry/opentelemetry-php#sdk-autoloading
-
-### Manual setup
-
-```php
-<?php
-require_once 'vendor/autoload.php';
-
-$tracerProvider = /*create tracer provider*/;
-$scope = \OpenTelemetry\API\Instrumentation\Configurator::create()
-    ->withTracerProvider($tracerProvider)
-    ->activate();
-
-//your application runs here
-
-$scope->detach();
-$tracerProvider->shutdown();
-```
-
-## Installation via composer
-
-```bash
-$ composer require open-telemetry/opentelemetry-auto-laravel
-```
-
-## Installing dependencies and executing tests
-
-From Laravel subdirectory:
-
-```bash
-$ composer install
-$ ./vendor/bin/phpunit tests
-```
+Auto-instrumentation hooks are registered via composer, and spans will automatically be created.
 
 ## Configuration
 
-Parts of this auto-instrumentation library can be configured, more options are available throught the
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
-| Name                                | Default value | Values                  | Example | Description                                                                     |
-|-------------------------------------|---------------|-------------------------|---------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | laravel | Disable one or more installed auto-instrumentations, names are comma seperated. |
-
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=laravel
+```

--- a/src/Instrumentation/MongoDB/README.md
+++ b/src/Instrumentation/MongoDB/README.md
@@ -1,64 +1,25 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-mongodb/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/MongoDB)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-mongodb)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-mongodb/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-mongodb/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-mongodb/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-mongodb/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry MongoDB auto-instrumentation
 
-**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**To run only this instrumentation, [install via composer](#Installation-via-composer)**
-
-## Requirements
-
--   OpenTelemetry extension
--   OpenTelemetry SDK and exporters (required to actually export traces)
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Overview
-
 Auto-instrumentation hooks are registered via composer, and spans will automatically be created for all MongoDB
 operations like `find` or `aggregate`.
 
-To export spans, you will need to create and register a `TracerProvider` early in your application's
-lifecycle. This can be done either manually or using SDK autoloading.
-
-### Using SDK autoloading
-
-See https://github.com/open-telemetry/opentelemetry-php#sdk-autoloading
-
-### Manual setup
-
-```php
-<?php
-require_once 'vendor/autoload.php';
-
-$tracerProvider = /*create tracer provider*/;
-$scope = \OpenTelemetry\API\Instrumentation\Configurator::create()
-    ->withTracerProvider($tracerProvider)
-    ->activate();
-
-//your application runs here
-
-$scope->detach();
-$tracerProvider->shutdown();
-```
-
-## Installation via composer
-
-```bash
-$ composer require open-telemetry/opentelemetry-auto-mongodb
-```
-
-## Installing dependencies and executing tests
-
-From MongoDB subdirectory:
-
-```bash
-$ composer install
-$ ./vendor/bin/phpunit tests
-```
-
 ## Configuration
 
-Parts of this auto-instrumentation library can be configured, more options are available throught the
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
-| Name                               | Default value | Values                  | Example | Description                                                                     |
-| ---------------------------------- | ------------- | ----------------------- | ------- | ------------------------------------------------------------------------------- |
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS | []            | Instrumentation name(s) | mongodb | Disable one or more installed auto-instrumentations, names are comma seperated. |
-
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=mongodb
+```

--- a/src/Instrumentation/PDO/README.md
+++ b/src/Instrumentation/PDO/README.md
@@ -1,63 +1,25 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-pdo/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/PDO)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-pdo)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-pdo/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-pdo/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-pdo/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-pdo/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry PDO (PHP DataObjects) auto-instrumentation
 
-**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [PDO](#Installation-via-composer)**
-
-## Requirements
-
-* OpenTelemetry extension
-* OpenTelemetry SDK and exporters (required to actually export traces)
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Overview
 Auto-instrumentation hooks are registered via composer, and spans will automatically be created for
 selected `PDO` and `PDOStatement` methods.
 
-To export spans, you will need to create and register a `TracerProvider` early in your application's
-lifecycle. This can be done either manually or using SDK autoloading.
-
-### Using SDK autoloading
-
-See https://github.com/open-telemetry/opentelemetry-php#sdk-autoloading
-
-### Manual setup
-
-```php
-<?php
-require_once 'vendor/autoload.php';
-
-$tracerProvider = /*create tracer provider*/;
-$scope = \OpenTelemetry\API\Instrumentation\Configurator::create()
-    ->withTracerProvider($tracerProvider)
-    ->activate();
-
-//your application runs here
-
-$scope->detach();
-$tracerProvider->shutdown();
-```
-
-## Installation via composer
-
-```bash
-$ composer require open-telemetry/opentelemetry-auto-pdo
-```
-
-## Installing dependencies and executing tests
-
-From PDO subdirectory:
-
-```bash
-$ composer install
-$ ./vendor/bin/phpunit tests
-```
-
 ## Configuration
 
-Parts of this auto-instrumentation library can be configured, more options are available throught the
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
-| Name                                | Default value | Values                  | Example | Description                                                                     |
-|-------------------------------------|---------------|-------------------------|---------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | pdo     | Disable one or more installed auto-instrumentations, names are comma seperated. |
-
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=pdo
+```

--- a/src/Instrumentation/Psr15/README.md
+++ b/src/Instrumentation/Psr15/README.md
@@ -1,46 +1,23 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-psr15/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Psr15)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-psr15)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-psr15/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr15/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-psr15/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr15/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry PSR-15 auto-instrumentation
-
-**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [PSR-15](#Installation-via-composer)**
-
-## Requirements
-
-* OpenTelemetry extension
-* OpenTelemetry SDK and exporters (required to actually export traces)
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Overview
 Auto-instrumentation hooks are registered via composer, and spans will automatically be created for each PSR-15 middleware that is executed.
 
-To export spans, you will need to create and register a `TracerProvider` early in your application's lifecycle:
-
-```php
-<?php
-require_once 'vendor/autoload.php';
-
-$tracerProvider = /*create tracer provider*/;
-$scope = \OpenTelemetry\API\Instrumentation\Configurator::create()
-    ->withTracerProvider($tracerProvider)
-    ->activate();
-
-//your application runs here
-
-$scope->detach();
-$tracerProvider->shutdown();
-```
-
-## Installation via composer
-
-```bash
-$ composer require open-telemetry/opentelemetry-auto-psr15
-```
-
 ## Configuration
 
-Parts of this auto-instrumentation library can be configured, more options are available throught the
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
-| Name                                | Default value | Values                  | Example | Description                                                                     |
-|-------------------------------------|---------------|-------------------------|---------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | psr15   | Disable one or more installed auto-instrumentations, names are comma seperated. |
-
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=psr15
+```

--- a/src/Instrumentation/Psr18/README.md
+++ b/src/Instrumentation/Psr18/README.md
@@ -1,52 +1,26 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-psr18/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Psr18)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-psr18)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-psr18/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr18/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-psr18/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr18/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry PSR-18 auto-instrumentation
-
-**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [PSR-18](#Installation-via-composer)**
-
-## Requirements
-
-* OpenTelemetry extension
-* OpenTelemetry SDK an exporter (required to actually export traces)
-* A psr-18 client
-* (optional) OpenTelemetry [SDK Autoloading](https://github.com/open-telemetry/opentelemetry-php/blob/main/examples/autoload_sdk.php) configured
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Overview
 Auto-instrumentation hooks are registered via composer, which will:
 
 * create spans automatically for each PSR-18 request that is sent
-* add a `traceparent` header to the request to facilitate distributed tracing.
-
-## Manual configuration
-If you are not using SDK autoloading, you will need to create and register a `TracerProvider` early in your application's lifecycle:
-
-```php
-<?php
-require_once 'vendor/autoload.php';
-
-$tracerProvider = /*create tracer provider*/;
-$scope = \OpenTelemetry\API\Instrumentation\Configurator::create()
-    ->withTracerProvider($tracerProvider)
-    ->activate();
-
-$client->sendRequest($request);
-
-$scope->detach();
-$tracerProvider->shutdown();
-```
-
-## Installation via composer
-
-```bash
-$ composer require open-telemetry/opentelemetry-auto-psr18
-```
+* add a `traceparent` header to the request to facilitate distributed tracing
 
 ## Configuration
 
-Parts of this auto-instrumentation library can be configured, more options are available throught the
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
-| Name                                | Default value | Values                  | Example | Description                                                                     |
-|-------------------------------------|---------------|-------------------------|---------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | psr18   | Disable one or more installed auto-instrumentations, names are comma seperated. |
-
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=psr18
+```

--- a/src/Instrumentation/Psr3/README.md
+++ b/src/Instrumentation/Psr3/README.md
@@ -1,22 +1,22 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-psr3/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Psr3)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-psr3)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-psr3/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr3/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-psr3/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr3/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry PSR-3 auto-instrumentation
 
-## Requirements
-
-- [OpenTelemetry extension](https://opentelemetry.io/docs/instrumentation/php/automatic/#installation)
-- OpenTelemetry SDK and exporter (required to actually export signal data)
-- A psr-3 logger
-- OpenTelemetry [SDK Autoloading](https://github.com/open-telemetry/opentelemetry-php/blob/main/examples/autoload_sdk.php) configured
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Overview
-
 Auto-instrumentation hooks are registered via composer, and depending on the mode, will:
 
 * automatically inject trace id and span id into log message context of any psr3 logger; or
 * transform the message into the OpenTelemetry LogRecord format, for export to an OpenTelemetry logging-compatible backend
-
-### Using SDK autoloading
-
-See https://github.com/open-telemetry/opentelemetry-php#sdk-autoloading
 
 ## Mode
 
@@ -51,20 +51,10 @@ $logger = /* create logger */
 $logger->info('Hello, OTEL');
 ```
 
-## Installation via composer
-
-```bash
-composer require open-telemetry/opentelemetry-auto-psr3
-```
-
 ## Configuration
 
-Parts of this auto-instrumentation library can be configured, more options are available through the
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
-| Name                               | Default value | Values                  | Example | Description                                                                     |
-| ---------------------------------- |---------------| ----------------------- |---------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS | []            | Instrumentation name(s) | psr3    | Disable one or more installed auto-instrumentations, names are comma seperated. |
-| OTEL_PHP_PSR3_MODE                 | inject        | inject, export          | export  | Change the behaviour of the package                                             |
-
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=psr3
+```

--- a/src/Instrumentation/Slim/README.md
+++ b/src/Instrumentation/Slim/README.md
@@ -1,57 +1,26 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-slim/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Slim)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-slim)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-slim/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-slim/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-slim/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-slim/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry Slim Framework auto-instrumentation
-
-**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [Slim](#Installation-via-composer)**
-
-## Requirements
-
-* OpenTelemetry extension
-* OpenTelemetry SDK and exporters (required to actually export traces)
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Overview
 Auto-instrumentation hooks are registered via composer, and spans will automatically be created for:
-
-* `App::handle()` - root span
-* `InvocationStrategyInterface` - controller/action
-* `RoutingMiddleware::performRouting` - update root span's name with either route name or pattern
-
-To export spans, you will need to create and register a `TracerProvider` early in your application's
-lifecycle. This can be done either manually or using SDK autoloading.
-
-### Using SDK autoloading
-
-See https://github.com/open-telemetry/opentelemetry-php#sdk-autoloading
-
-### Manual setup
-
-```php
-<?php
-require_once 'vendor/autoload.php';
-
-$tracerProvider = /*create tracer provider*/;
-$scope = \OpenTelemetry\API\Instrumentation\Configurator::create()
-    ->withTracerProvider($tracerProvider)
-    ->activate();
-
-//your application runs here
-
-$scope->detach();
-$tracerProvider->shutdown();
-```
-
-## Installation via composer
-
-```bash
-$ composer require open-telemetry/opentelemetry-auto-slim
-```
+- `App::handle()` - root span
+- `InvocationStrategyInterface` - controller/action
+- `RoutingMiddleware::performRouting` - update root span's name with either route name or pattern
 
 ## Configuration
 
-Parts of this auto-instrumentation library can be configured, more options are available throught the
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
-| Name                                | Default value | Values                  | Example | Description                                                                     |
-|-------------------------------------|---------------|-------------------------|---------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | slim    | Disable one or more installed auto-instrumentations, names are comma seperated. |
-
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=slim
+```

--- a/src/Instrumentation/Wordpress/README.md
+++ b/src/Instrumentation/Wordpress/README.md
@@ -1,21 +1,31 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-wordpress/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Wordpress)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-wordpress)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-wordpress/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-wordpress/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-wordpress/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-wordpress/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry Wordpress auto-instrumentation
 
-**Warning**: this is experimental, use at your own risk
-
-**Preferred and simplest way to install auto-instrumentation (c extension plus instrumentation libraries) is to use [opentelemetry-instrumentation-installer](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/AutoInstrumentationInstaller).**
-**The same process can be done manually by installing [c extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation#installation) plus all needed instrumentation libraries like [Wordpress](#Installation-via-composer)**
-
-## [Example using Docker](../../../examples/instrumentation/Wordpress/README.md)
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
 
 ## Requirements
 
 * OpenTelemetry extension
-* OpenTelemetry SDK exporter (required to actually export traces)
-* Wordpress installation
+* OpenTelemetry SDK + exporter (required to actually export traces)
+* WordPress installation
 * OpenTelemetry [SDK Autoloading](https://github.com/open-telemetry/opentelemetry-php/blob/main/examples/autoload_sdk.php) configured
 
 ## Overview
-OpenTelemetry depends on composer, unlike Wordpress. I developed this against [johnpbloch/wordpress-core](https://github.com/johnpbloch/wordpress-core-installer), but it should also work with other installation methods. This repo contains an example adding instrumentation to the official Wordpress Docker image [here](../../../examples/instrumentation/Wordpress/README.md).
+OpenTelemetry depends on composer, unlike Wordpress. This extension was developed against
+[johnpbloch/wordpress-core](https://github.com/johnpbloch/wordpress-core-installer),
+but it should also work with other installation methods.
+
+An example in Docker of extending the official Wordpress image to enable
+auto-instrumentation: https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/examples/instrumentation/Wordpress
 
 ### apache
 
@@ -38,11 +48,8 @@ $ composer require open-telemetry/opentelemetry-auto-wordpress
 
 ## Configuration
 
-Parts of this auto-instrumentation library can be configured, more options are available throught the
-[General SDK Configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#general-sdk-configuration):
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
-| Name                                | Default value | Values                  | Example   | Description                                                                     |
-|-------------------------------------|---------------|-------------------------|-----------|---------------------------------------------------------------------------------|
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s) | wordpress | Disable one or more installed auto-instrumentations, names are comma seperated. |
-
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=wordpress
+```

--- a/src/Logs/Monolog/README.md
+++ b/src/Logs/Monolog/README.md
@@ -1,3 +1,12 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-logs-monolog/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Logs/Monolog)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-logger-monolog)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-logger-monolog/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-logger-monolog/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-logger-monolog/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-logger-monolog/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry Monolog handler
 
 A monolog handler for OpenTelemetry. See https://opentelemetry.io/docs/instrumentation/php/manual/#logs for further documentation.

--- a/src/MetaPackages/opentelemetry/composer.json
+++ b/src/MetaPackages/opentelemetry/composer.json
@@ -6,12 +6,13 @@
   "homepage": "https://opentelemetry.io/docs/php",
   "readme": "./README.md",
   "license": "Apache-2.0",
+  "minimum-stability": "rc",
   "require": {
-    "open-telemetry/api": "^1-beta",
-    "open-telemetry/context": "^1-beta",
-    "open-telemetry/sdk": "^1-beta",
-    "open-telemetry/exporter-otlp": "^1-beta",
-    "open-telemetry/exporter-zipkin": "^1-beta",
+    "open-telemetry/api": "^1-rc",
+    "open-telemetry/context": "^1-rc",
+    "open-telemetry/sdk": "^1-rc",
+    "open-telemetry/exporter-otlp": "^1-rc",
+    "open-telemetry/exporter-zipkin": "^1-rc",
     "symfony/http-client": "^5|^6",
     "nyholm/psr7": "^1.5"
   },
@@ -20,5 +21,10 @@
       "name": "opentelemetry-php contributors",
       "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
     }
-  ]
+  ],
+  "config": {
+    "allow-plugins": {
+      "php-http/discovery": false
+    }
+  }
 }

--- a/src/Propagation/TraceResponse/README.md
+++ b/src/Propagation/TraceResponse/README.md
@@ -1,3 +1,12 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-propagator-traceresponse/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Propagation/TraceResponse)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-propagator-traceresponse)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-propagation-traceresponse/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-propagation-traceresponse/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-propagation-traceresponse/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-propagation-traceresponse/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry TraceResponse Propagator
 
 **Note:** This package is experimental as `traceresponse` is currently an editors' draft.

--- a/src/ResourceDetectors/Container/README.md
+++ b/src/ResourceDetectors/Container/README.md
@@ -1,3 +1,12 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-detector-container/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/ResourceDetectors/Container)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-detector-container)
+[![Latest Version](http://poser.pugx.org/open-telemetry/detector-container/v/unstable)](https://packagist.org/packages/open-telemetry/detector-container/)
+[![Stable](http://poser.pugx.org/open-telemetry/detector-container/v/stable)](https://packagist.org/packages/open-telemetry/detector-container/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry Container Detector
 
 This package provides an OpenTelemetry `ResourceDetector` which will detect docker container id at runtime, using either V1 (cgroup) or V2 (mountinfo).

--- a/src/Symfony/README.md
+++ b/src/Symfony/README.md
@@ -1,3 +1,12 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/symfony-sdk-bundle/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Symfony)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/symfony-sdk-bundle)
+[![Latest Version](http://poser.pugx.org/open-telemetry/symfony-sdk-bundle/v/unstable)](https://packagist.org/packages/open-telemetry/symfony-sdk-bundle/)
+[![Stable](http://poser.pugx.org/open-telemetry/symfony-sdk-bundle/v/stable)](https://packagist.org/packages/open-telemetry/symfony-sdk-bundle/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
 # OpenTelemetry Symfony bundle
 
 Installation and configuration instructions can be found in the [OtelSdkBundle subdirectory's README.md](src/OtelSdkBundle/README.md).


### PR DESCRIPTION
Following on from Laravel's readme updates, apply the same to other readme files. Add some badges, and a note to make clear that people are probably looking at a read-only subtree split.
In passing, update wordpress dockerfile and metapackage to use RC