### PR TITLE
Add support for OpenSwoole 22.x

### DIFF
--- a/src/Context/Swoole/src/SwooleContextHandler.php
+++ b/src/Context/Swoole/src/SwooleContextHandler.php
@@ -41,7 +41,8 @@ final class SwooleContextHandler
     public function splitOffChildCoroutines(): void
     {
         $pcid = Coroutine::getCid();
-        foreach (Coroutine::listCoroutines() as $cid) {
+        $clist = method_exists(Coroutine::class, 'list') ? Coroutine::list() : Coroutine::listCoroutines();
+        foreach ($clist as $cid) {
             if ($pcid === Coroutine::getPcid($cid) && !$this->isForked($cid)) {
                 $this->forkCoroutine($cid);
             }


### PR DESCRIPTION
Coroutine::listCoroutines() has been removed in version 22.0.0 ([see the changelog](https://pecl.php.net/package-info.php?package=openswoole&version=22.0.0)):

> Remove deprecated function Coroutine::listCoroutines, use Coroutine::list

This seems to be the only change that prevents using the context with the latest Swoole version. Could you please have a look?