### PR TITLE
Use Coroutine::list instead of Coroutine::listCoroutines

### DIFF
--- a/src/Context/Swoole/src/SwooleContextHandler.php
+++ b/src/Context/Swoole/src/SwooleContextHandler.php
@@ -41,7 +41,7 @@ final class SwooleContextHandler
     public function splitOffChildCoroutines(): void
     {
         $pcid = Coroutine::getCid();
-        foreach (Coroutine::listCoroutines() as $cid) {
+        foreach (Coroutine::list() as $cid) {
             if ($pcid === Coroutine::getPcid($cid) && !$this->isForked($cid)) {
                 $this->forkCoroutine($cid);
             }

--- a/src/Context/Swoole/src/SwooleContextHandler.php
+++ b/src/Context/Swoole/src/SwooleContextHandler.php
@@ -41,7 +41,7 @@ final class SwooleContextHandler
     public function splitOffChildCoroutines(): void
     {
         $pcid = Coroutine::getCid();
-        foreach (Coroutine::list() as $cid) {
+        foreach (method_exists(Coroutine::class, 'list') ? Coroutine::list() : Coroutine::listCoroutines() as $cid) {
             if ($pcid === Coroutine::getPcid($cid) && !$this->isForked($cid)) {
                 $this->forkCoroutine($cid);
             }


### PR DESCRIPTION
Since OpenSwoole: 4.4.0, 
the method Coroutine::list is available: https://openswoole.com/docs/modules/swoole-coroutine

In the 22 version, the method Coroutine::listCoroutines does not exist.
