### PR TITLE
fixing running phpt tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -94,7 +94,7 @@ jobs:
       working-directory: src/${{ matrix.project }}
       run: |
         composer config --no-plugins allow-plugins.php-http/discovery false
-        composer install --prefer-dist --no-progress --no-suggest
+        composer install --prefer-dist --no-progress
 
     - name: Validate Packages composer.json
       working-directory: src/${{ matrix.project }}
@@ -128,7 +128,11 @@ jobs:
 
     - name: Run PHPUnit
       working-directory: src/${{ matrix.project }}
-      run: vendor/bin/phpunit --testsuite integration --testsuite unit --coverage-text --coverage-clover=coverage.clover
+      run: vendor/bin/phpunit
+
+    - name: Run PHPUnit (coverage)
+      working-directory: src/${{ matrix.project }}
+      run: vendor/bin/phpunit --testsuite integration,unit --coverage-text --coverage-clover=coverage.clover
 
     - name: Code Coverage
       working-directory: src/${{ matrix.project }}

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ install: ## Install dependencies
 	$(DC_RUN_PHP) env XDEBUG_MODE=off composer install
 update: ## Update dependencies
 	$(DC_RUN_PHP) env XDEBUG_MODE=off composer update
-test: test-unit test-integration ## Run unit and integration tests
+test: ## Run all tests
+	$(DC_RUN_PHP) env XDEBUG_MODE=off vendor/bin/phpunit --testdox --colors=always
 test-unit: ## Run unit tests
 	$(DC_RUN_PHP) env XDEBUG_MODE=coverage vendor/bin/phpunit --testsuite unit --colors=always --coverage-text --testdox --coverage-clover coverage.clover --coverage-html=tests/coverage/html
 test-integration: ## Run integration tests

--- a/src/Instrumentation/Psr3/phpunit.xml.dist
+++ b/src/Instrumentation/Psr3/phpunit.xml.dist
@@ -41,6 +41,8 @@
         </testsuite>
         <testsuite name="integration">
             <directory>tests/Integration</directory>
+        </testsuite>
+        <testsuite name="phpt">
             <directory suffix=".phpt">tests/phpt</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
trying to generate code coverage for phpt tests breaks the tests, so move them out of "integration" and into their own suite. Introduce a full non-coverage test suite run, and only generate coverage off unit and integration as we did previously.