### PR TITLE
Fix broken Serializer when using Laravel Illuminate\Queue\LuaScripts

### DIFF
--- a/src/Instrumentation/Laravel/src/Watchers/RedisCommand/Serializer.php
+++ b/src/Instrumentation/Laravel/src/Watchers/RedisCommand/Serializer.php
@@ -69,6 +69,9 @@ class Serializer
             $paramsToSerialize[] = '[' . (count($params) - $paramsToSerializeNum) . ' other arguments]';
         }
 
+        // In some cases (for example when using LUA scripts) arrays are valid parameters
+        $paramsToSerialize = array_map(function($param) { return is_array($param) ? json_encode($param) : $param; }, $paramsToSerialize);
+        
         return $command . ' ' . implode(' ', $paramsToSerialize);
     }
 }

--- a/src/Instrumentation/Laravel/tests/Unit/Watches/RedisCommand/SerializerTest.php
+++ b/src/Instrumentation/Laravel/tests/Unit/Watches/RedisCommand/SerializerTest.php
@@ -31,5 +31,8 @@ class SerializerTest extends TestCase
 
         // Serialize all params
         yield ['DEL', ['param1', 'param2', 'param3', 'param4'], 'DEL param1 param2 param3 param4'];
+
+        // Parameters of array type
+        yield ['EVAL', ['param1', 'param2', ['arg1', 'arg2']], 'EVAL param1 param2 ["arg1","arg2"]'];
     }
 }


### PR DESCRIPTION
Since introduction of RedisCommandWatcher, auto-instrumentation for Laravel fails when using Lua scripts for Queue management, since command argument array can contains arrays.

I don't have the time right now to prepare failing PoC, problematic payload is created in Illuminate\Queue\RedisQueue, it seems that it fails when multiple jobs are passed into argument as an object.