### PR TITLE
PHP 8.4 - Fixes for implicit nullability deprecation

### DIFF
--- a/src/Instrumentation/ExtRdKafka/tests/Integration/ExtRdKafkaInstrumentationTest.php
+++ b/src/Instrumentation/ExtRdKafka/tests/Integration/ExtRdKafkaInstrumentationTest.php
@@ -136,7 +136,7 @@ class ExtRdKafkaInstrumentationTest extends TestCase
     private function produceMessage(
         string $message,
         ?string $key = null,
-        array $headers = null,
+        ?array $headers = null,
         bool $produceWithoutHeaders = false
     ): void {
         $conf = new Conf();
@@ -163,7 +163,7 @@ class ExtRdKafkaInstrumentationTest extends TestCase
     {
         $conf = new Conf();
 
-        $conf->setRebalanceCb(function (KafkaConsumer $kafka, $err, array $partitions = null) {
+        $conf->setRebalanceCb(function (KafkaConsumer $kafka, $err, ?array $partitions = null) {
             switch ($err) {
                 case RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS:
                     $kafka->assign($partitions);

--- a/src/Instrumentation/HttpAsyncClient/tests/Integration/HttpAsyncClientInstrumentationTest.php
+++ b/src/Instrumentation/HttpAsyncClient/tests/Integration/HttpAsyncClientInstrumentationTest.php
@@ -94,7 +94,7 @@ class HttpAsyncClientInstrumentationTest extends TestCase
                 $this->response = $response;
             }
 
-            public function then(callable $onFulfilled = null, callable $onRejected = null): Promise
+            public function then(?callable $onFulfilled = null, ?callable $onRejected = null): Promise
             {
                 $this->onFulfilled = $onFulfilled;
                 $this->onRejected = $onRejected;

--- a/src/Instrumentation/MongoDB/src/MongoDBInstrumentation.php
+++ b/src/Instrumentation/MongoDB/src/MongoDBInstrumentation.php
@@ -14,7 +14,7 @@ final class MongoDBInstrumentation
     /**
      * @param callable(object):?string $commandSerializer
      */
-    public static function register(callable $commandSerializer = null): void
+    public static function register(?callable $commandSerializer = null): void
     {
         $instrumentation = new CachedInstrumentation(
             'io.opentelemetry.contrib.php.mongodb',

--- a/src/Symfony/tests/Unit/OtelSdkBundle/Factory/GenericFactoryTraitTest.php
+++ b/src/Symfony/tests/Unit/OtelSdkBundle/Factory/GenericFactoryTraitTest.php
@@ -395,7 +395,7 @@ class TestedDefaultNullClass
     private $fooBar;
     private $fooBaz;
 
-    public function __construct(string $fooBar, stdClass $fooBaz = null)
+    public function __construct(string $fooBar, ?stdClass $fooBaz = null)
     {
         $this->fooBar = $fooBar;
         $this->fooBaz = $fooBaz;


### PR DESCRIPTION
Error running on PHP 8.4:

```
OpenTelemetry\Contrib\Instrumentation\MongoDB\MongoDBInstrumentation::register(): Implicitly marking parameter $commandSerializer as nullable is deprecated, the explicit nullable type must be used instead
```

Fixes all issues that emit deprecation notices on PHP 8.4 for implicit nullable parameter type declarations. This requires PHP 7.1 (we currently require PHP >=7.4), so we are safe
 
See:
 
* [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
* [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

