### PR TITLE
[auto-psr6 & auto-psr16] Require composer runtime package

### DIFF
--- a/src/Instrumentation/Psr16/composer.json
+++ b/src/Instrumentation/Psr16/composer.json
@@ -13,7 +13,8 @@
     "ext-opentelemetry": "*",
     "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.23",
-    "psr/simple-cache": "^1 || ^2 || ^3"
+    "psr/simple-cache": "^1 || ^2 || ^3",
+    "composer-runtime-api": "^2.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",

--- a/src/Instrumentation/Psr16/src/Psr16Instrumentation.php
+++ b/src/Instrumentation/Psr16/src/Psr16Instrumentation.php
@@ -27,7 +27,8 @@ class Psr16Instrumentation
     {
         $instrumentation = new CachedInstrumentation(
             'io.opentelemetry.contrib.php.psr16',
-            InstalledVersions::getVersion('open-telemetry/opentelemetry-auto-psr16')
+            InstalledVersions::getVersion('open-telemetry/opentelemetry-auto-psr16'),
+            'https://opentelemetry.io/schemas/1.25.0',
         );
 
         $pre = static function (CacheInterface $cacheItem, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {

--- a/src/Instrumentation/Psr6/composer.json
+++ b/src/Instrumentation/Psr6/composer.json
@@ -13,7 +13,8 @@
     "ext-opentelemetry": "*",
     "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.23",
-    "psr/cache": "^1 || ^2 || ^3"
+    "psr/cache": "^1 || ^2 || ^3",
+    "composer-runtime-api": "^2.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",


### PR DESCRIPTION
This is required to access `\Composer\InstalledVersions::getVersion()`