### PR TITLE
[auto-ext-amqp] Require correct version for composer runtime package

### DIFF
--- a/src/Instrumentation/ExtAmqp/composer.json
+++ b/src/Instrumentation/ExtAmqp/composer.json
@@ -9,7 +9,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": "^8.2",
-    "composer-runtime-api": "*",
+    "composer-runtime-api": "^2.0",
     "ext-amqp": "*",
     "ext-opentelemetry": "*",
     "open-telemetry/api": "^1",


### PR DESCRIPTION
This is required to access `\Composer\InstalledVersions::getVersion()` method. Docblock also clearly states this:
```php
<?php

namespace Composer;

use Composer\Autoload\ClassLoader;
use Composer\Semver\VersionParser;

/**
 * This class is copied in every Composer installed project and available to all
 *
 * See also https://getcomposer.org/doc/07-runtime.md#installed-versions
 *
 * To require its presence, you can require `composer-runtime-api ^2.0`
 *
 * @final
 */
class InstalledVersions 
{ 
    // ...
}
```

Noted in https://github.com/open-telemetry/opentelemetry-php-contrib/pull/222#discussion_r1423779364 