### PR TITLE
http server semconv 1.23 updates

### DIFF
--- a/src/Instrumentation/CodeIgniter/src/CodeIgniterInstrumentation.php
+++ b/src/Instrumentation/CodeIgniter/src/CodeIgniterInstrumentation.php
@@ -54,7 +54,7 @@ class CodeIgniterInstrumentation
                 $spanBuilder = $instrumentation
                     ->tracer()
                     /** @phan-suppress-next-line PhanDeprecatedFunction */
-                    ->spanBuilder(\sprintf('HTTP %s', $request?->getMethod(true) ?? 'unknown'))
+                    ->spanBuilder(\sprintf('%s', $request?->getMethod(true) ?? 'unknown'))
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
@@ -69,6 +69,7 @@ class CodeIgniterInstrumentation
                     /** @psalm-suppress DeprecatedMethod */
                     $spanBuilder = $spanBuilder->setParent($parent)
                         ->setAttribute(TraceAttributes::URL_FULL, (string) $request->getUri())
+                        ->setAttribute(TraceAttributes::URL_PATH, $request->getUri()->getPath())
                         /** @phan-suppress-next-line PhanDeprecatedFunction */
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod(true))
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->getHeaderLine('Content-Length'))
@@ -104,7 +105,7 @@ class CodeIgniterInstrumentation
                     foreach ((array) (get_cfg_var('otel.instrumentation.http.response_headers') ?: []) as $header) {
                         if ($response->hasHeader($header)) {
                             /** @psalm-suppress ArgumentTypeCoercion */
-                            $span->setAttribute(sprintf('http.response.header.%s', strtr(strtolower($header), ['-' => '_'])), $response->getHeaderLine($header));
+                            $span->setAttribute(sprintf('http.response.header.%s', strtolower($header)), $response->getHeaderLine($header));
                         }
                     }
 

--- a/src/Instrumentation/CodeIgniter/tests/Integration/CodeIgniterInstrumentationTest.php
+++ b/src/Instrumentation/CodeIgniter/tests/Integration/CodeIgniterInstrumentationTest.php
@@ -25,7 +25,7 @@ class CodeIgniterInstrumentationTest extends AbstractTest
 
         $attributes = $this->storage[0]->getAttributes();
         $this->assertCount(1, $this->storage);
-        $this->assertEquals('HTTP GET', $this->storage[0]->getName());
+        $this->assertEquals('GET', $this->storage[0]->getName());
         $this->assertEquals('http://example.com/index.php/home', $attributes->get(TraceAttributes::URL_FULL));
         $this->assertEquals('GET', $attributes->get(TraceAttributes::HTTP_REQUEST_METHOD));
         $this->assertEquals('http', $attributes->get(TraceAttributes::URL_SCHEME));
@@ -55,7 +55,7 @@ class CodeIgniterInstrumentationTest extends AbstractTest
 
         $attributes = $this->storage[0]->getAttributes();
         $this->assertCount(1, $this->storage);
-        $this->assertEquals('HTTP GET', $this->storage[0]->getName());
+        $this->assertEquals('GET', $this->storage[0]->getName());
         $this->assertEquals('http://example.com/index.php/exception', $attributes->get(TraceAttributes::URL_FULL));
         $this->assertEquals('GET', $attributes->get(TraceAttributes::HTTP_REQUEST_METHOD));
         $this->assertEquals('http', $attributes->get(TraceAttributes::URL_SCHEME));

--- a/src/Instrumentation/HttpAsyncClient/src/HttpAsyncClientInstrumentation.php
+++ b/src/Instrumentation/HttpAsyncClient/src/HttpAsyncClientInstrumentation.php
@@ -43,7 +43,7 @@ class HttpAsyncClientInstrumentation
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $spanBuilder = $instrumentation
                     ->tracer()
-                    ->spanBuilder(sprintf('HTTP %s', $request->getMethod()))
+                    ->spanBuilder(sprintf('%s', $request->getMethod()))
                     ->setParent($parentContext)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
                     ->setAttribute(TraceAttributes::URL_FULL, (string) $request->getUri())
@@ -65,7 +65,7 @@ class HttpAsyncClientInstrumentation
                 foreach ((array) (get_cfg_var('otel.instrumentation.http.request_headers') ?: []) as $header) {
                     if ($request->hasHeader($header)) {
                         $spanBuilder->setAttribute(
-                            sprintf('http.request.header.%s', strtr(strtolower($header), ['-' => '_'])),
+                            sprintf('http.request.header.%s', strtolower($header)),
                             $request->getHeader($header)
                         );
                     }

--- a/src/Instrumentation/Laravel/src/HttpInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/HttpInstrumentation.php
@@ -29,7 +29,7 @@ class HttpInstrumentation
                 $request = ($params[0] instanceof Request) ? $params[0] : null;
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation->tracer()
-                    ->spanBuilder(sprintf('HTTP %s', $request?->method() ?? 'unknown'))
+                    ->spanBuilder(sprintf('%s', $request?->method() ?? 'unknown'))
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)

