### PR TITLE
Laravel: handle possible LogWatcher TypeError's

### DIFF
--- a/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
@@ -10,6 +10,7 @@ use Illuminate\Log\LogManager;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Logs\LogRecord;
 use OpenTelemetry\API\Logs\Map\Psr3;
+use TypeError;
 
 class LogWatcher extends Watcher
 {
@@ -36,9 +37,17 @@ class LogWatcher extends Watcher
     {
         $underlyingLogger = $this->logger->getLogger();
 
-        /** @phan-suppress-next-line PhanUndeclaredMethod */
-        if (method_exists($underlyingLogger, 'isHandling') && !$underlyingLogger->isHandling($log->level)) {
-            return;
+        /**
+         * This assumes that the underlying logger (expected to be monolog) would accept `$log->level` as a string.
+         * With monolog < 3.x, this method would fail. Let's prevent this blowing up in Laravel<10.x.
+         */
+        try {
+            /** @phan-suppress-next-line PhanUndeclaredMethod */
+            if (method_exists($underlyingLogger, 'isHandling') && !$underlyingLogger->isHandling($log->level)) {
+                return;
+            }
+        } catch (TypeError) {
+            // Should this fail, we should continue to emit the LogRecord.
         }
 
         $attributes = [


### PR DESCRIPTION
Based on reported issues in #306 (with thanks to @flc1125 for raising it).

Given we are close to moving to package 1.1.x and dropping support of Laravel 6-9, then it may be preferable to restore the previous behaviour and allow the log messages through. This would keep the package viable for the older Laravel versions.

Unfortunately, there's no log level filtering at that point but I think it's better to handle this gracefully.

The approach in #306 could also provide a stable v1, while we look to tackle this more elegantly in future.