### PR TITLE
cURL instrumentation: support partially successful curl_setopt_array

### DIFF
--- a/src/Instrumentation/Curl/src/CurlInstrumentation.php
+++ b/src/Instrumentation/Curl/src/CurlInstrumentation.php
@@ -82,6 +82,14 @@ class CurlInstrumentation
             pre: null,
             post: static function ($obj, array $params, mixed $retVal) use ($curlHandleToAttributes) {
                 if ($retVal != true) {
+                    if (curl_error($params[0])) {
+                        foreach ($params[1] as $option => $value) {
+                            if (!curl_setopt($params[0], $option, $value)) {
+                                break;
+                            }
+                        }
+                    }
+
                     return;
                 }
 

--- a/src/Instrumentation/Curl/tests/Integration/CurlInstrumentationTest.php
+++ b/src/Instrumentation/Curl/tests/Integration/CurlInstrumentationTest.php
@@ -96,6 +96,19 @@ class CurlInstrumentationTest extends TestCase
         $this->assertStringContainsString('resolve host', $span->getStatus()->getDescription());
     }
 
+    public function test_curl_setopt_array_partial_success(): void
+    {
+        $ch = curl_init();
+        curl_setopt_array($ch, [CURLOPT_POST => 1,  CURLOPT_URL => 'http://gugugaga.gugugaga/', CURLOPT_SSLVERSION => 1000 ]);
+        curl_exec($ch);
+
+        $this->assertCount(1, $this->storage);
+        $span = $this->storage->offsetGet(0);
+        $this->assertSame('POST', $span->getName());
+        $this->assertSame('Error', $span->getStatus()->getCode());
+        $this->assertStringContainsString('resolve host', $span->getStatus()->getDescription());
+    }
+
     public function test_curl_copy_handle(): void
     {
         $ch = curl_init('http://gugugaga.gugugaga/');


### PR DESCRIPTION
When `curl_setopt_array` is partially successful we end up not recording curl options which were set successfully.
In order to work around this, the fix tries to emulate the behaviour of how `curl_setopt_array` works, and iterates over the passed options using `curl_opt`, recording each valid one, until an invalid option is encountered (reference: https://github.com/php/php-src/blob/fb257ee83c405fecf449571bfcd1cc0fb4910336/ext/curl/interface.c#L2381).