### PR TITLE
[Laravel] Allow Laravel 12

### DIFF
--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -12,7 +12,7 @@
     "php": "^8.1",
     "ext-json": "*",
     "ext-opentelemetry": "*",
-    "laravel/framework": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
+    "laravel/framework": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
     "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.30"
   },


### PR DESCRIPTION
Allows Laravel 12 to be installed with `open-telemetry/opentelemetry-auto-laravel`