### PR TITLE
link pdo prepare spans to execute + fetchAll spans

### DIFF
--- a/src/Instrumentation/PDO/composer.json
+++ b/src/Instrumentation/PDO/composer.json
@@ -7,6 +7,7 @@
   "readme": "./README.md",
   "license": "Apache-2.0",
   "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
     "php": "^8.2",
     "ext-pdo": "*",

--- a/src/Instrumentation/PDO/psalm.xml.dist
+++ b/src/Instrumentation/PDO/psalm.xml.dist
@@ -2,6 +2,8 @@
 <psalm
     errorLevel="3"
     cacheDirectory="var/cache/psalm"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">

--- a/src/Instrumentation/PDO/src/PDOTracker.php
+++ b/src/Instrumentation/PDO/src/PDOTracker.php
@@ -4,41 +4,51 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Contrib\Instrumentation\PDO;
 
+use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\SemConv\TraceAttributes;
+use PDO;
+use PDOStatement;
+use WeakMap;
+use WeakReference;
 
-final class PDOAttributeTracker
+final class PDOTracker
 {
     /**
-     * @var \WeakMap<\PDO, iterable<non-empty-string, bool|int|float|string|array|null>>
+     * @var WeakMap<PDO, iterable<non-empty-string, bool|int|float|string|array|null>>
      */
-    private \WeakMap $pdoToAttributesMap;
+    private WeakMap $pdoToAttributesMap;
     /**
-     * @var \WeakMap<\PDOStatement, \WeakReference<\PDO>>
+     * @var WeakMap<PDOStatement, WeakReference<PDO>>
      */
-    private \WeakMap $statementMapToPdoMap;
+    private WeakMap $statementMapToPdoMap;
+    private WeakMap $preparedStatementToSpanMap;
 
     public function __construct()
     {
         /** @psalm-suppress PropertyTypeCoercion */
-        $this->pdoToAttributesMap = new \WeakMap();
+        $this->pdoToAttributesMap = new WeakMap();
         /** @psalm-suppress PropertyTypeCoercion */
-        $this->statementMapToPdoMap = new \WeakMap();
+        $this->statementMapToPdoMap = new WeakMap();
+        $this->preparedStatementToSpanMap = new WeakMap();
     }
 
-    public function trackStatementToPdoMapping(\PDOStatement $statement, \PDO $pdo)
+    /**
+     * Maps a prepared statement to the PDO instance and the span context it was created in
+     */
+    public function trackStatement(PDOStatement $statement, PDO $pdo, SpanContextInterface $spanContext): void
     {
-        $this->statementMapToPdoMap[$statement] = \WeakReference::create($pdo);
+        $this->statementMapToPdoMap[$statement] = WeakReference::create($pdo);
+        $this->preparedStatementToSpanMap[$statement] = WeakReference::create($spanContext);
     }
 
     /**
      * Maps a statement back to the connection attributes.
      *
-     * @param \PDOStatement $statement
+     * @param PDOStatement $statement
      * @return iterable<non-empty-string, bool|int|float|string|array|null>
      */
-    public function trackedAttributesForStatement(\PDOStatement $statement): iterable
+    public function trackedAttributesForStatement(PDOStatement $statement): iterable
     {
-
         $pdo = ($this->statementMapToPdoMap[$statement] ?? null)?->get();
         if ($pdo === null) {
             return [];
@@ -48,18 +58,18 @@ final class PDOAttributeTracker
     }
 
     /**
-     * @param \PDO $pdo
+     * @param PDO $pdo
      * @return iterable<non-empty-string, bool|int|float|string|array|null>
      */
-    public function trackPdoAttributes(\PDO $pdo): iterable
+    public function trackPdoAttributes(PDO $pdo): iterable
     {
         $attributes = [];
 
         try {
-            $dbSystem = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
+            $dbSystem = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
             /** @psalm-suppress PossiblyInvalidArgument */
             $attributes[TraceAttributes::DB_SYSTEM] = self::mapDriverNameToAttribute($dbSystem);
-        } catch (\Error $e) {
+        } catch (\Error) {
             // if we catched an exception, the driver is likely not supporting the operation, default to "other"
             $attributes[TraceAttributes::DB_SYSTEM] = 'other_sql';
         }
@@ -67,9 +77,14 @@ final class PDOAttributeTracker
         return $this->pdoToAttributesMap[$pdo] = $attributes;
     }
 
-    public function trackedAttributesForPdo(\PDO $pdo)
+    public function trackedAttributesForPdo(PDO $pdo)
     {
         return $this->pdoToAttributesMap[$pdo] ?? [];
+    }
+
+    public function getSpanForPreparedStatement(PDOStatement $statement): ?SpanContextInterface
+    {
+        return ($this->preparedStatementToSpanMap[$statement] ?? null)?->get();
     }
 
     /**

--- a/src/Instrumentation/PDO/tests/Unit/PDOAttributeTrackerTest.php
+++ b/src/Instrumentation/PDO/tests/Unit/PDOAttributeTrackerTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Instrumentation\PDO\tests\Unit;
 
-use OpenTelemetry\Contrib\Instrumentation\PDO\PDOAttributeTracker;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\Contrib\Instrumentation\PDO\PDOTracker;
 use OpenTelemetry\SemConv\TraceAttributes;
 use PHPUnit\Framework\TestCase;
 
@@ -14,19 +15,21 @@ class PDOAttributeTrackerTest extends TestCase
     {
         $pdo = new \PDO('sqlite::memory:');
 
-        $objectMap = new PDOAttributeTracker();
+        $objectMap = new PDOTracker();
         $objectMap->trackPdoAttributes($pdo);
         $attributes = $objectMap->trackedAttributesForPdo($pdo);
+        $span = Span::getInvalid();
 
         $this->assertContains(TraceAttributes::DB_SYSTEM, array_keys($attributes));
 
         $stmt = $pdo->prepare('SELECT NULL LIMIT 0;');
-        $objectMap->trackStatementToPdoMapping($stmt, $pdo);
+        $objectMap->trackStatement($stmt, $pdo, $span->getContext());
         $attributes = $objectMap->trackedAttributesForStatement($stmt);
 
         /** @psalm-suppress InvalidArgument */
         $this->assertContains(TraceAttributes::DB_SYSTEM, array_keys($attributes));
         /** @psalm-suppress InvalidArrayAccess */
         $this->assertEquals('sqlite', $attributes[TraceAttributes::DB_SYSTEM]);
+        $this->assertSame($span->getContext(), $objectMap->getSpanForPreparedStatement($stmt));
     }
 }


### PR DESCRIPTION
- generalise PdoAttributeTracker to also track statements (and rename to suit)
- set all possible values on spans before starting them (per spec)
- import classes
- fix psalm config warnings
- prefer stable composer packages

Fixes: https://github.com/open-telemetry/opentelemetry-php/issues/1286
Fixes: https://github.com/open-telemetry/opentelemetry-php/issues/1285