### PR TITLE
Feat: Add contextual attributes register for queue

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/AttributesBuilderRegister.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/AttributesBuilderRegister.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue;
+
+use Illuminate\Queue\BeanstalkdQueue;
+use Illuminate\Queue\RedisQueue;
+use Illuminate\Queue\SqsQueue;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue\ContextualAttributesBuilders\BeanstalkdQueueAttributes;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue\ContextualAttributesBuilders\RedisQueueAttributes;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue\ContextualAttributesBuilders\SqsQueueAttributes;
+
+class AttributesBuilderRegister
+{
+    /**
+     * @var ContextualAttributesBuilder[]
+     */
+    private static array $contextualAttributesBuilders = [];
+
+    public static function registerContextualAttributesBuilder(ContextualAttributesBuilder $instance): void
+    {
+        self::$contextualAttributesBuilders[$instance::class] ??= $instance;
+    }
+
+    public static function clean(): void
+    {
+        self::$contextualAttributesBuilders = [];
+    }
+
+    /**
+     * @return ContextualAttributesBuilder[]
+     */
+    public static function getBuilders(): array
+    {
+        self::ensureDefaultBuilderIsRegistered();
+
+        return self::$contextualAttributesBuilders;
+    }
+
+    private static function ensureDefaultBuilderIsRegistered(): void
+    {
+        self::$contextualAttributesBuilders[BeanstalkdQueue::class] ??= new BeanstalkdQueueAttributes();
+        self::$contextualAttributesBuilders[RedisQueue::class] ??= new RedisQueueAttributes();
+        self::$contextualAttributesBuilders[SqsQueue::class] ??= new SqsQueueAttributes();
+    }
+}

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/ContextualAttributesBuilder.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/ContextualAttributesBuilder.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue;
+
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+
+interface ContextualAttributesBuilder
+{
+    public function canHandle(QueueContract $queue): bool;
+
+    public function contextualAttributes(
+        QueueContract $queue,
+        array $payload,
+        ?string $queueName = null,
+        array $options = [],
+        mixed ...$params
+    ): array;
+}

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/ContextualAttributesBuilders/AbstractContextualAttributesBuilder.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/ContextualAttributesBuilders/AbstractContextualAttributesBuilder.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue\ContextualAttributesBuilders;
+
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+use InvalidArgumentException;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue\ContextualAttributesBuilder;
+
+abstract class AbstractContextualAttributesBuilder implements ContextualAttributesBuilder
+{
+    protected ?string $handleClass = null;
+
+    public function canHandle(QueueContract $queue): bool
+    {
+        if ($this->handleClass === null) {
+            throw new InvalidArgumentException('ContextualAttributesBuilder cannot handle an null class.');
+        }
+
+        return $queue instanceof $this->handleClass;
+    }
+}

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/ContextualAttributesBuilders/BeanstalkdQueueAttributes.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/ContextualAttributesBuilders/BeanstalkdQueueAttributes.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue\ContextualAttributesBuilders;
+
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\BeanstalkdQueue;
+use OpenTelemetry\SemConv\TraceAttributes;
+
+class BeanstalkdQueueAttributes extends AbstractContextualAttributesBuilder
+{
+    protected ?string $handleClass = BeanstalkdQueue::class;
+
+    public function contextualAttributes(
+        Queue $queue,
+        array $payload,
+        ?string $queueName = null,
+        array $options = [],
+        ...$params
+    ): array {
+        if (!$queue instanceof BeanstalkdQueue) {
+            return [];
+        }
+
+        return [
+            TraceAttributes::MESSAGING_SYSTEM => 'beanstalk',
+            TraceAttributes::MESSAGING_DESTINATION_NAME => $queue->getQueue($queueName),
+        ];
+    }
+}

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/ContextualAttributesBuilders/RedisQueueAttributes.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/ContextualAttributesBuilders/RedisQueueAttributes.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue\ContextualAttributesBuilders;
+
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\RedisQueue;
+use OpenTelemetry\SemConv\TraceAttributes;
+
+class RedisQueueAttributes extends AbstractContextualAttributesBuilder
+{
+    protected ?string $handleClass = RedisQueue::class;
+
+    public function contextualAttributes(
+        Queue $queue,
+        array $payload,
+        ?string $queueName = null,
+        array $options = [],
+        ...$params
+    ): array {
+        if (!$queue instanceof RedisQueue) {
+            return [];
+        }
+
+        return [
+            TraceAttributes::MESSAGING_SYSTEM => 'redis',
+            TraceAttributes::MESSAGING_DESTINATION_NAME => $queue->getQueue($queueName),
+        ];
+    }
+}

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/ContextualAttributesBuilders/SqsQueueAttributes.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/ContextualAttributesBuilders/SqsQueueAttributes.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue\ContextualAttributesBuilders;
+
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Queue\SqsQueue;
+use OpenTelemetry\SemConv\TraceAttributes;
+use OpenTelemetry\SemConv\TraceAttributeValues;
+
+class SqsQueueAttributes extends AbstractContextualAttributesBuilder
+{
+    protected ?string $handleClass = SqsQueue::class;
+
+    public function contextualAttributes(
+        Queue $queue,
+        array $payload,
+        ?string $queueName = null,
+        array $options = [],
+        ...$params
+    ): array {
+        if (!$queue instanceof SqsQueue) {
+            return [];
+        }
+
+        return [
+            TraceAttributes::MESSAGING_SYSTEM => TraceAttributeValues::MESSAGING_SYSTEM_AWS_SQS,
+            TraceAttributes::MESSAGING_DESTINATION_NAME => $queue->getQueue($queueName),
+        ];
+    }
+}

