### PR TITLE
Fix: ignore redirection error

### DIFF
--- a/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
@@ -112,6 +112,12 @@ class ClientRequestWatcher extends Watcher
             return;
         }
 
+        // HTTP status code 3xx is not really error
+        // See https://www.rfc-editor.org/rfc/rfc9110.html#name-redirection-3xx
+        if ($response->redirect()) {
+            return;
+        }
+
         $span->setStatus(
             StatusCode::STATUS_ERROR,
             HttpResponse::$statusTexts[$response->status()] ?? (string) $response->status()


### PR DESCRIPTION
According to the definition in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-redirection-3xx):

> The 3xx (Redirection) class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request.

The 3xx status code only signifies that additional steps are required to determine the result, but merely encountering a 3xx status code does not necessarily indicate an error. Therefore, it is recommended to make this adjustment.