### PR TITLE
Exclude ApiPlatform test HttpClient from instrumentation

### DIFF
--- a/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
@@ -23,7 +23,7 @@ final class HttpClientInstrumentation
      */
     const NON_SUPPORTED_CLIENTS = [
         /** @psalm-suppress UndefinedClass */
-        \ApiPlatform\Symfony\Bundle\Test\Client::class,
+        '\ApiPlatform\Symfony\Bundle\Test\Client',
     ];
 
     public static function isSupportedImplementation(string $class): bool

--- a/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
@@ -28,7 +28,7 @@ final class HttpClientInstrumentation
 
     public static function isSupportedImplementation(string $class): bool
     {
-        return in_array($class, self::NON_SUPPORTED_CLIENTS);
+        return false === in_array($class, self::NON_SUPPORTED_CLIENTS);
     }
 
     public static function register(): void

--- a/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
@@ -33,6 +33,7 @@ final class HttpClientInstrumentation
                 ?string $filename,
                 ?int $lineno,
             ) use ($instrumentation): array {
+                /** @psalm-suppress UndefinedClass */
                 if (class_exists("\ApiPlatform\Symfony\Bundle\Test\Client") && $client instanceof \ApiPlatform\Symfony\Bundle\Test\Client) {
                     return $params;
                 }

--- a/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
@@ -34,7 +34,7 @@ final class HttpClientInstrumentation
                 ?int $lineno,
             ) use ($instrumentation): array {
                 /** @psalm-suppress UndefinedClass */
-                if (class_exists("\ApiPlatform\Symfony\Bundle\Test\Client") && $client instanceof \ApiPlatform\Symfony\Bundle\Test\Client) {
+                if ($client instanceof \ApiPlatform\Symfony\Bundle\Test\Client) {
                     return $params;
                 }
                 

--- a/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
@@ -33,6 +33,10 @@ final class HttpClientInstrumentation
                 ?string $filename,
                 ?int $lineno,
             ) use ($instrumentation): array {
+                if (class_exists("\ApiPlatform\Symfony\Bundle\Test\Client") && $client instanceof \ApiPlatform\Symfony\Bundle\Test\Client) {
+                    return $params;
+                }
+                
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation
                     ->tracer()

--- a/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
@@ -20,10 +20,9 @@ final class HttpClientInstrumentation
 {
     /**
      * These clients are not supported by this instrumentation.
-     *
-     * @psalm-suppress UndefinedClass
      */
     const NON_SUPPORTED_CLIENTS = [
+        /** @psalm-suppress UndefinedClass */
         \ApiPlatform\Symfony\Bundle\Test\Client::class,
     ];
 


### PR DESCRIPTION
The client doesn't support the `on_progress` option and makes tests fail that use the ApiPlatform test client

Longer term we should probably maintain a blacklist or level up this instrumentation significantly so we know the allowed options