### PR TITLE
Fix TraceResponse format to match specification

### DIFF
--- a/src/Propagation/ServerTiming/src/ServerTimingPropagator.php
+++ b/src/Propagation/ServerTiming/src/ServerTimingPropagator.php
@@ -17,8 +17,8 @@ use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
  */
 final class ServerTimingPropagator implements ResponsePropagator
 {
-    const IS_SAMPLED = '1';
-    const NOT_SAMPLED = '0';
+    const IS_SAMPLED = '01';
+    const NOT_SAMPLED = '00';
     const SUPPORTED_VERSION = '00';
     const SERVER_TIMING = 'server-timing';
     const TRACEPARENT = 'traceparent';

--- a/src/Propagation/ServerTiming/tests/Unit/PropagatorTest.php
+++ b/src/Propagation/ServerTiming/tests/Unit/PropagatorTest.php
@@ -19,8 +19,8 @@ class PropagatorTest extends TestCase
 {
     private const TRACE_ID = '5759e988bd862e3fe1be46a994272793';
     private const SPAN_ID = '53995c3f42cd8ad8';
-    private const TRACERESPONSE_HEADER_SAMPLED = '00-5759e988bd862e3fe1be46a994272793-53995c3f42cd8ad8-1';
-    private const TRACERESPONSE_HEADER_NOT_SAMPLED = '00-5759e988bd862e3fe1be46a994272793-53995c3f42cd8ad8-0';
+    private const TRACERESPONSE_HEADER_SAMPLED = '00-5759e988bd862e3fe1be46a994272793-53995c3f42cd8ad8-01';
+    private const TRACERESPONSE_HEADER_NOT_SAMPLED = '00-5759e988bd862e3fe1be46a994272793-53995c3f42cd8ad8-00';
 
     /**
      * @test

--- a/src/Propagation/TraceResponse/src/TraceResponsePropagator.php
+++ b/src/Propagation/TraceResponse/src/TraceResponsePropagator.php
@@ -17,8 +17,8 @@ use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
  */
 final class TraceResponsePropagator implements ResponsePropagator
 {
-    const IS_SAMPLED = '1';
-    const NOT_SAMPLED = '0';
+    const IS_SAMPLED = '01';
+    const NOT_SAMPLED = '00';
     const SUPPORTED_VERSION = '00';
     const TRACERESPONSE = 'traceresponse';
 

--- a/src/Propagation/TraceResponse/tests/Unit/PropagatorTest.php
+++ b/src/Propagation/TraceResponse/tests/Unit/PropagatorTest.php
@@ -19,8 +19,8 @@ class PropagatorTest extends TestCase
 {
     private const TRACE_ID = '5759e988bd862e3fe1be46a994272793';
     private const SPAN_ID = '53995c3f42cd8ad8';
-    private const TRACERESPONSE_HEADER_SAMPLED = '00-5759e988bd862e3fe1be46a994272793-53995c3f42cd8ad8-1';
-    private const TRACERESPONSE_HEADER_NOT_SAMPLED = '00-5759e988bd862e3fe1be46a994272793-53995c3f42cd8ad8-0';
+    private const TRACERESPONSE_HEADER_SAMPLED = '00-5759e988bd862e3fe1be46a994272793-53995c3f42cd8ad8-01';
+    private const TRACERESPONSE_HEADER_NOT_SAMPLED = '00-5759e988bd862e3fe1be46a994272793-53995c3f42cd8ad8-00';
 
     /**
      * @test


### PR DESCRIPTION
The [TraceResponse header specification](https://w3c.github.io/trace-context/#trace-context-http-response-headers-format) defines the following:
```
HEXDIGLC = DIGIT / "a" / "b" / "c" / "d" / "e" / "f"
value           = version "-" version-format
version-format   = trace-id "-" child-id "-" trace-flags
trace-flags      = 2HEXDIGLC
```
The document also specifies that it uses ABNF notation from [RFC5234](https://www.rfc-editor.org/rfc/rfc5234), where 3.7 defines `<n>element` to mean `exactly <n> occurrences of <element>`. Therefore `2HEXDIGLC` means exactly 2 hex digits.

Currently, the `trace-flags` are encoded with one digit - `0` or `1`, so changing them to follow the specification of using exactly 2 hex digits, thus `00` or `01`.

Also changing it in ServerTiming propagator as it is intended to use identical format to TraceResponse.