### PR TITLE
Extract response headers as attributes for Guzzle, HTTPlug Async

### DIFF
--- a/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php
+++ b/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php
@@ -100,6 +100,13 @@ class GuzzleInstrumentation
                         $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode());
                         $span->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $response->getProtocolVersion());
                         $span->setAttribute(TraceAttributes::HTTP_RESPONSE_BODY_SIZE, $response->getHeaderLine('Content-Length'));
+
+                        foreach ((array) (get_cfg_var('otel.instrumentation.http.response_headers') ?: []) as $header) {
+                            if ($response->hasHeader($header)) {
+                                /** @psalm-suppress ArgumentTypeCoercion */
+                                $span->setAttribute(sprintf('http.response.header.%s', strtolower($header)), $response->getHeader($header));
+                            }
+                        }
                         if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {
                             $span->setStatus(StatusCode::STATUS_ERROR);
                         }

--- a/src/Instrumentation/HttpAsyncClient/src/HttpAsyncClientInstrumentation.php
+++ b/src/Instrumentation/HttpAsyncClient/src/HttpAsyncClientInstrumentation.php
@@ -99,6 +99,13 @@ class HttpAsyncClientInstrumentation
                         $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode());
                         $span->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $response->getProtocolVersion());
                         $span->setAttribute(TraceAttributes::HTTP_RESPONSE_BODY_SIZE, $response->getHeaderLine('Content-Length'));
+
+                        foreach ((array) (get_cfg_var('otel.instrumentation.http.response_headers') ?: []) as $header) {
+                            if ($response->hasHeader($header)) {
+                                /** @psalm-suppress ArgumentTypeCoercion */
+                                $span->setAttribute(sprintf('http.response.header.%s', strtolower($header)), $response->getHeader($header));
+                            }
+                        }
                         if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {
                             $span->setStatus(StatusCode::STATUS_ERROR);
                         }


### PR DESCRIPTION
Extracting response headers as span attributes based on an INI option was supported on PSR-18, but not on Guzzle and HTTPlug Async. Both of these use PSR HTTP interfaces, so the code for these is identical to that of PSR-18.