### PR TITLE
fix: post hook invalid when symfony messenger sender throws exception

### DIFF
--- a/src/Instrumentation/Symfony/src/MessengerInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/MessengerInstrumentation.php
@@ -150,7 +150,7 @@ final class MessengerInstrumentation
             post: static function (
                 SenderInterface $sender,
                 array $params,
-                Envelope $result,
+                ?Envelope $result,
                 ?\Throwable $exception
             ): void {
                 $scope = Context::storage()->scope();


### PR DESCRIPTION
I still need to validate that this solves the problem but looking at the code this is the only thing that makes sense to me to solve it.

I’m opening this as a draft because we can’t submit issues, so while validating this if anyone else comes across it this may help them.

```
Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransport::send(): OpenTelemetry: post hook invalid signature, class=Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransport function=send
```