### PR TITLE
Bump dependecies for WordPress example

### DIFF
--- a/examples/instrumentation/Wordpress/autoinstrumented-wordpress.dockerfile
+++ b/examples/instrumentation/Wordpress/autoinstrumented-wordpress.dockerfile
@@ -3,7 +3,7 @@ FROM composer:2.5 as build
 COPY composer.json ./
 RUN composer install --ignore-platform-reqs
 
-FROM wordpress:6.2
+FROM wordpress:6.7.1
 # Install the opentelemetry and protobuf extensions
 RUN pecl install opentelemetry protobuf
 COPY otel.php.ini $PHP_INI_DIR/conf.d/.

--- a/examples/instrumentation/Wordpress/compose.yaml
+++ b/examples/instrumentation/Wordpress/compose.yaml
@@ -45,9 +45,9 @@ services:
     image: otel/opentelemetry-collector-contrib:0.79.0
     volumes:
       - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
-  
+
   jaeger:
-    image: jaegertracing/all-in-one:1.46
+    image: jaegertracing/all-in-one
     ports:
       - 16686:16686
     environment:

--- a/examples/instrumentation/Wordpress/composer.json
+++ b/examples/instrumentation/Wordpress/composer.json
@@ -1,17 +1,17 @@
 {
-    "name": "opentelemetry/wordpress-example",
-    "description": "An example of autoinstrumentation of wordpress with the official wordpress docker image",
-    "type": "project",
-    "minimum-stability": "beta",
-    "require": {
-        "open-telemetry/opentelemetry-auto-wordpress": "^0.0.15",
-        "open-telemetry/sdk": "^1.0",
-        "open-telemetry/exporter-otlp": "^1.0",
-        "php-http/guzzle7-adapter": "^1.0"
-    },
-    "config": {
-        "allow-plugins": {
-            "php-http/discovery": true
-        }
-    }
+	"name": "opentelemetry/wordpress-example",
+	"description": "An example of autoinstrumentation of wordpress with the official wordpress docker image",
+	"type": "project",
+	"minimum-stability": "beta",
+	"require": {
+		"open-telemetry/opentelemetry-auto-wordpress": "^0.0.16",
+		"open-telemetry/sdk": "^1.1",
+		"open-telemetry/exporter-otlp": "^1.1",
+		"php-http/guzzle7-adapter": "^1.1"
+	},
+	"config": {
+		"allow-plugins": {
+			"php-http/discovery": true
+		}
+	}
 }


### PR DESCRIPTION
This pull request includes updates to the `examples/instrumentation/Wordpress` project to ensure compatibility with newer versions of dependencies and improve the setup process. The most important changes include updating the base images in the Dockerfile and `compose.yaml`, and updating the required versions of dependencies in `composer.json`.

Dependency updates:

* [`examples/instrumentation/Wordpress/autoinstrumented-wordpress.dockerfile`](diffhunk://#diff-665f2f23f3809b287422c8f30d280d4a1e0774bddc07c5c05df144e45859e81fL6-R6): Updated the base image from `wordpress:6.2` to `wordpress:6.7.1`.
* [`examples/instrumentation/Wordpress/composer.json`](diffhunk://#diff-dd60b62f57a41df15e93653e76b6cf300ff1265cd716fda22b1b65f9d008108dL7-R10): Updated the required versions of `open-telemetry/opentelemetry-auto-wordpress`, `open-telemetry/sdk`, `open-telemetry/exporter-otlp`, and `php-http/guzzle7-adapter` to their respective newer versions.

Configuration improvements:

* [`examples/instrumentation/Wordpress/compose.yaml`](diffhunk://#diff-a53eef8407767d2590fcc8e2830de321a5a131f26efe7873e80f625fac14be0aL50-R50): Removed the specific version tag from the `jaegertracing/all-in-one` image to always pull the latest version.