### PR TITLE
Yii2 framework instrumentation

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,6 +29,7 @@ jobs:
           'Instrumentation/Laravel',
           'Instrumentation/MongoDB',
           'Instrumentation/CodeIgniter',
+          'Instrumentation/Yii',
           'Logs/Monolog',
           'Propagation/TraceResponse',
           'ResourceDetectors/Container',
@@ -53,6 +54,8 @@ jobs:
           - project: 'Instrumentation/Laravel'
             php-version: 7.4
           - project: 'Instrumentation/CodeIgniter'
+            php-version: 7.4
+          - project: 'Instrumentation/Yii'
             php-version: 7.4
           - project: 'Instrumentation/IO'
             php-version: 8.0

--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -36,6 +36,8 @@ splits:
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/contrib-auto-symfony.git"
   - prefix: "src/Instrumentation/Wordpress"
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/contrib-auto-wordpress.git"
+  - prefix: "src/Instrumentation/Yii"
+    target: "https://${GH_TOKEN}@github.com/opentelemetry-php/contrib-auto-yii.git"
   - prefix: "src/Context/Swoole"
     target: "https://${GH_TOKEN}@github.com/opentelemetry-php/context-swoole.git"
   - prefix: "src/AutoInstrumentationInstaller"

--- a/src/Instrumentation/Yii/.php-cs-fixer.php
+++ b/src/Instrumentation/Yii/.php-cs-fixer.php
@@ -1,0 +1,42 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->exclude('var/cache')
+    ->in(__DIR__);
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+    'concat_space' => ['spacing' => 'one'],
+    'declare_equal_normalize' => ['space' => 'none'],
+    'is_null' => true,
+    'modernize_types_casting' => true,
+    'ordered_imports' => true,
+    'php_unit_construct' => true,
+    'single_line_comment_style' => true,
+    'yoda_style' => false,
+    '@PSR2' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'blank_line_after_opening_tag' => true,
+    'blank_line_before_statement' => true,
+    'cast_spaces' => true,
+    'declare_strict_types' => true,
+    'function_typehint_space' => true,
+    'include' => true,
+    'lowercase_cast' => true,
+    'new_with_braces' => true,
+    'no_extra_blank_lines' => true,
+    'no_leading_import_slash' => true,
+    'echo_tag_syntax' => true,
+    'no_unused_imports' => true,
+    'no_useless_else' => true,
+    'no_useless_return' => true,
+    'phpdoc_order' => true,
+    'phpdoc_scalar' => true,
+    'phpdoc_types' => true,
+    'short_scalar_cast' => true,
+    'single_blank_line_before_namespace' => true,
+    'single_quote' => true,
+    'trailing_comma_in_multiline' => true,
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder($finder);

