### PR TITLE
Fix PSR-3 module description, standardize other PSR descriptions

### DIFF
--- a/src/Instrumentation/Psr14/composer.json
+++ b/src/Instrumentation/Psr14/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "open-telemetry/opentelemetry-auto-psr14",
-  "description": "OpenTelemetry auto-instrumentation for PSR-14 (EventDispatcher).",
+  "description": "OpenTelemetry auto-instrumentation for PSR-14 (Event Dispatcher).",
   "keywords": ["opentelemetry", "otel", "open-telemetry", "tracing", "psr14", "instrumentation", "EventDispatcher"],
   "type": "library",
   "homepage": "https://opentelemetry.io/docs/php",

--- a/src/Instrumentation/Psr15/composer.json
+++ b/src/Instrumentation/Psr15/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "open-telemetry/opentelemetry-auto-psr15",
-  "description": "OpenTelemetry auto-instrumentation for psr15 middleware.",
+  "description": "OpenTelemetry auto-instrumentation for PSR-15 (HTTP Server Request Handlers).",
   "keywords": ["opentelemetry", "otel", "open-telemetry", "tracing", "psr15", "instrumentation"],
   "type": "library",
   "homepage": "https://opentelemetry.io/docs/php",

--- a/src/Instrumentation/Psr18/composer.json
+++ b/src/Instrumentation/Psr18/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "open-telemetry/opentelemetry-auto-psr18",
-  "description": "OpenTelemetry auto-instrumentation for psr18 http clients.",
+  "description": "OpenTelemetry auto-instrumentation for PSR-18 (HTTP Client).",
   "keywords": ["opentelemetry", "otel", "open-telemetry", "tracing", "psr18", "instrumentation"],
   "type": "library",
   "homepage": "https://opentelemetry.io/docs/php",

--- a/src/Instrumentation/Psr3/composer.json
+++ b/src/Instrumentation/Psr3/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "open-telemetry/opentelemetry-auto-psr3",
-  "description": "OpenTelemetry auto-instrumentation for psr3 http clients.",
+  "description": "OpenTelemetry auto-instrumentation for PSR-3 (Logger Interface).",
   "keywords": [
     "opentelemetry",
     "otel",


### PR DESCRIPTION
PSR-3 module description was incorrectly describing it as HTTP client rather than logging instrumentation. Changed all PSR module descriptions to use the format `PSR-<number> (<official_name>)` based on the name used on PHP-FIG site.