### PR TITLE
Fix PHPStan+Slim and Psalm+MongoDB+PHP 8.3

### DIFF
--- a/src/Instrumentation/MongoDB/psalm.xml.dist
+++ b/src/Instrumentation/MongoDB/psalm.xml.dist
@@ -13,4 +13,7 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <issueHandlers>
+        <MissingClassConstType errorLevel="suppress" />
+    </issueHandlers>
 </psalm>

--- a/src/Instrumentation/Slim/phpstan.neon.dist
+++ b/src/Instrumentation/Slim/phpstan.neon.dist
@@ -10,5 +10,3 @@ parameters:
     excludePaths:
         analyseAndScan:
             - tests/Unit
-    ignoreErrors:
-        - '#Call to an undefined method Mockery\\LegacyMockInterface\:\:allows\(\)#'


### PR DESCRIPTION
Fixed an issue with Psalm for MongoDB + PHP 8.3. MongoDB is the only package running Psalm at error level 1, and recently a new `MissingClassConstType` issue was added to Psalm which gets triggered if error level is set to below 3. Since type declaration support for class constants were added in 8.3 and MongoDB package supports lower PHP versions, this issue cannot be fixed in code, so suppressing it via XML instead.

Fixed an issue with PHPStan for Slim. It had an ignore rule for a falsely detected error that no longer happens either due to fixes to the latest minor/patch versions of PHPStan itself or Mockery. Ignore rules that were not actually triggered caused CI failure, so removed that ignore rule.