### PR TITLE
Fix namespace to exclude ApiPlatform test HttpClient from instrumentation

### DIFF
--- a/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
@@ -24,7 +24,7 @@ final class HttpClientInstrumentation
      */
     const SYNCHRONOUS_CLIENTS = [
         /** @psalm-suppress UndefinedClass */
-        '\ApiPlatform\Symfony\Bundle\Test\Client',
+        'ApiPlatform\Symfony\Bundle\Test\Client',
     ];
 
     public static function supportsProgress(string $class): bool


### PR DESCRIPTION
We ran into the issue described in #235 and I was very happy when I realized that the fix was merged just two days ago! Thanks @cedricziel! But I think there is a small typo in the namespace used to exclude the ApiPlatform test HttpClient from instrumentation. So I created this PR to fix it!