### PR TITLE
[opentelemetry-auto-slim] fix schema url

### DIFF
--- a/src/Instrumentation/Slim/src/SlimInstrumentation.php
+++ b/src/Instrumentation/Slim/src/SlimInstrumentation.php
@@ -30,8 +30,9 @@ class SlimInstrumentation
     public static function register(): void
     {
         $instrumentation = new CachedInstrumentation(
-            name: 'io.opentelemetry.contrib.php.slim',
-            schemaUrl: 'https://opentelemetry.io/schemas/1.25.0'
+            'io.opentelemetry.contrib.php.slim',
+            null,
+            'https://opentelemetry.io/schemas/1.25.0'
         );
         /**
          * requires extension >= 1.0.2beta2

--- a/src/Instrumentation/Slim/src/SlimInstrumentation.php
+++ b/src/Instrumentation/Slim/src/SlimInstrumentation.php
@@ -29,7 +29,10 @@ class SlimInstrumentation
 
     public static function register(): void
     {
-        $instrumentation = new CachedInstrumentation('io.opentelemetry.contrib.php.slim', 'https://opentelemetry.io/schemas/1.25.0');
+        $instrumentation = new CachedInstrumentation(
+            name: 'io.opentelemetry.contrib.php.slim',
+            schemaUrl: 'https://opentelemetry.io/schemas/1.25.0'
+        );
         /**
          * requires extension >= 1.0.2beta2
          * @see https://github.com/open-telemetry/opentelemetry-php-instrumentation/pull/136

--- a/src/Instrumentation/Slim/tests/Integration/SlimInstrumentationTest.php
+++ b/src/Instrumentation/Slim/tests/Integration/SlimInstrumentationTest.php
@@ -164,6 +164,9 @@ class SlimInstrumentationTest extends TestCase
         $handler = $this->createMock(RequestHandlerInterface::class);
         $handler->method('handle')->willReturn($response);
 
+        /**
+         * @psalm-suppress MissingTemplateParam
+         */
         return new class($response, $routingMiddleware, $handler) extends App {
             private ResponseInterface $response;
             private RequestHandlerInterface $handler;


### PR DESCRIPTION
This pull request aims to fix an issue identified in which the value of `schemaUrl` is being inferred in the `$version` parameter instead of `$schemaUrl`