--- a/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
@@ -47,7 +47,7 @@ class ClientRequestWatcher extends Watcher
         if ($parsedUrl->has('query')) {
             $processedUrl .= '?' . $parsedUrl->get('query');
         }
-        $span = $this->instrumentation->tracer()->spanBuilder($request->request->method() ?? 'unknown')
+        $span = $this->instrumentation->tracer()->spanBuilder($request->request->method())
             ->setSpanKind(SpanKind::KIND_CLIENT)
             ->setAttributes([
                 TraceAttributes::HTTP_REQUEST_METHOD => $request->request->method(),

--- a/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
@@ -36,6 +36,9 @@ class ClientRequestWatcher extends Watcher
         $app['events']->listen(ResponseReceived::class, [$this, 'recordResponse']);
     }
 
+    /**
+     * @psalm-suppress ArgumentTypeCoercion
+     */
     public function recordRequest(RequestSending $request): void
     {
         $parsedUrl = collect(parse_url($request->request->url()));
@@ -44,7 +47,7 @@ class ClientRequestWatcher extends Watcher
         if ($parsedUrl->has('query')) {
             $processedUrl .= '?' . $parsedUrl->get('query');
         }
-        $span = $this->instrumentation->tracer()->spanBuilder('HTTP ' . $request->request->method())
+        $span = $this->instrumentation->tracer()->spanBuilder($request->request->method() ?? 'unknown')
             ->setSpanKind(SpanKind::KIND_CLIENT)
             ->setAttributes([
                 TraceAttributes::HTTP_REQUEST_METHOD => $request->request->method(),

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -55,12 +55,12 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertEquals(200, $response->status());
         $this->assertCount(1, $this->storage);
         $span = $this->storage->offsetGet(0);
-        $this->assertSame('HTTP GET', $span->getName());
+        $this->assertSame('GET', $span->getName());
     
         $response = Http::get('opentelemetry.io');
         $this->assertEquals(200, $response->status());
         $span = $this->storage->offsetGet(1);
-        $this->assertSame('HTTP GET', $span->getName());
+        $this->assertSame('GET', $span->getName());
     }
     public function test_cache_log_db(): void
     {
@@ -81,7 +81,7 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertEquals(200, $response->status());
         $this->assertCount(2, $this->storage);
         $span = $this->storage->offsetGet(1);
-        $this->assertSame('HTTP GET', $span->getName());
+        $this->assertSame('GET', $span->getName());
         $this->assertSame('http://localhost/hello', $span->getAttributes()->get(TraceAttributes::URL_FULL));
         $this->assertCount(5, $span->getEvents());
         $this->assertSame('cache set', $span->getEvents()[0]->getName());

--- a/src/Instrumentation/Psr15/src/Psr15Instrumentation.php
+++ b/src/Instrumentation/Psr15/src/Psr15Instrumentation.php
@@ -76,7 +76,7 @@ class Psr15Instrumentation
                 $builder = $instrumentation->tracer()->spanBuilder(
                     $root
                     ? sprintf('%s::%s', $class, $function)
-                    : sprintf('HTTP %s', $request?->getMethod() ?? 'unknown')
+                    : sprintf('%s', $request?->getMethod() ?? 'unknown')
                 )
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)

--- a/src/Instrumentation/Psr18/src/Psr18Instrumentation.php
+++ b/src/Instrumentation/Psr18/src/Psr18Instrumentation.php
@@ -46,7 +46,7 @@ class Psr18Instrumentation
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $spanBuilder = $instrumentation
                     ->tracer()
-                    ->spanBuilder(sprintf('HTTP %s', $request->getMethod()))
+                    ->spanBuilder(sprintf('%s', $request->getMethod()))
                     ->setParent($parentContext)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
                     ->setAttribute(TraceAttributes::URL_FULL, (string) $request->getUri())
@@ -69,7 +69,7 @@ class Psr18Instrumentation
                 foreach ((array) (get_cfg_var('otel.instrumentation.http.request_headers') ?: []) as $header) {
                     if ($request->hasHeader($header)) {
                         $spanBuilder->setAttribute(
-                            sprintf('http.request.header.%s', strtr(strtolower($header), ['-' => '_'])),
+                            sprintf('http.request.header.%s', strtolower($header)),
                             $request->getHeader($header)
                         );
                     }
@@ -102,7 +102,7 @@ class Psr18Instrumentation
                     foreach ((array) (get_cfg_var('otel.instrumentation.http.response_headers') ?: []) as $header) {
                         if ($response->hasHeader($header)) {
                             /** @psalm-suppress ArgumentTypeCoercion */
-                            $span->setAttribute(sprintf('http.response.header.%s', strtr(strtolower($header), ['-' => '_'])), $response->getHeader($header));
+                            $span->setAttribute(sprintf('http.response.header.%s', strtolower($header)), $response->getHeader($header));
                         }
                     }
                     if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {

--- a/src/Instrumentation/Slim/src/SlimInstrumentation.php
+++ b/src/Instrumentation/Slim/src/SlimInstrumentation.php
@@ -37,7 +37,7 @@ class SlimInstrumentation
                 $request = ($params[0] instanceof ServerRequestInterface) ? $params[0] : null;
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation->tracer()
-                    ->spanBuilder(sprintf('HTTP %s', $request?->getMethod() ?? 'unknown'))
+                    ->spanBuilder(sprintf('%s', $request?->getMethod() ?? 'unknown'))
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
@@ -52,6 +52,7 @@ class SlimInstrumentation
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->getHeaderLine('Content-Length'))
                         ->setAttribute(TraceAttributes::URL_SCHEME, $request->getUri()->getScheme())
+                        ->setAttribute(TraceAttributes::URL_PATH, $request->getUri()->getPath())
                         ->startSpan();
                     $request = $request->withAttribute(SpanInterface::class, $span);
                 } else {
@@ -109,6 +110,7 @@ class SlimInstrumentation
                 if (!$route instanceof RouteInterface) {
                     return;
                 }
+                $span->setAttribute(TraceAttributes::HTTP_ROUTE, $route->getName() ?? $route->getPattern());
                 $span->updateName(sprintf('%s %s', $request->getMethod(), $route->getName() ?? $route->getPattern()));
             }
         );

--- a/src/Instrumentation/Slim/tests/Integration/SlimInstrumentationTest.php
+++ b/src/Instrumentation/Slim/tests/Integration/SlimInstrumentationTest.php
@@ -131,7 +131,7 @@ class SlimInstrumentationTest extends TestCase
         }
         $this->assertCount(1, $this->storage);
         $span = $this->storage->offsetGet(0); // @var ImmutableSpan $span
-        $this->assertSame('HTTP GET', $span->getName(), 'span name was not updated because routing failed');
+        $this->assertSame('GET', $span->getName(), 'span name was not updated because routing failed');
     }
 
     public function createMockStrategy(): InvocationStrategyInterface

