### PR TITLE
Avoid supplying integer to function expecting string if status code is not in array.

### DIFF
--- a/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
@@ -110,7 +110,7 @@ class ClientRequestWatcher extends Watcher
 
         $span->setStatus(
             StatusCode::STATUS_ERROR,
-            HttpResponse::$statusTexts[$response->status()] ?? $response->status()
+            HttpResponse::$statusTexts[$response->status()] ?? (string) $response->status()
         );
     }
 }


### PR DESCRIPTION
This fixes https://github.com/open-telemetry/opentelemetry-php/issues/1238