--- a/src/Instrumentation/Yii/README.md
+++ b/src/Instrumentation/Yii/README.md
@@ -1,0 +1,25 @@
+[![Releases](https://img.shields.io/badge/releases-purple)](https://github.com/opentelemetry-php/contrib-auto-yii/releases)
+[![Issues](https://img.shields.io/badge/issues-pink)](https://github.com/open-telemetry/opentelemetry-php/issues)
+[![Source](https://img.shields.io/badge/source-contrib-green)](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Yii)
+[![Mirror](https://img.shields.io/badge/mirror-opentelemetry--php--contrib-blue)](https://github.com/opentelemetry-php/contrib-auto-yii)
+[![Latest Version](http://poser.pugx.org/open-telemetry/opentelemetry-auto-yii/v/unstable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-yii/)
+[![Stable](http://poser.pugx.org/open-telemetry/opentelemetry-auto-yii/v/stable)](https://packagist.org/packages/open-telemetry/opentelemetry-auto-yii/)
+
+This is a read-only subtree split of https://github.com/open-telemetry/opentelemetry-php-contrib.
+
+# OpenTelemetry Yii auto-instrumentation
+
+Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
+install and configure the extension and SDK.
+
+## Overview
+
+Requires Yii 2.0.13+
+
+## Configuration
+
+The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
+
+```shell
+OTEL_PHP_DISABLED_INSTRUMENTATIONS=yii
+```

--- a/src/Instrumentation/Yii/_register.php
+++ b/src/Instrumentation/Yii/_register.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenTelemetry\Contrib\Instrumentation\Yii\YiiInstrumentation;
+use OpenTelemetry\SDK\Sdk;
+
+if (class_exists(Sdk::class) && Sdk::isInstrumentationDisabled(YiiInstrumentation::NAME) === true) {
+    return;
+}
+
+if (extension_loaded('opentelemetry') === false) {
+    trigger_error('The opentelemetry extension must be loaded in order to autoload the OpenTelemetry Yii auto-instrumentation', E_USER_WARNING);
+
+    return;
+}
+
+YiiInstrumentation::register();

--- a/src/Instrumentation/Yii/composer.json
+++ b/src/Instrumentation/Yii/composer.json
@@ -6,12 +6,11 @@
     "homepage": "https://opentelemetry.io/docs/php",
     "readme": "./README.md",
     "license": "Apache-2.0",
-    "minimum-stability": "dev",
     "require": {
       "php": "^8.0",
       "ext-opentelemetry": "*",
       "yiisoft/yii2": "^2.0.13",
-      "open-telemetry/api": "^1.0.0beta10",
+      "open-telemetry/api": "^1",
       "open-telemetry/sem-conv": "^1.22"
     },
     "require-dev": {

--- a/src/Instrumentation/Yii/composer.json
+++ b/src/Instrumentation/Yii/composer.json
@@ -1,0 +1,53 @@
+{
+    "name": "open-telemetry/opentelemetry-auto-yii",
+    "description": "OpenTelemetry auto-instrumentation for Yii",
+    "keywords": ["opentelemetry", "otel", "open-telemetry", "tracing", "yii", "instrumentation"],
+    "type": "library",
+    "homepage": "https://opentelemetry.io/docs/php",
+    "readme": "./README.md",
+    "license": "Apache-2.0",
+    "minimum-stability": "dev",
+    "require": {
+      "php": "^8.0",
+      "ext-opentelemetry": "*",
+      "yiisoft/yii2": "^2.0.13",
+      "open-telemetry/api": "^1.0.0beta10",
+      "open-telemetry/sem-conv": "^1.22"
+    },
+    "require-dev": {
+      "friendsofphp/php-cs-fixer": "^3",
+      "open-telemetry/sdk": "^1.0",
+      "phan/phan": "^5.0",
+      "php-http/mock-client": "*",
+      "phpstan/phpstan": "^1.1",
+      "phpstan/phpstan-phpunit": "^1.0",
+      "psalm/plugin-phpunit": "^0.16",
+      "phpunit/phpunit": "^9.5",
+      "vimeo/psalm": "^4.0"
+    },
+    "repositories": [
+      {
+        "type": "composer",
+        "url": "https://asset-packagist.org"
+      }
+    ],
+    "autoload": {
+      "psr-4": {
+        "OpenTelemetry\\Contrib\\Instrumentation\\Yii\\": "src/"
+      },
+      "files": [
+        "_register.php"
+      ]
+    },
+    "autoload-dev": {
+      "psr-4": {
+        "OpenTelemetry\\Tests\\Instrumentation\\Yii\\": "tests/"
+      }
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false,
+            "yiisoft/yii2-composer": false
+        }
+    }
+}

--- a/src/Instrumentation/Yii/phpstan.neon.dist
+++ b/src/Instrumentation/Yii/phpstan.neon.dist
@@ -1,0 +1,11 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+
+parameters:
+    tmpDir: var/cache/phpstan
+    bootstrapFiles:
+        - tests/bootstrap.php
+    level: 5
+    paths:
+        - src
+        - tests

--- a/src/Instrumentation/Yii/phpunit.xml.dist
+++ b/src/Instrumentation/Yii/phpunit.xml.dist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="tests/bootstrap.php"
+    cacheResult="false"
+    colors="false"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    forceCoversAnnotation="false"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    stopOnRisky="false"
+    timeoutForSmallTests="1"
+    timeoutForMediumTests="10"
+    timeoutForLargeTests="60"
+    verbose="true">
+
+    <coverage processUncoveredFiles="true" disableCodeCoverageIgnore="false">
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
+
+    <php>
+        <ini name="date.timezone" value="UTC" />
+        <ini name="display_errors" value="On" />
+        <ini name="display_startup_errors" value="On" />
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
+
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/src/Instrumentation/Yii/psalm.xml.dist
+++ b/src/Instrumentation/Yii/psalm.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="3"
+    cacheDirectory="var/cache/psalm"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="tests"/>
+        <ignoreFiles>
+            <directory name="vendor/yiisoft/yii2" />
+        </ignoreFiles>
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/Instrumentation/Yii/src/RequestPropagationGetter.php
+++ b/src/Instrumentation/Yii/src/RequestPropagationGetter.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Yii;
+
+use function assert;
+use OpenTelemetry\Context\Propagation\PropagationGetterInterface;
+use yii\web\Request;
+
+/**
+ * @internal
+ */
+final class RequestPropagationGetter implements PropagationGetterInterface
+{
+    public static function instance(): self
+    {
+        static $instance;
+
+        return $instance ??= new self();
+    }
+
+    /** @psalm-suppress InvalidReturnType */
+    public function keys($carrier): array
+    {
+        assert($carrier instanceof Request);
+
+        return array_keys($carrier->getHeaders()->toArray());
+    }
+
+    public function get($carrier, string $key) : ?string
+    {
+        assert($carrier instanceof Request);
+
+        $result = $carrier->getHeaders()->get($key, null, true);
+
+        if (is_array($result)) {
+            return (string) array_values($result)[0];
+        }
+
+        return $result;
+        
+    }
+}

--- a/src/Instrumentation/Yii/src/ResponsePropagationSetter.php
+++ b/src/Instrumentation/Yii/src/ResponsePropagationSetter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Yii;
+
+use function assert;
+use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
+use yii\web\Response;
+
+/**
+ * @internal
+ */
+final class ResponsePropagationSetter implements PropagationSetterInterface
+{
+    public static function instance(): self
+    {
+        static $instance;
+
+        return $instance ??= new self();
+    }
+
+    /** @psalm-suppress InvalidReturnType */
+    public function keys($carrier): array
+    {
+        assert($carrier instanceof Response);
+
+        return array_keys($carrier->getHeaders()->toArray());
+    }
+
+    public function set(&$carrier, string $key, string $value): void
+    {
+        assert($carrier instanceof Response);
+
+        $carrier->getHeaders()->set($key, $value);
+    }
+}

--- a/src/Instrumentation/Yii/src/YiiInstrumentation.php
+++ b/src/Instrumentation/Yii/src/YiiInstrumentation.php
@@ -127,6 +127,7 @@ class YiiInstrumentation
 
                 $span = Span::fromContext($scope->context());
                 $route = YiiInstrumentation::normalizeRouteName(get_class($controller), $action->actionMethod);
+                /** @psalm-suppress ArgumentTypeCoercion */
                 $span->updateName($route);
                 $span->setAttribute(TraceAttributes::HTTP_ROUTE, $route);
             },

--- a/src/Instrumentation/Yii/src/YiiInstrumentation.php
+++ b/src/Instrumentation/Yii/src/YiiInstrumentation.php
@@ -127,6 +127,7 @@ class YiiInstrumentation
 
                 $span = Span::fromContext($scope->context());
                 $route = YiiInstrumentation::normalizeRouteName(get_class($controller), $action->actionMethod);
+                $span->updateName($route);
                 $span->setAttribute(TraceAttributes::HTTP_ROUTE, $route);
             },
             post: null

--- a/src/Instrumentation/Yii/src/YiiInstrumentation.php
+++ b/src/Instrumentation/Yii/src/YiiInstrumentation.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Yii;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\Context\Context;
+use function OpenTelemetry\Instrumentation\hook;
+use OpenTelemetry\SemConv\TraceAttributes;
+use yii\web\Application;
+use yii\web\Controller;
+use yii\web\Response;
+
+class YiiInstrumentation
+{
+    public const NAME = 'yii';
+
+    public static function register(): void
+    {
+        $instrumentation = new CachedInstrumentation('io.opentelemetry.contrib.php.yii');
+
+        hook(
+            Application::class,
+            'handleRequest',
+            pre: static function (
+                Application $application,
+                array $params,
+                string $class,
+                string $function,
+                ?string $filename,
+                ?int $lineno,
+            ) use ($instrumentation) : void {
+                $request = $application->getRequest();
+                $parent = Globals::propagator()->extract($request, RequestPropagationGetter::instance());
+
+                /** @psalm-suppress ArgumentTypeCoercion */
+                $spanBuilder = $instrumentation
+                    ->tracer()
+                    ->spanBuilder(sprintf('%s', $request->getMethod()))
+                    ->setParent($parent)
+                    ->setSpanKind(SpanKind::KIND_SERVER)
+                    ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
+                    ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
+                    ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)
+                    ->setAttribute(TraceAttributes::CODE_LINENO, $lineno)
+                    ->setAttribute(TraceAttributes::URL_FULL, $request->getAbsoluteUrl())
+                    ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
+                    ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->getHeaders()->get('Content-Length', null, true))
+                    ->setAttribute(TraceAttributes::URL_SCHEME, $request->getIsSecureConnection() ? 'https' : 'http');
+
+                $span = $spanBuilder->startSpan();
+
+                Context::storage()->attach($span->storeInContext($parent));
+            },
+            post: static function (
+                Application $application,
+                array $params,
+                ?Response $response,
+                ?\Throwable $exception
+            ): void {
+                $scope = Context::storage()->scope();
+                if (!$scope) {
+                    return;
+                }
+                $scope->detach();
+
+                $span = Span::fromContext($scope->context());
+
+                if ($response) {
+                    $statusCode = $response->getStatusCode();
+                    $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $statusCode);
+                    $span->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $response->version);
+                    $span->setAttribute(TraceAttributes::HTTP_RESPONSE_BODY_SIZE, YiiInstrumentation::getResponseLength($response));
+
+                    $headers = $response->getHeaders();
+
+                    foreach ((array) (get_cfg_var('otel.instrumentation.http.response_headers') ?: []) as $header) {
+                        if ($headers->has($header)) {
+                            /** @psalm-suppress ArgumentTypeCoercion */
+                            $span->setAttribute(sprintf('http.response.header.%s', strtr(strtolower($header), ['-' => '_'])), $headers->get($header, null, true));
+                        }
+                    }
+
+                    if ($statusCode >= 400 && $statusCode < 600) {
+                        $span->setStatus(StatusCode::STATUS_ERROR);
+                    }
+
+                    // Propagate traceresponse header to response, if TraceResponsePropagator is present
+                    if (class_exists('OpenTelemetry\Contrib\Propagation\TraceResponse\TraceResponsePropagator')) {
+                        /** @phan-suppress-next-line PhanUndeclaredClassMethod */
+                        $prop = new \OpenTelemetry\Contrib\Propagation\TraceResponse\TraceResponsePropagator();
+                        /** @phan-suppress-next-line PhanUndeclaredClassMethod */
+                        $prop->inject($response, ResponsePropagationSetter::instance(), $scope->context());
+                    }
+                }
+
+                if ($exception) {
+                    $span->recordException($exception, [TraceAttributes::EXCEPTION_ESCAPED => true]);
+                    $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
+                }
+
+                $span->end();
+            }
+        );
+
+        hook(
+            Controller::class,
+            'beforeAction',
+            pre: static function (
+                Controller $controller,
+                array $params,
+                string $class,
+                string $function,
+                ?string $filename,
+                ?int $lineno,
+            ) : void {
+                $action = $params[0] ?? null;
+                $scope = Context::storage()->scope();
+                if (!$action || !$scope) {
+                    return;
+                }
+
+                $span = Span::fromContext($scope->context());
+                $route = YiiInstrumentation::normalizeRouteName(get_class($controller), $action->actionMethod);
+                $span->setAttribute(TraceAttributes::HTTP_ROUTE, $route);
+            },
+            post: null
+        );
+    }
+
+    protected static function getResponseLength(Response $response): ?string
+    {
+        $headerValue = $response->getHeaders()->get('Content-Length', null, true);
+        if (is_string($headerValue)) {
+            return $headerValue;
+        }
+
+        if ($response->content != null) {
+            return (string) (strlen($response->content));
+        }
+
+        return null;
+    }
+
+    protected static function normalizeRouteName(string $controllerClassName, string $controllerMethod): string
+    {
+        $lastSegment = strrchr($controllerClassName, '\\');
+        
+        if ($lastSegment === false) {
+            return $controllerClassName . '.' . $controllerMethod;
+        }
+
+        return substr($lastSegment, 1) . '.' . $controllerMethod;
+    }
+}

--- a/src/Instrumentation/Yii/tests/Integration/AbstractTest.php
+++ b/src/Instrumentation/Yii/tests/Integration/AbstractTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Instrumentation\Yii\tests\Integration;
+
+use ArrayObject;
+use OpenTelemetry\API\Instrumentation\Configurator;
+use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
+use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractTest extends TestCase
+{
+    private ScopeInterface $scope;
+    protected ArrayObject $storage;
+
+    public function setUp(): void
+    {
+        $this->storage = new ArrayObject();
+        $tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($this->storage)
+            )
+        );
+
+        $this->scope = Configurator::create()
+            ->withTracerProvider($tracerProvider)
+            ->withPropagator(TraceContextPropagator::getInstance())
+            ->activate();
+        
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->scope->detach();
+    }
+}

--- a/src/Instrumentation/Yii/tests/Integration/YiiInstrumentationTest.php
+++ b/src/Instrumentation/Yii/tests/Integration/YiiInstrumentationTest.php
@@ -20,7 +20,7 @@ class YiiInstrumentationTest extends AbstractTest
 
         $attributes = $this->storage[0]->getAttributes();
         $this->assertCount(1, $this->storage);
-        $this->assertEquals('GET', $this->storage[0]->getName());
+        $this->assertEquals('SiteController.actionIndex', $this->storage[0]->getName());
         $this->assertEquals('http://example.com/site/index', $attributes->get(TraceAttributes::URL_FULL));
         $this->assertEquals('GET', $attributes->get(TraceAttributes::HTTP_REQUEST_METHOD));
         $this->assertEquals('http', $attributes->get(TraceAttributes::URL_SCHEME));
@@ -39,7 +39,7 @@ class YiiInstrumentationTest extends AbstractTest
 
         $attributes = $this->storage[0]->getAttributes();
         $this->assertCount(1, $this->storage);
-        $this->assertEquals('GET', $this->storage[0]->getName());
+        $this->assertEquals('SiteController.actionThrow', $this->storage[0]->getName());
         $this->assertEquals('http://example.com/site/throw', $attributes->get(TraceAttributes::URL_FULL));
         $this->assertEquals('GET', $attributes->get(TraceAttributes::HTTP_REQUEST_METHOD));
         $this->assertEquals('http', $attributes->get(TraceAttributes::URL_SCHEME));
@@ -65,7 +65,7 @@ class YiiInstrumentationTest extends AbstractTest
 
         $attributes = $span->getAttributes();
         $this->assertCount(1, $this->storage);
-        $this->assertEquals('GET', $this->storage[0]->getName());
+        $this->assertEquals('SiteController.actionIndex', $this->storage[0]->getName());
         $this->assertEquals('http://example.com/site/index', $attributes->get(TraceAttributes::URL_FULL));
         $this->assertEquals('GET', $attributes->get(TraceAttributes::HTTP_REQUEST_METHOD));
         $this->assertEquals('http', $attributes->get(TraceAttributes::URL_SCHEME));

--- a/src/Instrumentation/Yii/tests/Integration/YiiInstrumentationTest.php
+++ b/src/Instrumentation/Yii/tests/Integration/YiiInstrumentationTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Instrumentation\Yii\tests\Integration;
+
+use OpenTelemetry\SemConv\TraceAttributes;
+use yii\web\Application;
+use yii\web\Controller;
+
+class YiiInstrumentationTest extends AbstractTest
+{
+    public function test_success()
+    {
+        $exception = $this->runRequest('/site/index');
+
+        // Throws on success because headers cannot be sent
+        $this->assertNotNull($exception);
+        $this->assertEquals('yii\web\HeadersAlreadySentException', get_class($exception));
+
+        $attributes = $this->storage[0]->getAttributes();
+        $this->assertCount(1, $this->storage);
+        $this->assertEquals('GET', $this->storage[0]->getName());
+        $this->assertEquals('http://example.com/site/index', $attributes->get(TraceAttributes::URL_FULL));
+        $this->assertEquals('GET', $attributes->get(TraceAttributes::HTTP_REQUEST_METHOD));
+        $this->assertEquals('http', $attributes->get(TraceAttributes::URL_SCHEME));
+        $this->assertEquals('SiteController.actionIndex', $attributes->get(TraceAttributes::HTTP_ROUTE));
+        $this->assertEquals(200, $attributes->get(TraceAttributes::HTTP_RESPONSE_STATUS_CODE));
+        $this->assertEquals('1.1', $attributes->get(TraceAttributes::NETWORK_PROTOCOL_VERSION));
+        $this->assertGreaterThan(0, $attributes->get(TraceAttributes::HTTP_RESPONSE_BODY_SIZE));
+    }
+
+    public function test_exception()
+    {
+        $exception = $this->runRequest('/site/throw');
+
+        $this->assertNotNull($exception);
+        $this->assertEquals('Threw', $exception->getMessage());
+
+        $attributes = $this->storage[0]->getAttributes();
+        $this->assertCount(1, $this->storage);
+        $this->assertEquals('GET', $this->storage[0]->getName());
+        $this->assertEquals('http://example.com/site/throw', $attributes->get(TraceAttributes::URL_FULL));
+        $this->assertEquals('GET', $attributes->get(TraceAttributes::HTTP_REQUEST_METHOD));
+        $this->assertEquals('http', $attributes->get(TraceAttributes::URL_SCHEME));
+        $this->assertEquals('SiteController.actionThrow', $attributes->get(TraceAttributes::HTTP_ROUTE));
+    }
+
+    public function test_parent()
+    {
+        try {
+            $_SERVER['HTTP_TRACEPARENT'] = '00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01';
+            $exception = $this->runRequest('/site/index');
+        } finally {
+            unset($_SERVER['HTTP_TRACEPARENT']);
+        }
+
+        // Throws on success because headers cannot be sent
+        $this->assertNotNull($exception);
+        $this->assertEquals('yii\web\HeadersAlreadySentException', get_class($exception));
+
+        $span = $this->storage[0];
+        $this->assertEquals('0af7651916cd43dd8448eb211c80319c', $span->getTraceId());
+        $this->assertEquals('b9c7c989f97918e1', $span->getParentSpanId());
+
+        $attributes = $span->getAttributes();
+        $this->assertCount(1, $this->storage);
+        $this->assertEquals('GET', $this->storage[0]->getName());
+        $this->assertEquals('http://example.com/site/index', $attributes->get(TraceAttributes::URL_FULL));
+        $this->assertEquals('GET', $attributes->get(TraceAttributes::HTTP_REQUEST_METHOD));
+        $this->assertEquals('http', $attributes->get(TraceAttributes::URL_SCHEME));
+        $this->assertEquals('SiteController.actionIndex', $attributes->get(TraceAttributes::HTTP_ROUTE));
+        $this->assertEquals(200, $attributes->get(TraceAttributes::HTTP_RESPONSE_STATUS_CODE));
+        $this->assertEquals('1.1', $attributes->get(TraceAttributes::NETWORK_PROTOCOL_VERSION));
+        $this->assertGreaterThan(0, $attributes->get(TraceAttributes::HTTP_RESPONSE_BODY_SIZE));
+    }
+
+    private function runRequest($path)
+    {
+        $config = [
+            'id' => 'basic',
+            'basePath' => dirname(__DIR__),
+            'bootstrap' => ['log'],
+            'components' => [
+                'request' => [
+                    // !!! insert a secret key in the following (if it is empty) - this is required by cookie validation
+                    'cookieValidationKey' => 'ybQT_avit3_11aPJfJQ6zwbdjjwjOYbs',
+                ],
+                'cache' => [
+                    'class' => 'yii\caching\FileCache',
+                ],
+                'user' => [
+                    'identityClass' => 'app\models\User',
+                    'enableAutoLogin' => true,
+                ],
+                'errorHandler' => [
+                    'errorAction' => 'site/error',
+                ],
+                'log' => [
+                    'traceLevel' => 3,
+                    'targets' => [
+                        [
+                            'class' => 'yii\log\FileTarget',
+                            'levels' => ['error', 'warning'],
+                        ],
+                    ],
+                ],
+                'db' => [
+                    'class' => 'yii\db\Connection',
+                    'dsn' => 'mysql:host=localhost;dbname=yii2basic',
+                    'username' => 'root',
+                    'password' => '',
+                    'charset' => 'utf8',
+                ],
+                'urlManager' => [
+                    'enablePrettyUrl' => true,
+                    'showScriptName' => false,
+                    'rules' => [
+                        '<controller:\w+>' => '<controller>',
+                        '<controller:\w+>/<action:\w+>' => '<controller>/<action>',
+                    ],
+                ],
+            ],
+            'controllerMap' => [
+                'site' => [
+                    'class' => 'OpenTelemetry\Tests\Instrumentation\Yii\tests\Integration\SiteController',
+                ],
+            ],
+            'params' => [],
+        ];
+
+        $_SERVER['SERVER_NAME'] = 'example.com';
+        $_SERVER['REQUEST_URI'] = $path;
+        $_SERVER['SCRIPT_NAME'] = '/';
+        $_SERVER['SCRIPT_FILENAME'] = '/';
+
+        $exception = null;
+
+        try {
+            (new Application($config))->run();
+        } catch (\Exception $e) {
+            $exception = $e;
+        }
+
+        return $exception;
+    }
+}
+
+class SiteController extends Controller
+{
+    public function actionIndex()
+    {
+        return \Yii::createObject([
+            'class' => 'yii\web\Response',
+            'format' => \yii\web\Response::FORMAT_RAW,
+            'content' => 'hello',
+        ]);
+    }
+
+    public function actionThrow()
+    {
+        throw new \Exception('Threw');
+    }
+}

--- a/src/Instrumentation/Yii/tests/bootstrap.php
+++ b/src/Instrumentation/Yii/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+define('YII_ENABLE_ERROR_HANDLER', false);
+define('YII_DEBUG', true);
+define('YII_ENV', 'test');
+
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';


### PR DESCRIPTION
Implements Yii 2.0.13+ auto-instrumentation (open-telemetry/opentelemetry-auto-yii package). Earlier versions have a class naming conflict with PHP 8.0+ itself. Currently only collects root span.