### PR TITLE
fix symfony breakages

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -124,6 +124,10 @@ jobs:
             php-version: 7.4
           - project: 'Sampler/RuleBased'
             php-version: 8.0
+          - project: 'Symfony'
+            php-version: 7.4
+          - project: 'Symfony'
+            php-version: 8.0
     steps:
     - uses: actions/checkout@v4
 

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -7,7 +7,7 @@
     ],
     "prefer-stable": true,
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "open-telemetry/api": "^1",
         "open-telemetry/context": "^1",
@@ -53,7 +53,6 @@
         "symfony/http-client": "^5.3",
         "symfony/http-kernel": "^4.4|^5.3|^6.0",
         "symfony/options-resolver": "^4.4|^5.3|^6.0",
-        "symfony/polyfill-php80": "^1.16",
         "symfony/proxy-manager-bridge": "^4.4|^5.3|^6.0",
         "symfony/yaml": "^4.4|^5.3|^6.0",
         "vimeo/psalm": "^5.0"

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -5,7 +5,6 @@
     "license": "Apache-2.0",
     "authors": [
     ],
-    "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
         "php": "^7.4 || ^8.0",
@@ -35,14 +34,14 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "google/protobuf": "^3.23",
         "guzzlehttp/guzzle": "^7.3",
-        "guzzlehttp/psr7": "^2.0@RC",
+        "guzzlehttp/psr7": "^2.0",
         "jangregor/phpstan-prophecy": "^1.0",
         "kriswallsmith/buzz": "^1.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.3",
         "mikey179/vfsstream": "^1.6",
         "nyholm/psr7": "^1.4",
         "open-telemetry/dev-tools": "dev-main",
-        "open-telemetry/sdk": "^1",
+        "open-telemetry/sdk": "^1.1",
         "phan/phan": "^4.1 || ^5",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^1.4",
@@ -76,8 +75,9 @@
         "sort-packages": true,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
+            "php-http/discovery": false,
             "symfony/runtime": true,
-            "php-http/discovery": false
+            "tbachert/spi": true
         }
     }
 }

--- a/src/Symfony/psalm.xml.dist
+++ b/src/Symfony/psalm.xml.dist
@@ -2,6 +2,8 @@
 <psalm
     errorLevel="3"
     cacheDirectory="var/cache/psalm"
+    findUnusedBaselineEntry="false"
+    findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">

--- a/src/Symfony/src/OtelBundle/composer.json
+++ b/src/Symfony/src/OtelBundle/composer.json
@@ -7,8 +7,8 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "composer-runtime-api": "^2.0",
-        "open-telemetry/api": "^0.0.14",
-        "open-telemetry/context": "^0.0.14",
+        "open-telemetry/api": "^1",
+        "open-telemetry/context": "^1",
         "open-telemetry/sem-conv": "^1.23",
         "symfony/config": "^4.4 || ^5.4 || ^6.1",
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.1"

--- a/src/Symfony/src/OtelSdkBundle/Debug/TraceableTracerProvider.php
+++ b/src/Symfony/src/OtelSdkBundle/Debug/TraceableTracerProvider.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Debug;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DataCollector\OtelDataCollector;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
+use OpenTelemetry\SDK\Common\InstrumentationScope\Configurator;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 
 /** @phan-file-suppress PhanUndeclaredInterface */
@@ -39,5 +40,9 @@ class TraceableTracerProvider implements TracerProviderInterface
     public function getTracer(string $name, ?string $version = null, ?string $schemaUrl = null, iterable $attributes = []): TracerInterface
     {
         return $this->tracerProvider->getTracer($name, $version, $schemaUrl, $attributes);
+    }
+
+    public function updateConfigurator(Configurator $configurator): void
+    {
     }
 }

--- a/src/Symfony/src/OtelSdkBundle/Resources/config/sdk.php
+++ b/src/Symfony/src/OtelSdkBundle/Resources/config/sdk.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Resources;
 
 use OpenTelemetry\API;
+use OpenTelemetry\API\Common\Time\SystemClock;
 use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Ids;
 use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Parameters;
 use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ConfigHelper;
@@ -12,7 +13,6 @@ use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServicesConfiguratorHelper;
 use OpenTelemetry\SDK;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
-use OpenTelemetry\SDK\Common\Time\SystemClock;
 use OpenTelemetry\SDK\Resource;
 use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Sampler;

--- a/src/Symfony/src/OtelSdkBundle/composer.json
+++ b/src/Symfony/src/OtelSdkBundle/composer.json
@@ -10,17 +10,17 @@
             "homepage": "https://github.com/open-telemetry/opentelemetry-php-contrib/graphs/contributors"
         }
     ],
-    "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4 || ^8.0",
-        "open-telemetry/sdk-contrib": "self.version",
-        "open-telemetry/sdk": "self.version",
+        "php": "^8.1",
+        "open-telemetry/sdk": "^1.1",
+        "open-telemetry/exporter-otlp": "^1.0",
+        "open-telemetry/exporter-zipkin": "^1.0",
+        "open-telemetry/transport-grpc": "^1.0",
         "php-http/message": "^1.12",
         "php-http/discovery": "^1.14",
         "symfony/config": "^4.4|^5.3|^6.0",
         "symfony/options-resolver": "^4.4|^5.3|^6.0",
-        "symfony/polyfill-php80": "^1.16",
         "symfony/dependency-injection": "^4.4|^5.3|^6.0"
     },
     "autoload": {

--- a/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/OtelSdkExtensionTest.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/DependencyInjection/OtelSdkExtensionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\DependencyInjection;
 
 use Exception;
+use OpenTelemetry\API\Common\Time\SystemClock;
 use OpenTelemetry\Contrib\Otlp\SpanExporterFactory as OtlpExporterFactory;
 use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
 use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Parameters;
@@ -15,7 +16,6 @@ use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use OpenTelemetry\Contrib\Zipkin\SpanExporterFactory as ZipkinSpanExporterFactory;
 use OpenTelemetry\SDK;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
-use OpenTelemetry\SDK\Common\Time\SystemClock;
 use OpenTelemetry\SDK\Trace\SpanProcessor;
 use OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock;
 use OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory as MockSpanExporterFactory;

--- a/src/Symfony/tests/Integration/OtelSdkBundle/Resources/SdkConfigTest.php
+++ b/src/Symfony/tests/Integration/OtelSdkBundle/Resources/SdkConfigTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Contrib\Symfony\Integration\OtelSdkBundle\Resources;
 
 use Exception;
+use OpenTelemetry\API\Common\Time\SystemClock;
 use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
 use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\DependencyInjection\Parameters;
 use OpenTelemetry\Contrib\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
-use OpenTelemetry\SDK\Common\Time\SystemClock;
 use OpenTelemetry\SDK\Resource;
 use OpenTelemetry\SDK\Trace;
 use OpenTelemetry\SDK\Trace\Sampler;


### PR DESCRIPTION
* update TraceableTracerProvider to support SDK 1.1.0+ (add updateConfigurator method).
* update sdk dependency to 1.1 (which drops PHP 7.4+8.0 support)
* update SystemClock refs from sdk to api
* update psalm config
* use stable versions

This makes the build green again.

Fixes: https://github.com/open-telemetry/opentelemetry-php/issues/1461