### PR TITLE
Update SwooleContextHandler.php

### DIFF
--- a/src/Context/Swoole/src/SwooleContextHandler.php
+++ b/src/Context/Swoole/src/SwooleContextHandler.php
@@ -28,7 +28,7 @@ final class SwooleContextHandler
     {
         $cid = Coroutine::getCid();
         if ($cid !== -1 && !$this->isForked($cid)) {
-            for ($pcid = $cid; ($pcid = Coroutine::getPcid($pcid)) !== -1 && !$this->isForked($pcid);) {
+            for ($pcid = $cid; ($pcid = Coroutine::getPcid($pcid)) !== -1 && Coroutine::exists($pcid) && !$this->isForked($pcid);) {
             }
 
             $this->storage->switch($pcid);


### PR DESCRIPTION
If the exception in the coroutine is not caught or other unknown circumstances, the code stack will run in a non-coroutine. At this time, Coroutine::getPcid($pcid) will return false, and SwooleContextHandler::isForked(int id) will raise a TypeError. fatal error.