### PR TITLE
feat: track dbname and other pdo attributes

### DIFF
--- a/src/Instrumentation/PDO/src/PDOInstrumentation.php
+++ b/src/Instrumentation/PDO/src/PDOInstrumentation.php
@@ -53,7 +53,9 @@ class PDOInstrumentation
                 }
                 $span = Span::fromContext($scope->context());
 
-                $attributes = $pdoTracker->trackPdoAttributes($pdo);
+                $dsn = $params[0] ?? '';
+
+                $attributes = $pdoTracker->trackPdoAttributes($pdo, $dsn);
                 $span->setAttributes($attributes);
 
                 self::end($exception);

--- a/src/Instrumentation/PDO/src/PDOTracker.php
+++ b/src/Instrumentation/PDO/src/PDOTracker.php
@@ -112,9 +112,9 @@ final class PDOTracker
      * Extracts attributes from a DSN string
      *
      * @param string $dsn
-     * @return array
+     * @return iterable<non-empty-string, bool|int|float|string|array|null>
      */
-    private static function extractAttributesFromDSN(string $dsn): array
+    private static function extractAttributesFromDSN(string $dsn): iterable
     {
         $attributes = [];
         if (str_starts_with($dsn, 'sqlite::memory:')) {

--- a/src/Instrumentation/PDO/src/PDOTracker.php
+++ b/src/Instrumentation/PDO/src/PDOTracker.php
@@ -123,15 +123,15 @@ final class PDOTracker
             return $attributes;
         }
 
-        if (preg_match("/user=([^;]*)/", $dsn, $matches)) {
+        if (preg_match('/user=([^;]*)/', $dsn, $matches)) {
             $user = $matches[1];
             $attributes[TraceAttributes::DB_USER] = $user ?? 'unknown';
         }
-        if (preg_match("/host=([^;]*)/", $dsn, $matches)) {
+        if (preg_match('/host=([^;]*)/', $dsn, $matches)) {
             $host = $matches[1];
             $attributes[TraceAttributes::NET_PEER_NAME] = $host ?? 'unknown';
         }
-        if (preg_match("/dbname=([^;]*)/", $dsn, $matches)) {
+        if (preg_match('/dbname=([^;]*)/', $dsn, $matches)) {
             $dbname = $matches[1];
             $attributes[TraceAttributes::DB_NAME] = $dbname ?? 'unknown';
         }

--- a/src/Instrumentation/PDO/src/PDOTracker.php
+++ b/src/Instrumentation/PDO/src/PDOTracker.php
@@ -122,12 +122,12 @@ final class PDOTracker
             $attributes[TraceAttributes::DB_NAME] = 'memory';
 
             return $attributes;
-        } else if (str_starts_with($dsn, 'sqlite:')) {
+        } elseif (str_starts_with($dsn, 'sqlite:')) {
             $attributes[TraceAttributes::DB_SYSTEM] = 'sqlite';
             $attributes[TraceAttributes::DB_NAME] = substr($dsn, 7);
 
             return $attributes;
-        } else if (str_starts_with($dsn, 'sqlite')) {
+        } elseif (str_starts_with($dsn, 'sqlite')) {
             $attributes[TraceAttributes::DB_SYSTEM] = 'sqlite';
             $attributes[TraceAttributes::DB_NAME] = $dsn;
 

--- a/src/Instrumentation/PDO/src/PDOTracker.php
+++ b/src/Instrumentation/PDO/src/PDOTracker.php
@@ -125,15 +125,21 @@ final class PDOTracker
 
         if (preg_match('/user=([^;]*)/', $dsn, $matches)) {
             $user = $matches[1];
-            $attributes[TraceAttributes::DB_USER] = $user ?? 'unknown';
+            if ($user !== '') {
+                $attributes[TraceAttributes::DB_USER] = $user;
+            }
         }
         if (preg_match('/host=([^;]*)/', $dsn, $matches)) {
             $host = $matches[1];
-            $attributes[TraceAttributes::NET_PEER_NAME] = $host ?? 'unknown';
+            if ($host !== '') {
+                $attributes[TraceAttributes::NET_PEER_NAME] = $host;
+            }
         }
         if (preg_match('/dbname=([^;]*)/', $dsn, $matches)) {
             $dbname = $matches[1];
-            $attributes[TraceAttributes::DB_NAME] = $dbname ?? 'unknown';
+            if ($dbname !== '') {
+                $attributes[TraceAttributes::DB_NAME] = $dbname;
+            }
         }
 
         return $attributes;

--- a/src/Instrumentation/PDO/src/PDOTracker.php
+++ b/src/Instrumentation/PDO/src/PDOTracker.php
@@ -117,7 +117,18 @@ final class PDOTracker
     private static function extractAttributesFromDSN(string $dsn): array
     {
         $attributes = [];
-        if (str_starts_with($dsn, 'sqlite')) {
+        if (str_starts_with($dsn, 'sqlite::memory:')) {
+            $attributes[TraceAttributes::DB_SYSTEM] = 'sqlite';
+            $attributes[TraceAttributes::DB_NAME] = 'memory';
+
+            return $attributes;
+        } else if (str_starts_with($dsn, 'sqlite:')) {
+            $attributes[TraceAttributes::DB_SYSTEM] = 'sqlite';
+            $attributes[TraceAttributes::DB_NAME] = substr($dsn, 7);
+
+            return $attributes;
+        } else if (str_starts_with($dsn, 'sqlite')) {
+            $attributes[TraceAttributes::DB_SYSTEM] = 'sqlite';
             $attributes[TraceAttributes::DB_NAME] = $dsn;
 
             return $attributes;

--- a/src/Instrumentation/PDO/tests/Unit/PDOAttributeTrackerTest.php
+++ b/src/Instrumentation/PDO/tests/Unit/PDOAttributeTrackerTest.php
@@ -13,14 +13,17 @@ class PDOAttributeTrackerTest extends TestCase
 {
     public function testPdoCanBeTracked()
     {
-        $pdo = new \PDO('sqlite::memory:');
+        $dsn = 'sqlite::memory:';
+        $pdo = new \PDO($dsn);
 
         $objectMap = new PDOTracker();
-        $objectMap->trackPdoAttributes($pdo);
+        $objectMap->trackPdoAttributes($pdo, $dsn);
         $attributes = $objectMap->trackedAttributesForPdo($pdo);
         $span = Span::getInvalid();
 
         $this->assertContains(TraceAttributes::DB_SYSTEM, array_keys($attributes));
+        $this->assertContains(TraceAttributes::DB_NAME, array_keys($attributes));
+        $this->assertSame($dsn, $attributes[TraceAttributes::DB_NAME]);
 
         $stmt = $pdo->prepare('SELECT NULL LIMIT 0;');
         $objectMap->trackStatement($stmt, $pdo, $span->getContext());

--- a/src/Instrumentation/PDO/tests/Unit/PDOAttributeTrackerTest.php
+++ b/src/Instrumentation/PDO/tests/Unit/PDOAttributeTrackerTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class PDOAttributeTrackerTest extends TestCase
 {
-    public function testPdoCanBeTracked()
+    public function testPdoCanBeTracked(): void
     {
         $dsn = 'sqlite::memory:';
         $pdo = new \PDO($dsn);
@@ -21,8 +21,11 @@ class PDOAttributeTrackerTest extends TestCase
         $attributes = $objectMap->trackedAttributesForPdo($pdo);
         $span = Span::getInvalid();
 
+        /** @psalm-suppress InvalidArgument */
         $this->assertContains(TraceAttributes::DB_SYSTEM, array_keys($attributes));
+        /** @psalm-suppress InvalidArgument */
         $this->assertContains(TraceAttributes::DB_NAME, array_keys($attributes));
+        /** @psalm-suppress InvalidArrayAccess */
         $this->assertSame('memory', $attributes[TraceAttributes::DB_NAME]);
 
         $stmt = $pdo->prepare('SELECT NULL LIMIT 0;');

--- a/src/Instrumentation/PDO/tests/Unit/PDOAttributeTrackerTest.php
+++ b/src/Instrumentation/PDO/tests/Unit/PDOAttributeTrackerTest.php
@@ -23,7 +23,7 @@ class PDOAttributeTrackerTest extends TestCase
 
         $this->assertContains(TraceAttributes::DB_SYSTEM, array_keys($attributes));
         $this->assertContains(TraceAttributes::DB_NAME, array_keys($attributes));
-        $this->assertSame($dsn, $attributes[TraceAttributes::DB_NAME]);
+        $this->assertSame('memory', $attributes[TraceAttributes::DB_NAME]);
 
         $stmt = $pdo->prepare('SELECT NULL LIMIT 0;');
         $objectMap->trackStatement($stmt, $pdo, $span->getContext());


### PR DESCRIPTION
This change tracks db name and user / host, if set per PDO object so it gets attached to every related span.