### PR TITLE
feat(laravel-auto-instrumentation): use logger provider in logwatcher

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Foundation/Application.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Foundation/Application.php
@@ -30,7 +30,7 @@ class Application implements LaravelHook
                 $this->registerWatchers($application, new CacheWatcher());
                 $this->registerWatchers($application, new ClientRequestWatcher($this->instrumentation));
                 $this->registerWatchers($application, new ExceptionWatcher());
-                $this->registerWatchers($application, new LogWatcher());
+                $this->registerWatchers($application, new LogWatcher($this->instrumentation));
                 $this->registerWatchers($application, new QueryWatcher($this->instrumentation));
             },
         );

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/AttributesBuilder.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/AttributesBuilder.php
@@ -16,7 +16,7 @@ trait AttributesBuilder
     private function buildMessageAttributes(
         QueueContract $queue,
         string $rawPayload,
-        string $queueName = null,
+        ?string $queueName = null,
         array $options = [],
         mixed ...$params,
     ): array {
@@ -38,7 +38,7 @@ trait AttributesBuilder
     private function contextualMessageSystemAttributes(
         QueueContract $queue,
         array $payload,
-        string $queueName = null,
+        ?string $queueName = null,
         array $options = [],
         mixed ...$params,
     ): array {
@@ -50,7 +50,7 @@ trait AttributesBuilder
         };
     }
 
-    private function beanstalkContextualAttributes(BeanstalkdQueue $queue, array $payload, string $queueName = null, array $options = [], mixed ...$params): array
+    private function beanstalkContextualAttributes(BeanstalkdQueue $queue, array $payload, ?string $queueName = null, array $options = [], mixed ...$params): array
     {
         return [
             TraceAttributes::MESSAGING_SYSTEM => 'beanstalk',
@@ -58,7 +58,7 @@ trait AttributesBuilder
         ];
     }
 
-    private function redisContextualAttributes(RedisQueue $queue, array $payload, string $queueName = null, array $options = [], mixed ...$params): array
+    private function redisContextualAttributes(RedisQueue $queue, array $payload, ?string $queueName = null, array $options = [], mixed ...$params): array
     {
         return [
             TraceAttributes::MESSAGING_SYSTEM => 'redis',
@@ -66,7 +66,7 @@ trait AttributesBuilder
         ];
     }
 
-    private function awsSqsContextualAttributes(SqsQueue $queue, array $payload, string $queueName = null, array $options = [], mixed ...$params): array
+    private function awsSqsContextualAttributes(SqsQueue $queue, array $payload, ?string $queueName = null, array $options = [], mixed ...$params): array
     {
         return [
             TraceAttributes::MESSAGING_SYSTEM => TraceAttributeValues::MESSAGING_SYSTEM_AWS_SQS,

--- a/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
@@ -6,8 +6,8 @@ namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\Events\MessageLogged;
-use OpenTelemetry\API\Logs\LogRecord;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Logs\LogRecord;
 use OpenTelemetry\API\Logs\Map\Psr3;
 
 class LogWatcher extends Watcher

--- a/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
@@ -6,11 +6,17 @@ namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\Events\MessageLogged;
-use OpenTelemetry\API\Trace\Span;
-use OpenTelemetry\Context\Context;
+use OpenTelemetry\API\Logs\LogRecord;
+use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Logs\Map\Psr3;
 
 class LogWatcher extends Watcher
 {
+    public function __construct(
+        private CachedInstrumentation $instrumentation,
+    ) {
+    }
+
     /** @psalm-suppress UndefinedInterfaceMethod */
     public function register(Application $app): void
     {
@@ -24,18 +30,16 @@ class LogWatcher extends Watcher
     public function recordLog(MessageLogged $log): void
     {
         $attributes = [
-            'level' => $log->level,
+            'context' => json_encode(array_filter($log->context)),
         ];
 
-        $attributes['context'] = json_encode(array_filter($log->context));
+        $logger = $this->instrumentation->logger();
 
-        $message = $log->message;
+        $record = (new LogRecord($log->message))
+            ->setSeverityText($log->level)
+            ->setSeverityNumber(Psr3::severityNumber($log->level))
+            ->setAttributes($attributes);
 
-        $scope = Context::storage()->scope();
-        if (!$scope) {
-            return;
-        }
-        $span = Span::fromContext($scope->context());
-        $span->addEvent($message, $attributes);
+        $logger->emit($record);
     }
 }

--- a/src/Instrumentation/Laravel/tests/Integration/Queue/QueueTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Queue/QueueTest.php
@@ -38,11 +38,15 @@ class QueueTest extends TestCase
             $logger->info('Logged from closure');
         });
 
-        $this->assertEquals('sync process', $this->storage[0]->getName());
-        $this->assertEquals('Task: A', $this->storage[0]->getEvents()[0]->getName());
-
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord0 */
+        $logRecord0 = $this->storage[0];
+        $this->assertEquals('Task: A', $logRecord0->getBody());
         $this->assertEquals('sync process', $this->storage[1]->getName());
-        $this->assertEquals('Logged from closure', $this->storage[1]->getEvents()[0]->getName());
+
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord2 */
+        $logRecord2 = $this->storage[2];
+        $this->assertEquals('Logged from closure', $logRecord2->getBody());
+        $this->assertEquals('sync process', $this->storage[3]->getName());
     }
 
     public function test_it_can_push_a_message_with_a_delay(): void
