### PR TITLE
Add traces attributes

### DIFF
--- a/src/Instrumentation/CodeIgniter/src/CodeIgniterInstrumentation.php
+++ b/src/Instrumentation/CodeIgniter/src/CodeIgniterInstrumentation.php
@@ -73,6 +73,9 @@ class CodeIgniterInstrumentation
                         /** @phan-suppress-next-line PhanDeprecatedFunction */
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod(true))
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->getHeaderLine('Content-Length'))
+                        ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->getHeaderLine('User-Agent'))
+                        ->setAttribute(TraceAttributes::SERVER_ADDRESS, $request->getUri()->getHost())
+                        ->setAttribute(TraceAttributes::SERVER_PORT, $request->getUri()->getPort())
                         ->setAttribute(TraceAttributes::URL_SCHEME, $request->getUri()->getScheme());
                 }
 

--- a/src/Instrumentation/Psr15/src/Psr15Instrumentation.php
+++ b/src/Instrumentation/Psr15/src/Psr15Instrumentation.php
@@ -93,6 +93,10 @@ class Psr15Instrumentation
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->getHeaderLine('Content-Length'))
                         ->setAttribute(TraceAttributes::URL_SCHEME, $request->getUri()->getScheme())
+                        ->setAttribute(TraceAttributes::URL_PATH, $request->getUri()->getPath())
+                        ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->getHeaderLine('User-Agent'))
+                        ->setAttribute(TraceAttributes::SERVER_ADDRESS, $request->getUri()->getHost())
+                        ->setAttribute(TraceAttributes::SERVER_PORT, $request->getUri()->getPort())
                         ->startSpan();
                     $request = $request->withAttribute(SpanInterface::class, $span);
                 } else {

--- a/src/Instrumentation/Slim/src/SlimInstrumentation.php
+++ b/src/Instrumentation/Slim/src/SlimInstrumentation.php
@@ -51,6 +51,9 @@ class SlimInstrumentation
                         ->setAttribute(TraceAttributes::URL_FULL, $request->getUri()->__toString())
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->getHeaderLine('Content-Length'))
+                        ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->getHeaderLine('User-Agent'))
+                        ->setAttribute(TraceAttributes::SERVER_ADDRESS, $request->getUri()->getHost())
+                        ->setAttribute(TraceAttributes::SERVER_PORT, $request->getUri()->getPort())
                         ->setAttribute(TraceAttributes::URL_SCHEME, $request->getUri()->getScheme())
                         ->setAttribute(TraceAttributes::URL_PATH, $request->getUri()->getPath())
                         ->startSpan();

--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -57,6 +57,9 @@ final class SymfonyInstrumentation
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->headers->get('Content-Length'))
                         ->setAttribute(TraceAttributes::URL_SCHEME, $request->getScheme())
                         ->setAttribute(TraceAttributes::URL_PATH, $request->getPathInfo())
+                        ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->headers->get('User-Agent'))
+                        ->setAttribute(TraceAttributes::SERVER_ADDRESS, $request->getHost())
+                        ->setAttribute(TraceAttributes::SERVER_PORT, $request->getPort())
                         ->startSpan();
                     $request->attributes->set(SpanInterface::class, $span);
                 } else {

--- a/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
+++ b/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
@@ -88,6 +88,8 @@ class WordpressInstrumentation
                     ->setParent($parent)
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::URL_FULL, (string) $request->getUri())
+                    ->setAttribute(TraceAttributes::URL_SCHEME, $request->getUri()->getScheme())
+                    ->setAttribute(TraceAttributes::URL_PATH, $request->getUri()->getPath())
                     ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
                     ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $request->getProtocolVersion())
                     ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->getHeaderLine('User-Agent'))


### PR DESCRIPTION
After the semantic convention was stabilized in [v1.23](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#http-server), I added some missing attributes.
I noticed that some automatic instrumentation already had it, but other instrumentation was missing.