### PR TITLE
Add peer.service attribute to psr18 spans

### DIFF
--- a/src/Instrumentation/Psr18/src/Psr18Instrumentation.php
+++ b/src/Instrumentation/Psr18/src/Psr18Instrumentation.php
@@ -49,6 +49,7 @@ class Psr18Instrumentation
                     ->spanBuilder(sprintf('%s', $request->getMethod()))
                     ->setParent($parentContext)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
+                    ->setAttribute(TraceAttributes::PEER_SERVICE, $request->getUri()->getHost())
                     ->setAttribute(TraceAttributes::URL_FULL, (string) $request->getUri())
                     ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
                     ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $request->getProtocolVersion())

--- a/src/Instrumentation/Psr18/tests/Integration/Psr18InstrumentationTest.php
+++ b/src/Instrumentation/Psr18/tests/Integration/Psr18InstrumentationTest.php
@@ -80,6 +80,8 @@ class Psr18InstrumentationTest extends TestCase
         $span = $this->storage[0];
 
         $this->assertStringContainsString($method, $span->getName());
+        $this->assertTrue($span->getAttributes()->has(TraceAttributes::PEER_SERVICE));
+        $this->assertSame(parse_url($uri)['host'] ?? null, $span->getAttributes()->get(TraceAttributes::PEER_SERVICE));
         $this->assertTrue($span->getAttributes()->has(TraceAttributes::URL_FULL));
         $this->assertSame($uri, $span->getAttributes()->get(TraceAttributes::URL_FULL));
         $this->assertTrue($span->getAttributes()->has(TraceAttributes::HTTP_REQUEST_METHOD));


### PR DESCRIPTION
The peer.service attribute helps to relate traces between services. The attribute is defined in the semantic conventions: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/peer.md?plain=1#L15

Add the peer.service attribute to the Psr18 spans that request known services.