### PR TITLE
Laravel: decoupled from SDK ClockFactory (& some linting)

### DIFF
--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -13,7 +13,6 @@
     "ext-opentelemetry": "*",
     "laravel/framework": ">=6.0",
     "open-telemetry/api": "^1.0",
-    "open-telemetry/sdk": "^1.0",
     "open-telemetry/sem-conv": "^1.22"
   },
   "require-dev": {
@@ -21,6 +20,7 @@
     "guzzlehttp/guzzle": "*",
     "laravel/tinker": "*",
     "nunomaduro/collision": "*",
+    "open-telemetry/sdk": "^1.0",
     "orchestra/testbench": ">=4.0",
     "phan/phan": "^5.0",
     "php-http/mock-client": "*",

--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -12,7 +12,8 @@
     "ext-json": "*",
     "ext-opentelemetry": "*",
     "laravel/framework": ">=6.0",
-    "open-telemetry/api": "^1.0.0beta10",
+    "open-telemetry/api": "^1.0",
+    "open-telemetry/sdk": "^1.0",
     "open-telemetry/sem-conv": "^1.22"
   },
   "require-dev": {
@@ -22,7 +23,6 @@
     "laravel/sanctum": "*",
     "laravel/tinker": "*",
     "nunomaduro/collision": "*",
-    "open-telemetry/sdk": "^1.0",
     "orchestra/testbench": ">=4.0",
     "phan/phan": "^5.0",
     "php-http/mock-client": "*",

--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -19,8 +19,6 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",
     "guzzlehttp/guzzle": "*",
-    "laravel/sail": "*",
-    "laravel/sanctum": "*",
     "laravel/tinker": "*",
     "nunomaduro/collision": "*",
     "orchestra/testbench": ">=4.0",

--- a/src/Instrumentation/Laravel/src/Watchers/QueryWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/QueryWatcher.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Str;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Trace\SpanKind;
-use OpenTelemetry\SDK\Common\Time\ClockFactory;
 use OpenTelemetry\SemConv\TraceAttributes;
 
 class QueryWatcher extends Watcher
@@ -33,7 +32,7 @@ class QueryWatcher extends Watcher
     /** @psalm-suppress UndefinedThisPropertyFetch */
     public function recordQuery(QueryExecuted $query): void
     {
-        $nowInNs = ClockFactory::getDefault()->now();
+        $nowInNs = (int) (microtime(true) * 1E9);
 
         $operationName = Str::upper(Str::before($query->sql, ' '));
         if (! in_array($operationName, ['SELECT', 'INSERT', 'UPDATE', 'DELETE'])) {
@@ -60,6 +59,6 @@ class QueryWatcher extends Watcher
 
     private function calculateQueryStartTime(int $nowInNs, float $queryTimeMs): int
     {
-        return (int) ($nowInNs - ($queryTimeMs * 1000000));
+        return (int) ($nowInNs - ($queryTimeMs * 1E6));
     }
 }


### PR DESCRIPTION
OpenTelemetry\SDK is used in the QueryWatcher instrumentation, so has been promoted from a dev dependency.