@@ -51,19 +55,19 @@ class QueueTest extends TestCase
         $this->queue->later(new DateInterval('PT10M'), new DummyJob('DateInterval'));
         $this->queue->later(new DateTimeImmutable('2024-04-15 22:29:00.123Z'), new DummyJob('DateTime'));
 
-        $this->assertEquals('sync create', $this->storage[1]->getName());
+        $this->assertEquals('sync create', $this->storage[2]->getName());
         $this->assertIsInt(
-            $this->storage[1]->getAttributes()->get('messaging.message.delivery_timestamp'),
-        );
-
-        $this->assertEquals('sync create', $this->storage[3]->getName());
-        $this->assertIsInt(
-            $this->storage[3]->getAttributes()->get('messaging.message.delivery_timestamp'),
+            $this->storage[2]->getAttributes()->get('messaging.message.delivery_timestamp'),
         );
 
         $this->assertEquals('sync create', $this->storage[5]->getName());
         $this->assertIsInt(
             $this->storage[5]->getAttributes()->get('messaging.message.delivery_timestamp'),
+        );
+
+        $this->assertEquals('sync create', $this->storage[8]->getName());
+        $this->assertIsInt(
+            $this->storage[8]->getAttributes()->get('messaging.message.delivery_timestamp'),
         );
     }
 
@@ -141,9 +145,14 @@ class QueueTest extends TestCase
         }
 
         /** @psalm-suppress PossiblyInvalidMethodCall */
-        $this->assertEquals(102, $this->storage->count());
+        $this->assertEquals(204, $this->storage->count());
 
-        $this->assertEquals('Task: 500', $this->storage[50]->getEvents()[0]->getName());
-        $this->assertEquals('Task: More work', $this->storage[100]->getEvents()[0]->getName());
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord100 */
+        $logRecord100 = $this->storage[100];
+        $this->assertEquals('Task: 500', $logRecord100->getBody());
+
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord200 */
+        $logRecord200 = $this->storage[200];
+        $this->assertEquals('Task: More work', $logRecord200->getBody());
     }
 }

--- a/src/Instrumentation/Laravel/tests/Integration/TestCase.php
+++ b/src/Instrumentation/Laravel/tests/Integration/TestCase.php
@@ -7,18 +7,23 @@ namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration;
 use ArrayObject;
 use OpenTelemetry\API\Instrumentation\Configurator;
 use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\SDK\Logs\LoggerProvider;
+use OpenTelemetry\SDK\Logs\Processor\SimpleLogRecordProcessor;
+use OpenTelemetry\SDK\Logs\Exporter\InMemoryExporter as LogInMemoryExporter;
 use OpenTelemetry\SDK\Trace\ImmutableSpan;
-use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter as SpanInMemoryExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use OpenTelemetry\SDK\Logs\ReadWriteLogRecord;
 
 abstract class TestCase extends BaseTestCase
 {
     protected ScopeInterface $scope;
-    /** @var ArrayObject|ImmutableSpan[] $storage */
+    /** @var ArrayObject|ImmutableSpan[]|ReadWriteLogRecord $storage */
     protected ArrayObject $storage;
     protected TracerProvider $tracerProvider;
+    protected LoggerProvider $loggerProvider;
 
     public function setUp(): void
     {
@@ -27,12 +32,20 @@ abstract class TestCase extends BaseTestCase
         $this->storage = new ArrayObject();
         $this->tracerProvider = new TracerProvider(
             new SimpleSpanProcessor(
-                new InMemoryExporter($this->storage),
+                new SpanInMemoryExporter($this->storage),
             ),
         );
+        $this->loggerProvider = LoggerProvider::builder()
+            ->addLogRecordProcessor(
+                new SimpleLogRecordProcessor(
+                    new LogInMemoryExporter($this->storage),
+                ),
+            )
+            ->build();
 
         $this->scope = Configurator::create()
             ->withTracerProvider($this->tracerProvider)
+            ->withLoggerProvider($this->loggerProvider)
             ->activate();
     }
 

--- a/src/Instrumentation/Laravel/tests/Integration/TestCase.php
+++ b/src/Instrumentation/Laravel/tests/Integration/TestCase.php
@@ -7,15 +7,15 @@ namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration;
 use ArrayObject;
 use OpenTelemetry\API\Instrumentation\Configurator;
 use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\SDK\Logs\Exporter\InMemoryExporter as LogInMemoryExporter;
 use OpenTelemetry\SDK\Logs\LoggerProvider;
 use OpenTelemetry\SDK\Logs\Processor\SimpleLogRecordProcessor;
-use OpenTelemetry\SDK\Logs\Exporter\InMemoryExporter as LogInMemoryExporter;
+use OpenTelemetry\SDK\Logs\ReadWriteLogRecord;
 use OpenTelemetry\SDK\Trace\ImmutableSpan;
 use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter as SpanInMemoryExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
-use OpenTelemetry\SDK\Logs\ReadWriteLogRecord;
 
 abstract class TestCase extends BaseTestCase
 {


### PR DESCRIPTION
I am by no means an expert in the OpenTelemetry spec, but I noticed that other auto instrumentations, like the ones available for python, record logs with the logger provider APIs.

Currently the Laravel auto instrumentation stores logs it encounters as events on the span. This PR changes this behavior to use the logger provider API instead.