### PR TITLE
Rename the span name of Laravel HTTP requests to include the low cardinality route name if possible.

### DIFF
--- a/src/Instrumentation/Laravel/src/HttpInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/HttpInstrumentation.php
@@ -87,6 +87,7 @@ class HttpInstrumentation
                         $route = '/' . $route;
                     }
 
+                    /** @psalm-suppress ArgumentTypeCoercion */
                     $span->updateName(sprintf('%s %s', $request?->method() ?? 'unknown', $route));
                 }
 

--- a/src/Instrumentation/Laravel/src/HttpInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/HttpInstrumentation.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Contrib\Instrumentation\Laravel;
 
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Trace\Span;
@@ -78,6 +79,10 @@ class HttpInstrumentation
                     $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode());
                     $span->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $response->getProtocolVersion());
                     $span->setAttribute(TraceAttributes::HTTP_RESPONSE_BODY_SIZE, $response->headers->get('Content-Length'));
+                }
+                if(($route = Route::getCurrentRoute()?->uri()) !== null) {
+                    $request = ($params[0] instanceof Request) ? $params[0] : null;
+                    $span->updateName(sprintf('%s %s', $request?->method() ?? 'unknown', $route));
                 }
 
                 $span->end();

--- a/src/Instrumentation/Laravel/src/HttpInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/HttpInstrumentation.php
@@ -82,6 +82,11 @@ class HttpInstrumentation
                 }
                 if(($route = Route::getCurrentRoute()?->uri()) !== null) {
                     $request = ($params[0] instanceof Request) ? $params[0] : null;
+
+                    if (! str_starts_with($route, '/')) {
+                        $route = '/' . $route;
+                    }
+
                     $span->updateName(sprintf('%s %s', $request?->method() ?? 'unknown', $route));
                 }
 

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -47,7 +47,7 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertEquals(200, $response->status());
         $this->assertCount(2, $this->storage);
         $span = $this->storage[1];
-        $this->assertSame('GET hello', $span->getName());
+        $this->assertSame('GET /hello', $span->getName());
         $this->assertSame('http://localhost/hello', $span->getAttributes()->get(TraceAttributes::URL_FULL));
         $this->assertCount(5, $span->getEvents());
         $this->assertSame('cache set', $span->getEvents()[0]->getName());
@@ -73,7 +73,17 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertEquals(200, $response->status());
         $this->assertCount(1, $this->storage);
         $span = $this->storage[0];
-        $this->assertSame('GET hello/{name}', $span->getName());
+        $this->assertSame('GET /hello/{name}', $span->getName());
+    }
+
+    public function test_route_span_name_if_not_found(): void
+    {
+        $this->assertCount(0, $this->storage);
+        $response = $this->call('GET', '/not-found');
+        $this->assertEquals(404, $response->status());
+        $this->assertCount(1, $this->storage);
+        $span = $this->storage[0];
+        $this->assertSame('GET', $span->getName());
     }
     private function router(): Router
     {

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -66,7 +66,7 @@ class LaravelInstrumentationTest extends TestCase
 
     public function test_low_cardinality_route_span_name(): void
     {
-        $this->router()->get('/hello/{name}', fn () => null);
+        $this->router()->get('/hello/{name}', fn () => null)->name('hello-name');
 
         $this->assertCount(0, $this->storage);
         $response = $this->call('GET', '/hello/opentelemetry');
@@ -85,6 +85,7 @@ class LaravelInstrumentationTest extends TestCase
         $span = $this->storage[0];
         $this->assertSame('GET', $span->getName());
     }
+
     private function router(): Router
     {
         /** @psalm-suppress PossiblyNullReference */


### PR DESCRIPTION
This renames the span name created around a request in Laravel to include the low cardinality route name if possible.

For example, the route registered as `Route::get('/user/{userId}` when requested with `GET /user/123` would previously result in a span.name of `GET`, where it will now show as `GET /user/{userId}`.

This is to follow the spec presented in the OpenTelemetry docs: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#:~:text=HTTP%20server%20span%20names%20SHOULD%20be%20%7Bmethod%7D%20%7Bhttp.route%7D%20if%20there%20is%20a%20(low%2Dcardinality)%20http.route%20available%20(see%20below%20for%20the%20exact%20definition%20of%20the%20%7Bmethod%7D%20placeholder).