### PR TITLE
Add peer.service attribute to symfony http client spans

### DIFF
--- a/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/HttpClientInstrumentation.php
@@ -52,6 +52,7 @@ final class HttpClientInstrumentation
                     ->tracer()
                     ->spanBuilder(\sprintf('%s', $params[0]))
                     ->setSpanKind(SpanKind::KIND_CLIENT)
+                    ->setAttribute(TraceAttributes::PEER_SERVICE, parse_url((string) $params[1])['host'] ?? null)
                     ->setAttribute(TraceAttributes::URL_FULL, (string) $params[1])
                     ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $params[0])
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)

--- a/src/Instrumentation/Symfony/tests/Integration/HttpClientInstrumentationTest.php
+++ b/src/Instrumentation/Symfony/tests/Integration/HttpClientInstrumentationTest.php
@@ -48,6 +48,8 @@ final class HttpClientInstrumentationTest extends AbstractTest
             $this->assertNotNull($requestHeaders['HTTP_TRACEPARENT']);
         }
 
+        $this->assertTrue($span->getAttributes()->has(TraceAttributes::PEER_SERVICE));
+        $this->assertSame(parse_url($uri)['host'] ?? null, $span->getAttributes()->get(TraceAttributes::PEER_SERVICE));
         $this->assertTrue($span->getAttributes()->has(TraceAttributes::URL_FULL));
         $this->assertSame($uri, $span->getAttributes()->get(TraceAttributes::URL_FULL));
         $this->assertTrue($span->getAttributes()->has(TraceAttributes::HTTP_REQUEST_METHOD));


### PR DESCRIPTION
The peer.service attribute helps to relate traces between services. The attribute is defined in the semantic conventions: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/peer.md?plain=1#L15

Add the peer.service attribute to the HTTP client spans that request known services.