### PR TITLE
Include schema_url in CachedInstrumentation

### DIFF
--- a/src/Instrumentation/Slim/src/SlimInstrumentation.php
+++ b/src/Instrumentation/Slim/src/SlimInstrumentation.php
@@ -29,7 +29,7 @@ class SlimInstrumentation
 
     public static function register(): void
     {
-        $instrumentation = new CachedInstrumentation('io.opentelemetry.contrib.php.slim');
+        $instrumentation = new CachedInstrumentation('io.opentelemetry.contrib.php.slim', schemaUrl: TraceAttributes::SCHEMA_URL);
         /**
          * requires extension >= 1.0.2beta2
          * @see https://github.com/open-telemetry/opentelemetry-php-instrumentation/pull/136


### PR DESCRIPTION
This change is in reference to https://github.com/open-telemetry/opentelemetry-php/issues/1290 and is in line with other Auto Instrumentation implementations.

https://github.com/open-telemetry/opentelemetry-php-contrib/blob/491827d0c93921669e657a37b071e3413bcbf4f5/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php#L31

https://github.com/open-telemetry/opentelemetry-php-contrib/blob/491827d0c93921669e657a37b071e3413bcbf4f5/src/Instrumentation/ExtAmqp/src/ExtAmqpInstrumentation.php#L27-L30

