### PR TITLE
fix: post hook threw exception on JsonResponse

### DIFF
--- a/src/Instrumentation/Laravel/src/Propagators/ResponsePropagationSetter.php
+++ b/src/Instrumentation/Laravel/src/Propagators/ResponsePropagationSetter.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Propagators;
 
 use function assert;
-use Illuminate\Http\Response;
 use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal


### PR DESCRIPTION
If a controller returns an Illuminate\Http\JsonResponse and you have the
OpenTelemetry traceresponse or server-timing propagator installed, the
Illuminate\Foundation\Http\Kernel::handle() post hook throws an
exception due to the ResponsePropagationSetter Illuminate\Http\Response
assertion.

Changing the Response assertion to the Symfony parent class fixes this.
