### PR TITLE
Fix span status for 4XX responses

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
@@ -91,7 +91,7 @@ class Kernel implements LaravelHook
                 }
 
                 if ($response) {
-                    if ($response->getStatusCode() >= 400) {
+                    if ($response->getStatusCode() >= 500) {
                         $span->setStatus(StatusCode::STATUS_ERROR);
                     }
                     $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode());


### PR DESCRIPTION
For servers then Span Status should only be set to `Error` for responses >= 500, and 400 should be left unset.

See https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md?plain=1#L108-L112

