### PR TITLE
Use normal version instead of beta version constraint

### DIFF
--- a/src/Aws/composer.json
+++ b/src/Aws/composer.json
@@ -14,7 +14,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4 || ^8.0",
-        "open-telemetry/api": "^1.0.0beta10",
+        "open-telemetry/api": "^1.0",
         "open-telemetry/sdk": "^1.0",
         "aws/aws-sdk-php": "^3.232"
     },

--- a/src/Instrumentation/CodeIgniter/composer.json
+++ b/src/Instrumentation/CodeIgniter/composer.json
@@ -11,7 +11,7 @@
       "php": "^8.0",
       "ext-opentelemetry": "*",
       "codeigniter4/framework": ">=4.0",
-      "open-telemetry/api": "^1.0.0beta10",
+      "open-telemetry/api": "^1.0",
       "open-telemetry/sem-conv": "^1.22"
     },
     "require-dev": {

--- a/src/Instrumentation/HttpAsyncClient/composer.json
+++ b/src/Instrumentation/HttpAsyncClient/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": "^8.0",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1.0.0beta10",
+    "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.22",
     "php-http/httplug": "^2"
   },

--- a/src/Instrumentation/IO/composer.json
+++ b/src/Instrumentation/IO/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "^8.2",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1.0.0beta10",
+    "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.22"
   },
   "require-dev": {

--- a/src/Instrumentation/PDO/composer.json
+++ b/src/Instrumentation/PDO/composer.json
@@ -11,7 +11,7 @@
     "php": "^8.2",
     "ext-pdo": "*",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1.0.0beta10",
+    "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.22"
   },
   "require-dev": {

--- a/src/Instrumentation/Psr15/composer.json
+++ b/src/Instrumentation/Psr15/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": "^8.0",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1.0.0beta10",
+    "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.22",
     "psr/http-server-middleware": "^1"
   },

--- a/src/Instrumentation/Psr18/composer.json
+++ b/src/Instrumentation/Psr18/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": "^8.0",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1.0.0beta10",
+    "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.22",
     "psr/http-client": "^1"
   },

--- a/src/Instrumentation/Slim/composer.json
+++ b/src/Instrumentation/Slim/composer.json
@@ -12,7 +12,7 @@
     "php": "^8.0",
     "ext-opentelemetry": "*",
     "ext-reflection": "*",
-    "open-telemetry/api": "^1.0.0beta10",
+    "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.22",
     "slim/slim": "^4"
   },

--- a/src/Instrumentation/Symfony/composer.json
+++ b/src/Instrumentation/Symfony/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "^8.0",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1.0.0beta10",
+    "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.22",
     "symfony/http-kernel": "*",
     "symfony/http-client-contracts": "*"

--- a/src/Instrumentation/Wordpress/composer.json
+++ b/src/Instrumentation/Wordpress/composer.json
@@ -10,7 +10,7 @@
   "require": {
     "php": "^8.0",
     "ext-opentelemetry": "*",
-    "open-telemetry/api": "^1.0.0beta10",
+    "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.22",
     "nyholm/psr7": "^1",
     "nyholm/psr7-server": "^1"


### PR DESCRIPTION
Noted in https://github.com/open-telemetry/opentelemetry-php-contrib/pull/222 and asked to create a separate PR 