### PR TITLE
Adding JsonFormatter Support to Monolog Handler

### DIFF
--- a/src/Logs/Monolog/src/Handler.php
+++ b/src/Logs/Monolog/src/Handler.php
@@ -45,16 +45,15 @@ class Handler extends AbstractProcessingHandler
      */
     protected function write($record): void
     {
-        $formatted = $record['formatted'];
         $logRecord = (new API\LogRecord())
             ->setTimestamp((int) $record['datetime']->format('Uu') * 1000)
             ->setSeverityNumber(API\Map\Psr3::severityNumber($record['level_name']))
             ->setSeverityText($record['level_name'])
-            ->setBody($formatted['message'])
+            ->setBody($record['message'])
         ;
         foreach (['context', 'extra'] as $key) {
-            if (isset($formatted[$key]) && count($formatted[$key]) > 0) {
-                $logRecord->setAttribute($key, $formatted[$key]);
+            if (isset($record[$key]) && count($record[$key]) > 0) {
+                $logRecord->setAttribute($key, $record[$key]);
             }
         }
         $this->getLogger($record['channel'])->emit($logRecord);

--- a/src/Logs/Monolog/src/Handler.php
+++ b/src/Logs/Monolog/src/Handler.php
@@ -45,15 +45,18 @@ class Handler extends AbstractProcessingHandler
      */
     protected function write($record): void
     {
+        $formatted = ($this->getFormatter() instanceof JsonFormatter)
+            ? json_decode($record['formatted'], true)
+            : $record['formatted'];
         $logRecord = (new API\LogRecord())
             ->setTimestamp((int) $record['datetime']->format('Uu') * 1000)
             ->setSeverityNumber(API\Map\Psr3::severityNumber($record['level_name']))
             ->setSeverityText($record['level_name'])
-            ->setBody($record['message'])
+            ->setBody($formatted['message'])
         ;
         foreach (['context', 'extra'] as $key) {
-            if (isset($record[$key]) && count($record[$key]) > 0) {
-                $logRecord->setAttribute($key, $record[$key]);
+            if (isset($formatted[$key]) && count($formatted[$key]) > 0) {
+                $logRecord->setAttribute($key, $formatted[$key]);
             }
         }
         $this->getLogger($record['channel'])->emit($logRecord);


### PR DESCRIPTION
In the current iteration `$record['formatted']` is a string, which is then used later used in an attempt to access `message` from. I can only imagine this was typo, or an oversight.

I have tested locally and this works now.