### PR TITLE
Fix Wordpress DB attributes

### DIFF
--- a/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
+++ b/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
@@ -45,7 +45,7 @@ class WordpressInstrumentation
             pre: static function ($object, ?array $params, ?string $class, ?string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
                 $span = self::builder($instrumentation, 'wpdb.__connect', $function, $class, $filename, $lineno)
                     ->setAttribute(TraceAttributes::DB_USER, $params[0] ?? 'unknown')
-                    ->setAttribute(TraceAttributes::DB_NAME, $params[1] ?? 'unknown')
+                    ->setAttribute(TraceAttributes::DB_NAME, $params[2] ?? 'unknown')
                     ->setAttribute(TraceAttributes::DB_SYSTEM, 'mysql')
                     ->startSpan();
                 Context::storage()->attach($span->storeInContext(Context::getCurrent()));


### PR DESCRIPTION
The attribute for the DB name was being incorrectly set to the DB password, resulting in exposed credentials when viewing traces.

[`wp-includes/class-wpdb.php`](https://github.com/WordPress/WordPress/blob/6aa053dc01aeab4ca197091d0c9a4c3437591640/wp-includes/wp-db.php#L700)
```
public function __construct( $dbuser, $dbpassword, $dbname, $dbhost ) {
```

`params[1]` corresponds to `$dbpassword` which should never be exposed in a trace.

![Screenshot 2024-06-18 at 1 59 24 PM redacted2](https://github.com/open-telemetry/opentelemetry-php-contrib/assets/94399475/0c97d618-f013-4f24-9e60-85ff989be0aa)
