### PR TITLE
QA workflow jobs sorted alphabetically.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,3 @@
-
 name: PHP QA
 
 on:
@@ -19,28 +18,30 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        # Sorted alphabetically to ease finding the desired run in the GitHub Workflow UI.
         project: [
           'Aws',
           'Context/Swoole',
+          'Instrumentation/CakePHP',
+          'Instrumentation/CodeIgniter',
           'Instrumentation/ExtAmqp',
           'Instrumentation/ExtRdKafka',
           'Instrumentation/Guzzle',
           'Instrumentation/HttpAsyncClient',
-          'Instrumentation/Slim',
-          'Instrumentation/CakePHP',
+          'Instrumentation/IO',
+          'Instrumentation/Laravel',
+          'Instrumentation/MongoDB',
+          'Instrumentation/OpenAIPHP',
+          'Instrumentation/PDO',
+          # Sort PSRs numerically.
           'Instrumentation/Psr3',
           'Instrumentation/Psr6',
           'Instrumentation/Psr14',
           'Instrumentation/Psr15',
           'Instrumentation/Psr16',
           'Instrumentation/Psr18',
-          'Instrumentation/IO',
-          'Instrumentation/PDO',
+          'Instrumentation/Slim',
           'Instrumentation/Symfony',
-          'Instrumentation/OpenAIPHP',
-          'Instrumentation/Laravel',
-          'Instrumentation/MongoDB',
-          'Instrumentation/CodeIgniter',
           'Instrumentation/Yii',
           'Logs/Monolog',
           'Propagation/ServerTiming',
@@ -49,7 +50,7 @@ jobs:
           'ResourceDetectors/Container',
           'Sampler/RuleBased',
           'Shims/OpenTracing',
-          'Symfony'
+          'Symfony',
         ]
         exclude:
           - project: 'Instrumentation/Guzzle'


### PR DESCRIPTION
There's a lot of combinations in the QA workflow and it's (personally) nice to have a sensible order when looking through the GitHub UI. :nerd_face: 

Before:
![image](https://github.com/user-attachments/assets/9a922c86-1c06-4238-bfcf-a84b87980d4d)

After:
![image](https://github.com/user-attachments/assets/b4bf9689-c206-4ad0-8279-4270c1162043)
