### PR TITLE
fix: resolve PDO WeakMap warning

### DIFF
--- a/src/Instrumentation/PDO/src/PDOTracker.php
+++ b/src/Instrumentation/PDO/src/PDOTracker.php
@@ -57,7 +57,8 @@ final class PDOTracker
             return [];
         }
 
-        return $this->pdoToAttributesMap[$pdo] ?: [];
+        /** @psalm-var array<non-empty-string, bool|int|float|string|array|null> */
+        return $this->pdoToAttributesMap[$pdo] ?? [];
     }
 
     /**
@@ -91,7 +92,8 @@ final class PDOTracker
      */
     public function trackedAttributesForPdo(PDO $pdo): array
     {
-        return $this->pdoToAttributesMap[$pdo] ?: [];
+        /** @psalm-var array<non-empty-string, bool|int|float|string|array|null> */
+        return $this->pdoToAttributesMap[$pdo] ?? [];
     }
 
     public function getSpanForPreparedStatement(PDOStatement $statement): ?SpanContextInterface


### PR DESCRIPTION
Replace comparison operators with null coalescing operator to fix undefined array error.

Fixes [#1529](https://github.com/open-telemetry/opentelemetry-php/issues/1529)