### PR TITLE
Add missing cloud.platform in AWS EC2 detector

### DIFF
--- a/src/Aws/src/Ec2/Detector.php
+++ b/src/Aws/src/Ec2/Detector.php
@@ -45,6 +45,7 @@ class Detector implements ResourceDetectorInterface
     private const AWS_METADATA_TTL_HEADER = 'X-aws-ec2-metadata-token-ttl-seconds';
     private const AWS_METADATA_TOKEN_HEADER = 'X-aws-ec2-metadata-token';
     private const CLOUD_PROVIDER = 'aws';
+    private const CLOUD_PLATFORM = 'aws_ec2';
 
     private ClientInterface $client;
     private RequestFactoryInterface $requestFactory;
@@ -112,6 +113,7 @@ class Detector implements ResourceDetectorInterface
 
             $attributes[ResourceAttributes::HOST_NAME] = $hostName;
             $attributes[ResourceAttributes::CLOUD_PROVIDER] = self::CLOUD_PROVIDER;
+            $attributes[ResourceAttributes::CLOUD_PLATFORM] = self::CLOUD_PLATFORM;
 
             return ResourceInfo::create(Attributes::create($attributes), ResourceAttributes::SCHEMA_URL);
         } catch (\Throwable $e) {

--- a/src/Aws/tests/Unit/Ec2/DetectorTest.php
+++ b/src/Aws/tests/Unit/Ec2/DetectorTest.php
@@ -42,6 +42,7 @@ class DetectorTest extends TestCase
     private const CLOUD_ACCOUNT_ID = 'my-account-id';
     private const CLOUD_REGION = 'my-region';
     private const CLOUD_PROVIDER = 'aws';
+    private const CLOUD_PLATFORM = 'aws_ec2';
 
     /**
      * @test
@@ -74,6 +75,7 @@ class DetectorTest extends TestCase
                     ResourceAttributes::CLOUD_REGION => self::CLOUD_REGION,
                     ResourceAttributes::HOST_NAME => self::MOCK_HOSTNAME,
                     ResourceAttributes::CLOUD_PROVIDER => self::CLOUD_PROVIDER,
+                    ResourceAttributes::CLOUD_PLATFORM => self::CLOUD_PLATFORM,
                 ]
             ),
             $detector->getResource()->getAttributes()
@@ -156,6 +158,7 @@ class DetectorTest extends TestCase
                     ResourceAttributes::CLOUD_ACCOUNT_ID => self::CLOUD_ACCOUNT_ID,
                     ResourceAttributes::CLOUD_REGION => self::CLOUD_REGION,
                     ResourceAttributes::CLOUD_PROVIDER => self::CLOUD_PROVIDER,
+                    ResourceAttributes::CLOUD_PLATFORM => self::CLOUD_PLATFORM,
                 ]
             ),
             $detector->getResource()->getAttributes()
@@ -214,6 +217,7 @@ class DetectorTest extends TestCase
                     ResourceAttributes::HOST_IMAGE_ID => self::HOST_IMAGE_ID,
                     ResourceAttributes::HOST_NAME => self::MOCK_HOSTNAME,
                     ResourceAttributes::CLOUD_PROVIDER => self::CLOUD_PROVIDER,
+                    ResourceAttributes::CLOUD_PLATFORM => self::CLOUD_PLATFORM,
                 ]
             ),
             $detector->getResource()->getAttributes()


### PR DESCRIPTION
For consistency with other EC2 detectors, this commit adds the `cloud.platform` resource attribute with value `aws_ec2`.