### PR TITLE
[symfony] Fix: Set span status according to otel convention

### DIFF
--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -104,7 +104,7 @@ final class SymfonyInstrumentation
                     $span->recordException($exception, [
                         TraceAttributes::EXCEPTION_ESCAPED => true,
                     ]);
-                    if(null !== $response && $response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
+                    if (null !== $response && $response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
                         $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
                     }
                 }

--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -104,7 +104,9 @@ final class SymfonyInstrumentation
                     $span->recordException($exception, [
                         TraceAttributes::EXCEPTION_ESCAPED => true,
                     ]);
-                    $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
+                    if(null !== $response && $response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
+                        $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
+                    }
                 }
 
                 if (null === $response) {
@@ -159,8 +161,7 @@ final class SymfonyInstrumentation
                 Span::getCurrent()
                     ->recordException($throwable, [
                         TraceAttributes::EXCEPTION_ESCAPED => true,
-                    ])
-                    ->setStatus(StatusCode::STATUS_ERROR, $throwable->getMessage());
+                    ]);
 
                 return $params;
             },


### PR DESCRIPTION
Only set error status on span  if we know the response code is 500 or higher.

Addresses https://github.com/open-telemetry/opentelemetry-php/issues/1403

In Symfony any error is handled as an exception. The instrumentation added an error status to any span when an exception occurred. This is not in line with the spec. For span kinds of server, the error status must ONLY be set for response codes of 500 and higher.
Earlier improvement was done in PR #295, but that fix wasn't sufficient.