--- a/src/Instrumentation/Laravel/tests/Fixtures/Queues/AnotherAttributesBuilder.php
+++ b/src/Instrumentation/Laravel/tests/Fixtures/Queues/AnotherAttributesBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Queues;
+
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue\ContextualAttributesBuilders\AbstractContextualAttributesBuilder;
+use OpenTelemetry\SemConv\TraceAttributes;
+
+class AnotherAttributesBuilder extends AbstractContextualAttributesBuilder
+{
+    protected ?string $handleClass = AnotherQueue::class;
+
+    public function contextualAttributes(
+        QueueContract $queue,
+        array $payload,
+        ?string $queueName = null,
+        array $options = [],
+        ...$params
+    ): array {
+        return [
+            TraceAttributes::MESSAGING_SYSTEM => 'another-queue',
+            TraceAttributes::MESSAGING_DESTINATION_NAME =>  $queue->getQueue($queueName),
+        ];
+    }
+}

--- a/src/Instrumentation/Laravel/tests/Fixtures/Queues/AnotherQueue.php
+++ b/src/Instrumentation/Laravel/tests/Fixtures/Queues/AnotherQueue.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Queues;
+
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Queue\Queue;
+
+class AnotherQueue extends Queue implements QueueContract
+{
+    public function getQueue($queue)
+    {
+        return 'another-queue-name';
+    }
+
+    public function size($queue = null)
+    {
+        // dummy
+    }
+
+    public function push($job, $data = '', $queue = null)
+    {
+        // dummy
+    }
+
+    public function pushRaw($payload, $queue = null, array $options = [])
+    {
+        // dummy
+    }
+
+    public function later($delay, $job, $data = '', $queue = null)
+    {
+        // dummy
+    }
+
+    public function pop($queue = null)
+    {
+        // dummy
+    }
+}


### PR DESCRIPTION
I have been using the package [vladimir-yuldashev/laravel-queue-rabbitmq](https://github.com/vyuldashev/laravel-queue-rabbitmq) in my work. However, I noticed that the auto Laravel feature only handles Laravel's native queues, without any interface for developers to add custom queue parsing.

This PR introduces an interface that allows the registration of custom queues. By creating a class that extends `AbstractContextualAttributesBuilder` and registering it with `AttributesBuilderRegister` , it will automatically be recognized and processed during the hook phase.