### PR TITLE
Update Symfony Messenger instrumentation to use SpanKind::KIND_PRODUCER, SpanKind::KIND_CONSUMER #1314

### DIFF
--- a/src/Instrumentation/Symfony/src/MessengerInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/MessengerInstrumentation.php
@@ -125,7 +125,7 @@ final class MessengerInstrumentation
                 $builder = $instrumentation
                     ->tracer()
                     ->spanBuilder(\sprintf('SEND %s', $messageClass))
-                    ->setSpanKind(SpanKind::KIND_CONSUMER)
+                    ->setSpanKind(SpanKind::KIND_PRODUCER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
                     ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)

--- a/src/Instrumentation/Symfony/src/MessengerInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/MessengerInstrumentation.php
@@ -58,7 +58,7 @@ final class MessengerInstrumentation
                 $builder = $instrumentation
                     ->tracer()
                     ->spanBuilder(\sprintf('DISPATCH %s', $messageClass))
-                    ->setSpanKind(SpanKind::KIND_INTERNAL)
+                    ->setSpanKind(SpanKind::KIND_PRODUCER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
                     ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)
@@ -125,7 +125,7 @@ final class MessengerInstrumentation
                 $builder = $instrumentation
                     ->tracer()
                     ->spanBuilder(\sprintf('SEND %s', $messageClass))
-                    ->setSpanKind(SpanKind::KIND_INTERNAL)
+                    ->setSpanKind(SpanKind::KIND_CONSUMER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION, $function)
                     ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
                     ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)

--- a/src/Instrumentation/Symfony/tests/Integration/MessengerInstrumentationTest.php
+++ b/src/Instrumentation/Symfony/tests/Integration/MessengerInstrumentationTest.php
@@ -157,7 +157,7 @@ final class MessengerInstrumentationTest extends AbstractTest
             [
                 new SendEmailMessage('Hello Again'),
                 'SEND OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration\SendEmailMessage',
-                SpanKind::KIND_CONSUMER,
+                SpanKind::KIND_PRODUCER,
                 [
                     MessengerInstrumentation::ATTRIBUTE_MESSENGER_TRANSPORT => class_exists('Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport') ? 'Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport' : 'Symfony\Component\Messenger\Transport\InMemoryTransport',
                     MessengerInstrumentation::ATTRIBUTE_MESSENGER_MESSAGE => 'OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration\SendEmailMessage',

--- a/src/Instrumentation/Symfony/tests/Integration/MessengerInstrumentationTest.php
+++ b/src/Instrumentation/Symfony/tests/Integration/MessengerInstrumentationTest.php
@@ -157,7 +157,7 @@ final class MessengerInstrumentationTest extends AbstractTest
             [
                 new SendEmailMessage('Hello Again'),
                 'SEND OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration\SendEmailMessage',
-                SpanKind::KIND_INTERNAL,
+                SpanKind::KIND_CONSUMER,
                 [
                     MessengerInstrumentation::ATTRIBUTE_MESSENGER_TRANSPORT => class_exists('Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport') ? 'Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport' : 'Symfony\Component\Messenger\Transport\InMemoryTransport',
                     MessengerInstrumentation::ATTRIBUTE_MESSENGER_MESSAGE => 'OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration\SendEmailMessage',
@@ -172,7 +172,7 @@ final class MessengerInstrumentationTest extends AbstractTest
             [
                 new SendEmailMessage('Hello Again'),
                 'DISPATCH OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration\SendEmailMessage',
-                SpanKind::KIND_INTERNAL,
+                SpanKind::KIND_PRODUCER,
                 [
                     MessengerInstrumentation::ATTRIBUTE_MESSENGER_BUS => 'Symfony\Component\Messenger\MessageBus',
                     MessengerInstrumentation::ATTRIBUTE_MESSENGER_MESSAGE => 'OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration\SendEmailMessage',


### PR DESCRIPTION
This implements instrumentation for the Symfony Messenger component in the OpenTelemetry PHP SDK. It fixes the spanKind label to follow https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#span-kind for both the dispatch and send methods, allowing for better tracing and monitoring of message handling within Symfony applications.

This PR addresses Issue [](https://github.com/open-telemetry/opentelemetry-php/issues/1314) regarding the need for appropriate span kinds and attributes for message processing in the Symfony Messenger. @brettmc 

Closes: https://github.com/open-telemetry/opentelemetry-php/issues/1314
