### PR TITLE
AWS ECS detector: add support for cloud.{account.id,availability_zone,region}

### DIFF
--- a/src/Aws/src/Ecs/Detector.php
+++ b/src/Aws/src/Ecs/Detector.php
@@ -198,7 +198,7 @@ class Detector implements ResourceDetectorInterface
             }
 
             $arnParts = explode(':', $taskArn);
-            if len($arnParts) > 5 {
+            if (count($arnParts) > 5) {
                 $cloudResource = $cloudResource->merge(ResourceInfo::create(Attributes::create([
                     ResourceAttributes::CLOUD_ACCOUNT_ID => $arnParts[4],
                     ResourceAttributes::CLOUD_REGION => $arnParts[3],

--- a/src/Aws/src/Ecs/Detector.php
+++ b/src/Aws/src/Ecs/Detector.php
@@ -72,6 +72,9 @@ class Detector implements ResourceDetectorInterface
      * If running on ECS with an ECS agent v1.4, the returned resource has additionally the following
      * attributes as specified in https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/cloud_provider/aws/ecs/:
      *
+     * - cloud.account.id => <account_id> , e.g., '111122223333'
+     * - cloud.availability_zone => <availability_zone> , e.g., 'us-east-1a'
+     * - cloud.region => <availability_zone> , e.g., 'us-east-1'
      * - aws.ecs.container.arn
      * - aws.ecs.cluster.arn
      * - aws.ecs.launchtype
@@ -178,6 +181,13 @@ class Detector implements ResourceDetectorInterface
 
         $clusterArn = null;
         $taskArn = null;
+
+        $cloudResource = isset($taskMetadata['AvailabilityZone'])
+            ? ResourceInfo::create(Attributes::create([
+                ResourceAttributes::CLOUD_AVAILABILITY_ZONE => $taskMetadata['AvailabilityZone'],
+            ]))
+            : ResourceInfo::emptyResource();
+
         if (isset($taskMetadata['Cluster']) && isset($taskMetadata['TaskARN'])) {
             $taskArn = $taskMetadata['TaskARN'];
             $lastIndexOfColon = strrpos($taskArn, ':');
@@ -185,6 +195,14 @@ class Detector implements ResourceDetectorInterface
                 $baseArn = substr($taskArn, 0, $lastIndexOfColon);
                 $cluster = $taskMetadata['Cluster'];
                 $clusterArn = strpos($cluster, 'arn:') === 0 ? $cluster : $baseArn . ':cluster/' . $cluster;
+            }
+
+            $arnParts = explode(':', $taskArn);
+            if len($arnParts) > 5 {
+                $cloudResource = $cloudResource->merge(ResourceInfo::create(Attributes::create([
+                    ResourceAttributes::CLOUD_ACCOUNT_ID => $arnParts[4],
+                    ResourceAttributes::CLOUD_REGION => $arnParts[3],
+                ])));
             }
         }
 
@@ -222,6 +240,6 @@ class Detector implements ResourceDetectorInterface
             ResourceAttributes::AWS_ECS_TASK_REVISION => $taskRevision,
         ]));
 
-        return $ecsResource->merge($logResource);
+        return $ecsResource->merge($cloudResource)->merge($logResource);
     }
 }

--- a/src/Aws/tests/Unit/Ecs/DetectorTest.php
+++ b/src/Aws/tests/Unit/Ecs/DetectorTest.php
@@ -323,6 +323,9 @@ class DetectorTest extends TestCase
                 [
                     ResourceAttributes::CLOUD_PROVIDER => self::CLOUD_PROVIDER,
                     ResourceAttributes::CLOUD_PLATFORM => self::CLOUD_PLATFORM,
+                    ResourceAttributes::CLOUD_ACCOUNT_ID => '111122223333',
+                    ResourceAttributes::CLOUD_AVAILABILITY_ZONE => 'us-west-2d',
+                    ResourceAttributes::CLOUD_REGION => 'us-west-2',
                     ResourceAttributes::AWS_ECS_CONTAINER_ARN => 'arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9',
                     ResourceAttributes::AWS_ECS_CLUSTER_ARN => 'arn:aws:ecs:us-west-2:111122223333:cluster/default',
                     ResourceAttributes::AWS_ECS_LAUNCHTYPE => 'ec2',
@@ -366,6 +369,9 @@ class DetectorTest extends TestCase
                 [
                     ResourceAttributes::CLOUD_PROVIDER => self::CLOUD_PROVIDER,
                     ResourceAttributes::CLOUD_PLATFORM => self::CLOUD_PLATFORM,
+                    ResourceAttributes::CLOUD_ACCOUNT_ID => '111122223333',
+                    ResourceAttributes::CLOUD_AVAILABILITY_ZONE => 'us-west-2a',
+                    ResourceAttributes::CLOUD_REGION => 'us-west-2',
                     ResourceAttributes::AWS_ECS_CONTAINER_ARN => 'arn:aws:ecs:us-west-2:111122223333:container/05966557-f16c-49cb-9352-24b3a0dcd0e1',
                     ResourceAttributes::AWS_ECS_CLUSTER_ARN => 'arn:aws:ecs:us-west-2:111122223333:cluster/default',
                     ResourceAttributes::AWS_ECS_LAUNCHTYPE => 'fargate',
@@ -409,6 +415,9 @@ class DetectorTest extends TestCase
                 [
                     ResourceAttributes::CLOUD_PROVIDER => self::CLOUD_PROVIDER,
                     ResourceAttributes::CLOUD_PLATFORM => self::CLOUD_PLATFORM,
+                    ResourceAttributes::CLOUD_ACCOUNT_ID => '111122223333',
+                    ResourceAttributes::CLOUD_AVAILABILITY_ZONE => 'us-west-2a',
+                    ResourceAttributes::CLOUD_REGION => 'us-west-2',
                     ResourceAttributes::AWS_ECS_CONTAINER_ARN => 'arn:aws:ecs:us-west-2:111122223333:container/05966557-f16c-49cb-9352-24b3a0dcd0e1',
                     ResourceAttributes::AWS_ECS_CLUSTER_ARN => 'arn:aws:ecs:us-west-2:111122223333:cluster/default',
                     ResourceAttributes::AWS_ECS_LAUNCHTYPE => 'fargate',


### PR DESCRIPTION
Add support for cloud.{account.id,availability_zone,region} when using the AWS ECS detector with v4 metadata