### PR TITLE
[Symfony] Fix: Set span status according to otel convention

### DIFF
--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -113,7 +113,12 @@ final class SymfonyInstrumentation
                     return;
                 }
 
-                if ($response->getStatusCode() >= Response::HTTP_BAD_REQUEST) {
+                // Do not set error status on server spans for 4xx responses
+                if (!$span->getKind(SpanKind::KIND_SERVER) && $response->getStatusCode() >= Response::HTTP_BAD_REQUEST) {
+                    $span->setStatus(StatusCode::STATUS_ERROR);
+                }
+                // Do set error status on all spans for 5xx responses
+                if ($response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
                     $span->setStatus(StatusCode::STATUS_ERROR);
                 }
                 $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode());

--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -113,11 +113,6 @@ final class SymfonyInstrumentation
                     return;
                 }
 
-                // Do not set error status on server spans for 4xx responses
-                if (!$span->getKind(SpanKind::KIND_SERVER) && $response->getStatusCode() >= Response::HTTP_BAD_REQUEST) {
-                    $span->setStatus(StatusCode::STATUS_ERROR);
-                }
-                // Do set error status on all spans for 5xx responses
                 if ($response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
                     $span->setStatus(StatusCode::STATUS_ERROR);
                 }


### PR DESCRIPTION
The span status was always set to error for responses with status code 400 and up.  
According to the otel semantic conventions, for 4xx status, the span status MUST be left unset for spans with SpanKind.SERVER This commit adds the logic to implement this behaviour.

Ref: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status