### PR TITLE
psr3: handle non-string attribute keys

### DIFF
--- a/src/Instrumentation/Psr3/src/Formatter.php
+++ b/src/Instrumentation/Psr3/src/Formatter.php
@@ -10,21 +10,21 @@ class Formatter
 {
     public static function format(array $context): array
     {
-        $return = [];
+        $formatted = [];
         foreach ($context as $key => $value) {
             if ($key === 'exception' && $value instanceof Throwable) {
-                $return[$key] = self::formatThrowable($value);
+                $formatted[$key] = self::formatThrowable($value);
             } else {
-                $return[$key] = json_decode(json_encode($value));
+                $formatted[$key] = json_decode(json_encode($value));
             }
         }
 
-        return $return;
+        return $formatted;
     }
 
-    public static function formatThrowable(?Throwable $exception): array
+    private static function formatThrowable(?Throwable $exception): array
     {
-        if($exception) {
+        if ($exception) {
             return [
                 'message' => $exception->getMessage(),
                 'code' => $exception->getCode(),
@@ -36,6 +36,5 @@ class Formatter
         }
 
         return [];
-        
     }
 }

--- a/src/Instrumentation/Psr3/src/Psr3Instrumentation.php
+++ b/src/Instrumentation/Psr3/src/Psr3Instrumentation.php
@@ -76,8 +76,10 @@ class Psr3Instrumentation
                     }
 
                     $record = (new API\LogRecord($body))
-                        ->setSeverityNumber(API\Map\Psr3::severityNumber($level))
-                        ->setAttributes(Formatter::format($context));
+                        ->setSeverityNumber(API\Map\Psr3::severityNumber($level));
+                    foreach (Formatter::format($context) as $key => $value) {
+                        $record->setAttribute((string) $key, $value);
+                    }
                     $instrumentation->logger()->emit($record);
 
                     break;

--- a/src/Instrumentation/Psr3/tests/Integration/Psr3InstrumentationTest.php
+++ b/src/Instrumentation/Psr3/tests/Integration/Psr3InstrumentationTest.php
@@ -49,7 +49,7 @@ class Psr3InstrumentationTest extends TestCase
     {
         $level = LogLevel::EMERGENCY;
         $msg = 'log test';
-        $context = ['user' => 'php', 'pid' => 1];
+        $context = [0 => 'zero', 'user' => 'php', 'pid' => 1];
 
         $this->logger
             ->expects($this->once())

--- a/src/Instrumentation/Psr3/tests/Unit/FormatterTest.php
+++ b/src/Instrumentation/Psr3/tests/Unit/FormatterTest.php
@@ -12,6 +12,7 @@ class FormatterTest extends TestCase
     public function test_format(): void
     {
         $context = [
+            0 => 'zero',
             'foo' => 'bar',
             'exception' => new \Exception('foo', 500, new \RuntimeException('bar')),
         ];

--- a/src/Instrumentation/Psr3/tests/phpt/export_apix.phpt
+++ b/src/Instrumentation/Psr3/tests/phpt/export_apix.phpt
@@ -22,7 +22,7 @@ $scope = $span->activate();
 
 $input = require(__DIR__ . '/input.php');
 
-$logger->info($input['message'], $input['context']);
+$logger->info($input['message'], $input['context'] + ['zero']);
 
 $scope->detach();
 $span->end();
@@ -81,7 +81,8 @@ $span->end();
                                 ],
                                 "previous": []
                             }
-                        }
+                        },
+                        "0": "zero"
                     },
                     "dropped_attributes_count": 0
                 }

--- a/src/Instrumentation/Psr3/tests/phpt/export_monolog.phpt
+++ b/src/Instrumentation/Psr3/tests/phpt/export_monolog.phpt
@@ -21,7 +21,7 @@ $scope = $span->activate();
 
 $input = require(__DIR__ . '/input.php');
 
-$logger->warning($input['message'], $input['context']);
+$logger->warning($input['message'], $input['context'] + ['zero']);
 
 $scope->detach();
 $span->end();
@@ -78,7 +78,8 @@ $span->end();
                                 ],
                                 "previous": []
                             }
-                        }
+                        },
+                        "0": "zero"
                     },
                     "dropped_attributes_count": 0
                 }

--- a/src/Instrumentation/Psr3/tests/phpt/export_symfony.phpt
+++ b/src/Instrumentation/Psr3/tests/phpt/export_symfony.phpt
@@ -21,7 +21,7 @@ $scope = $span->activate();
 
 $input = require(__DIR__ . '/input.php');
 
-$logger->warning($input['message'], $input['context']);
+$logger->warning($input['message'], $input['context'] + ['zero']);
 
 $scope->detach();
 $span->end();
@@ -74,7 +74,8 @@ $span->end();
                                 "trace": %a,
                                 "previous": []
                             }
-                        }
+                        },
+                        "0": "zero"
                     },
                     "dropped_attributes_count": 0
                 }


### PR DESCRIPTION
non-string attribute keys cause an error, and stop log messages from being exported. cast the numeric keys to a string to ensure they make it through alive. update tests, skipping cake because it does weird stuff when presented with a numeric key which completely changes the structure of the incoming context.

Closes: https://github.com/open-telemetry/opentelemetry-php/issues/1374