--- a/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
@@ -36,7 +36,7 @@ final class HttpClientInstrumentation
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation
                     ->tracer()
-                    ->spanBuilder(\sprintf('HTTP %s', $params[0]))
+                    ->spanBuilder(\sprintf('%s', $params[0]))
                     ->setSpanKind(SpanKind::KIND_CLIENT)
                     ->setAttribute(TraceAttributes::URL_FULL, (string) $params[1])
                     ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $params[0])

--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -40,7 +40,7 @@ final class SymfonyInstrumentation
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation
                     ->tracer()
-                    ->spanBuilder(\sprintf('HTTP %s', $request?->getMethod() ?? 'unknown'))
+                    ->spanBuilder(\sprintf('%s', $request?->getMethod() ?? 'unknown'))
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
@@ -56,6 +56,7 @@ final class SymfonyInstrumentation
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->headers->get('Content-Length'))
                         ->setAttribute(TraceAttributes::URL_SCHEME, $request->getScheme())
+                        ->setAttribute(TraceAttributes::URL_PATH, $request->getPathInfo())
                         ->startSpan();
                     $request->attributes->set(SpanInterface::class, $span);
                 } else {

--- a/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
+++ b/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
@@ -84,7 +84,7 @@ class WordpressInstrumentation
 
                 $span = $instrumentation
                     ->tracer()
-                    ->spanBuilder(sprintf('HTTP %s', $request->getMethod()))
+                    ->spanBuilder(sprintf('%s', $request->getMethod()))
                     ->setParent($parent)
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::URL_FULL, (string) $request->getUri())


### PR DESCRIPTION
* update http server span names to match spec ("GET" or "GET <route>"), per https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#name
* adding http client/server span attributes
* do not normalize hyphen to underscore for http request/response header key, per https://opentelemetry.io/blog/2023/http-conventions-declared-stable/#common-attributes-across-http-client-and-server-spans