### PR TITLE
TraceResponse and ServerTiming response propagation for CodeIgniter, Yii, Laravel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@ composer.lock
 var
 vendor
 .idea/
+.vscode/
 coverage.clover
 **/tests/coverage
+**/tests/runtime/cache
 .php_cs.cache
 phpunit.xml
 psalm.xml

--- a/src/Instrumentation/CodeIgniter/src/CodeIgniterInstrumentation.php
+++ b/src/Instrumentation/CodeIgniter/src/CodeIgniterInstrumentation.php
@@ -116,6 +116,14 @@ class CodeIgniterInstrumentation
                         $span->setStatus(StatusCode::STATUS_ERROR);
                     }
 
+                    // Propagate server-timing header to response, if ServerTimingPropagator is present
+                    if (class_exists('OpenTelemetry\Contrib\Propagation\ServerTiming\ServerTimingPropagator')) {
+                        /** @phan-suppress-next-line PhanUndeclaredClassMethod */
+                        $prop = new \OpenTelemetry\Contrib\Propagation\ServerTiming\ServerTimingPropagator();
+                        /** @phan-suppress-next-line PhanUndeclaredClassMethod */
+                        $prop->inject($response, ResponsePropagationSetter::instance(), $scope->context());
+                    }
+
                     // Propagate traceresponse header to response, if TraceResponsePropagator is present
                     if (class_exists('OpenTelemetry\Contrib\Propagation\TraceResponse\TraceResponsePropagator')) {
                         /** @phan-suppress-next-line PhanUndeclaredClassMethod */

--- a/src/Instrumentation/Laravel/src/HttpInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/HttpInstrumentation.php
@@ -79,6 +79,22 @@ class HttpInstrumentation
                     $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode());
                     $span->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $response->getProtocolVersion());
                     $span->setAttribute(TraceAttributes::HTTP_RESPONSE_BODY_SIZE, $response->headers->get('Content-Length'));
+
+                    // Propagate server-timing header to response, if ServerTimingPropagator is present
+                    if (class_exists('OpenTelemetry\Contrib\Propagation\ServerTiming\ServerTimingPropagator')) {
+                        /** @phan-suppress-next-line PhanUndeclaredClassMethod */
+                        $prop = new \OpenTelemetry\Contrib\Propagation\ServerTiming\ServerTimingPropagator();
+                        /** @phan-suppress-next-line PhanUndeclaredClassMethod */
+                        $prop->inject($response, ResponsePropagationSetter::instance(), $scope->context());
+                    }
+
+                    // Propagate traceresponse header to response, if TraceResponsePropagator is present
+                    if (class_exists('OpenTelemetry\Contrib\Propagation\TraceResponse\TraceResponsePropagator')) {
+                        /** @phan-suppress-next-line PhanUndeclaredClassMethod */
+                        $prop = new \OpenTelemetry\Contrib\Propagation\TraceResponse\TraceResponsePropagator();
+                        /** @phan-suppress-next-line PhanUndeclaredClassMethod */
+                        $prop->inject($response, ResponsePropagationSetter::instance(), $scope->context());
+                    }
                 }
                 if(($route = Route::getCurrentRoute()?->uri()) !== null) {
                     $request = ($params[0] instanceof Request) ? $params[0] : null;

--- a/src/Instrumentation/Laravel/src/ResponsePropagationSetter.php
+++ b/src/Instrumentation/Laravel/src/ResponsePropagationSetter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel;
+
+use function assert;
+use Illuminate\Http\Response;
+use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
+
+/**
+ * @internal
+ */
+class ResponsePropagationSetter implements PropagationSetterInterface
+{
+    public static function instance(): self
+    {
+        static $instance;
+
+        return $instance ??= new self();
+    }
+
+    public function set(&$carrier, string $key, string $value): void
+    {
+        assert($carrier instanceof Response);
+
+        $carrier->headers->set($key, $value);
+    }
+}

--- a/src/Instrumentation/Yii/src/YiiInstrumentation.php
+++ b/src/Instrumentation/Yii/src/YiiInstrumentation.php
@@ -90,6 +90,14 @@ class YiiInstrumentation
                         $span->setStatus(StatusCode::STATUS_ERROR);
                     }
 
+                    // Propagate server-timing header to response, if ServerTimingPropagator is present
+                    if (class_exists('OpenTelemetry\Contrib\Propagation\ServerTiming\ServerTimingPropagator')) {
+                        /** @phan-suppress-next-line PhanUndeclaredClassMethod */
+                        $prop = new \OpenTelemetry\Contrib\Propagation\ServerTiming\ServerTimingPropagator();
+                        /** @phan-suppress-next-line PhanUndeclaredClassMethod */
+                        $prop->inject($response, ResponsePropagationSetter::instance(), $scope->context());
+                    }
+
                     // Propagate traceresponse header to response, if TraceResponsePropagator is present
                     if (class_exists('OpenTelemetry\Contrib\Propagation\TraceResponse\TraceResponsePropagator')) {
                         /** @phan-suppress-next-line PhanUndeclaredClassMethod */


### PR DESCRIPTION
There are 2 response propagators which include a W3C TraceParent formatted tracing context info: TraceResponse and ServerTiming. The latter is necessary for RUM integration since frontend JS can read the value from ServerTiming, and the former is the more standardized method, but unsuitable for RUM until browsers add it to the list of headers that can be read from JS.

Previous state:
* Symfony already had both
* CodeIgniter and Yii only had `TraceResponse`
* Laravel had neither

Added the missing ones to make sure both are present for Symfony, Laravel, CodeIgniter and Yii. PSR-15 and consequently Slim have a method for setting headers that isn't trivially compatible with `PropagationSetterInterface` (as response is modified by `$response = $response->withX(...)` pattern), so it is not included here.

As integration tests are not applicable for testing that the headers actually get set, tested this manually for each of them.

The code duplication for each framework for this purpose is not ideal, so at some point we should think of ways to fix that, but it is not in the scope for this PR.