### PR TITLE
Add db statements to linked spans

### DIFF
--- a/src/Instrumentation/PDO/README.md
+++ b/src/Instrumentation/PDO/README.md
@@ -23,3 +23,14 @@ The extension can be disabled via [runtime configuration](https://opentelemetry.
 ```shell
 OTEL_PHP_DISABLED_INSTRUMENTATIONS=pdo
 ```
+                     
+In case UI used to view telemetry data does not support links between spans (for example newrelic),
+you can optionally enable setting db statements attribute to `fetchAll` and `execute` spans using 
+configuration directive:
+```
+otel.instrumentation.pdo.distribute_statement_to_linked_spans = true
+```
+or environment variable:
+```shell
+OTEL_PHP_INSTRUMENTATION_PDO_DISTRIBUTE_STATEMENT_TO_LINKED_SPANS=true
+```


### PR DESCRIPTION
This PR introduces a new feature to the PDO auto instrumentation that enhances the observability of database queries, specifically for clients that do not support linked spans (e.g., New Relic).

Changes:
- Added a new environment variable (`OTEL_PHP_INSTRUMENTATION_PDO_DISTRIBUTE_STATEMENT_TO_LINKED_SPANS`) and cfg variable (`otel.instrumentation.pdo.distribute_statement_to_linked_spans`).
- When enabled (true), the database statement is included in linked spans (so statement is set not only in `PDO::prepare` but also in `PDOStatement::execute` and `PDOStatement::fetchAll`). **It will result in more data being sent, be aware that it might generate additional cost.** It is disabled by default.
- This allows clients like New Relic to display the full query in the span spans that are actually taking the longest.