### PR TITLE
silence mongo deprecation warnings

### DIFF
--- a/src/Instrumentation/MongoDB/psalm.xml.dist
+++ b/src/Instrumentation/MongoDB/psalm.xml.dist
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
+    findUnusedBaselineEntry="false"
+    findUnusedCode="false"
     cacheDirectory="var/cache/psalm"
     errorBaseline="psalm.baseline.xml"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -15,5 +17,6 @@
     </plugins>
     <issueHandlers>
         <MissingClassConstType errorLevel="suppress" />
+        <DeprecatedConstant errorLevel="suppress" />
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
this is caused by the moratorium on updating semconv, so I guess we will see more of these soon enough