### PR TITLE
Laravel: disable CLI Console kernel tracing by default

### DIFF
--- a/src/Instrumentation/Laravel/src/ConsoleInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/ConsoleInstrumentation.php
@@ -11,8 +11,8 @@ use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\Context;
-use OpenTelemetry\SDK\Common\Configuration\Configuration;
 use function OpenTelemetry\Instrumentation\hook;
+use OpenTelemetry\SDK\Common\Configuration\Configuration;
 use OpenTelemetry\SemConv\TraceAttributes;
 use Throwable;
 

--- a/src/Instrumentation/Laravel/tests/Integration/ConsoleInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/ConsoleInstrumentationTest.php
@@ -27,14 +27,15 @@ class ConsoleInstrumentationTest extends TestCase
          *
          * @see \Illuminate\Foundation\Console\OptimizeClearCommand::handle() for the additional commands/spans.
          */
-        $count = 8;
-        $this->assertCount($count, $this->storage);
+        $this->assertCount(7, $this->storage);
 
-        $span = $this->storage[--$count];
-        $this->assertSame('Artisan handler', $span->getName());
-
-        $span = $this->storage[--$count];
-        $this->assertSame('Command optimize:clear', $span->getName());
+        $this->assertSame('Command event:clear', $this->storage[0]->getName());
+        $this->assertSame('Command view:clear', $this->storage[1]->getName());
+        $this->assertSame('Command cache:clear', $this->storage[2]->getName());
+        $this->assertSame('Command route:clear', $this->storage[3]->getName());
+        $this->assertSame('Command config:clear', $this->storage[4]->getName());
+        $this->assertSame('Command clear-compiled', $this->storage[5]->getName());
+        $this->assertSame('Command optimize:clear', $this->storage[6]->getName());
     }
 
     private function kernel(): Kernel


### PR DESCRIPTION
Tracing Console kernel in long-running CLI scripts is disabled by default but can be optionally enabled via `OTEL_PHP_TRACE_CLI_ENABLED`.

The difference can be seen here both with the CLI tracing disabled and then enabled via config:
![image](https://github.com/open-telemetry/opentelemetry-php-contrib/assets/106102472/d2f08b4b-7316-4062-82a3-ae99366ede0a)

Here's a GET request served via Octane (started via `artisan octane:start` command):
![image](https://github.com/open-telemetry/opentelemetry-php-contrib/assets/106102472/c930f252-d0f3-4ec3-8b1d-a21e7c7bdf37)
