### PR TITLE
Avoid creating many server spans

### DIFF
--- a/src/Instrumentation/Psr15/src/Psr15Instrumentation.php
+++ b/src/Instrumentation/Psr15/src/Psr15Instrumentation.php
@@ -100,7 +100,7 @@ class Psr15Instrumentation
                         ->startSpan();
                     $request = $request->withAttribute(SpanInterface::class, $span);
                 } else {
-                    $span = $builder->startSpan();
+                    $span = $builder->setSpanKind(SpanKind::KIND_INTERNAL)->startSpan();
                 }
                 Context::storage()->attach($span->storeInContext($parent));
 


### PR DESCRIPTION
When root span is already present, avoid creating additional kind=server ones.

This is a problem with nested request handlers.

Instead recognize the existing one and mark child spans created for request handlers as internal