### PR TITLE
feat: track Eloquent ORM

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Database/Eloquent/Model.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Database/Eloquent/Model.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Database\Eloquent;
+
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHook;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHookTrait;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\PostHookTrait;
+use function OpenTelemetry\Instrumentation\hook;
+use OpenTelemetry\SemConv\TraceAttributes;
+use Throwable;
+
+class Model implements LaravelHook
+{
+    use LaravelHookTrait;
+    use PostHookTrait;
+
+    public function instrument(): void
+    {
+        $this->hookFind();
+        $this->hookPerformInsert();
+        $this->hookPerformUpdate();
+        $this->hookDelete();
+        $this->hookGetModels();
+        $this->hookDestroy();
+        $this->hookRefresh();
+    }
+
+    private function hookFind(): void
+    {
+        /** @psalm-suppress UnusedFunctionCall */
+        hook(
+            \Illuminate\Database\Eloquent\Builder::class,
+            'find',
+            pre: function ($builder, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+                $model = $builder->getModel();
+                $builder = $this->instrumentation
+                    ->tracer()
+                    ->spanBuilder($model::class . '::find')
+                    ->setSpanKind(SpanKind::KIND_INTERNAL)
+                    ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, $function)
+                    ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
+                    ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)
+                    ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno)
+                    ->setAttribute('laravel.eloquent.model', $model::class)
+                    ->setAttribute('laravel.eloquent.table', $model->getTable())
+                    ->setAttribute('laravel.eloquent.operation', 'find');
+
+                $parent = Context::getCurrent();
+                $span = $builder->startSpan();
+                Context::storage()->attach($span->storeInContext($parent));
+
+                return $params;
+            },
+            post: function ($builder, array $params, $result, ?Throwable $exception) {
+                $this->endSpan($exception);
+            }
+        );
+    }
+
+    private function hookPerformUpdate(): void
+    {
+        /** @psalm-suppress UnusedFunctionCall */
+        hook(
+            EloquentModel::class,
+            'performUpdate',
+            pre: function (EloquentModel $model, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+                $builder = $this->instrumentation
+                    ->tracer()
+                    ->spanBuilder($model::class . '::update')
+                    ->setSpanKind(SpanKind::KIND_INTERNAL)
+                    ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, $function)
+                    ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
+                    ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)
+                    ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno)
+                    ->setAttribute('laravel.eloquent.model', $model::class)
+                    ->setAttribute('laravel.eloquent.table', $model->getTable())
+                    ->setAttribute('laravel.eloquent.operation', 'update');
+
+                $parent = Context::getCurrent();
+                $span = $builder->startSpan();
+                Context::storage()->attach($span->storeInContext($parent));
+
+                return $params;
+            },
+            post: function (EloquentModel $model, array $params, $result, ?Throwable $exception) {
+                $this->endSpan($exception);
+            }
+        );
+    }
+
+    private function hookPerformInsert(): void
+    {
+        /** @psalm-suppress UnusedFunctionCall */
+        hook(
+            EloquentModel::class,
+            'performInsert',
+            pre: function (EloquentModel $model, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+                $builder = $this->instrumentation
+                    ->tracer()
+                    ->spanBuilder($model::class . '::create')
+                    ->setSpanKind(SpanKind::KIND_INTERNAL)
+                    ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, $function)
+                    ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
+                    ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)
+                    ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno)
+                    ->setAttribute('laravel.eloquent.model', $model::class)
+                    ->setAttribute('laravel.eloquent.table', $model->getTable())
+                    ->setAttribute('laravel.eloquent.operation', 'create');
+
+                $parent = Context::getCurrent();
+                $span = $builder->startSpan();
+                Context::storage()->attach($span->storeInContext($parent));
+
+                return $params;
+            },
+            post: function (EloquentModel $model, array $params, $result, ?Throwable $exception) {
+                $this->endSpan($exception);
+            }
+        );
+    }
+
+    private function hookDelete(): void
+    {
+        /** @psalm-suppress UnusedFunctionCall */
+        hook(
+            EloquentModel::class,
+            'delete',
+            pre: function (EloquentModel $model, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+                $builder = $this->instrumentation
+                    ->tracer()
+                    ->spanBuilder($model::class . '::delete')
+                    ->setSpanKind(SpanKind::KIND_INTERNAL)
+                    ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, $function)
+                    ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
+                    ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)
+                    ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno)
+                    ->setAttribute('laravel.eloquent.model', $model::class)
+                    ->setAttribute('laravel.eloquent.table', $model->getTable())
+                    ->setAttribute('laravel.eloquent.operation', 'delete');
+
+                $parent = Context::getCurrent();
+                $span = $builder->startSpan();
+                Context::storage()->attach($span->storeInContext($parent));
+
+                return $params;
+            },
+            post: function (EloquentModel $model, array $params, $result, ?Throwable $exception) {
+                $this->endSpan($exception);
+            }
+        );
+    }
+
+    private function hookGetModels(): void
+    {
+        /** @psalm-suppress UnusedFunctionCall */
+        hook(
+            \Illuminate\Database\Eloquent\Builder::class,
+            'getModels',
+            pre: function ($builder, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+                $model = $builder->getModel();
+                $builder = $this->instrumentation
+                    ->tracer()
+                    ->spanBuilder($model::class . '::get')
+                    ->setSpanKind(SpanKind::KIND_INTERNAL)
+                    ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, $function)
+                    ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
+                    ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)
+                    ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno)
+                    ->setAttribute('laravel.eloquent.model', $model::class)
+                    ->setAttribute('laravel.eloquent.table', $model->getTable())
+                    ->setAttribute('laravel.eloquent.operation', 'get')
+                    ->setAttribute('db.statement', $builder->getQuery()->toSql());
+
+                $parent = Context::getCurrent();
+                $span = $builder->startSpan();
+                Context::storage()->attach($span->storeInContext($parent));
+
+                return $params;
+            },
+            post: function ($builder, array $params, $result, ?Throwable $exception) {
+                $this->endSpan($exception);
+            }
+        );
+    }
+
+    private function hookDestroy(): void
+    {
+        /** @psalm-suppress UnusedFunctionCall */
+        hook(
+            EloquentModel::class,
+            'destroy',
+            pre: function ($model, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+                $builder = $this->instrumentation
+                    ->tracer()
+                    ->spanBuilder($model::class . '::destroy')
+                    ->setSpanKind(SpanKind::KIND_INTERNAL)
+                    ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, $function)
+                    ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
+                    ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)
+                    ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno)
+                    ->setAttribute('laravel.eloquent.model', $model::class)
+                    ->setAttribute('laravel.eloquent.table', $model->getTable())
+                    ->setAttribute('laravel.eloquent.operation', 'destroy');
+
+                $parent = Context::getCurrent();
+                $span = $builder->startSpan();
+                Context::storage()->attach($span->storeInContext($parent));
+
+                return $params;
+            },
+            post: function ($model, array $params, $result, ?Throwable $exception) {
+                $this->endSpan($exception);
+            }
+        );
+    }
+
+    private function hookRefresh(): void
+    {
+        /** @psalm-suppress UnusedFunctionCall */
+        hook(
+            EloquentModel::class,
+            'refresh',
+            pre: function (EloquentModel $model, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+                $builder = $this->instrumentation
+                    ->tracer()
+                    ->spanBuilder($model::class . '::refresh')
+                    ->setSpanKind(SpanKind::KIND_INTERNAL)
+                    ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, $function)
+                    ->setAttribute(TraceAttributes::CODE_NAMESPACE, $class)
+                    ->setAttribute(TraceAttributes::CODE_FILEPATH, $filename)
+                    ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno)
+                    ->setAttribute('laravel.eloquent.model', $model::class)
+                    ->setAttribute('laravel.eloquent.table', $model->getTable())
+                    ->setAttribute('laravel.eloquent.operation', 'refresh');
+
+                $parent = Context::getCurrent();
+                $span = $builder->startSpan();
+                Context::storage()->attach($span->storeInContext($parent));
+
+                return $params;
+            },
+            post: function (EloquentModel $model, array $params, $result, ?Throwable $exception) {
+                $this->endSpan($exception);
+            }
+        );
+    }
+}

--- a/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
@@ -29,6 +29,7 @@ class LaravelInstrumentation
         Hooks\Illuminate\Queue\SyncQueue::hook($instrumentation);
         Hooks\Illuminate\Queue\Queue::hook($instrumentation);
         Hooks\Illuminate\Queue\Worker::hook($instrumentation);
+        Hooks\Illuminate\Database\Eloquent\Model::hook($instrumentation);
     }
 
     public static function shouldTraceCli(): bool

--- a/src/Instrumentation/Laravel/tests/Fixtures/Models/TestModel.php
+++ b/src/Instrumentation/Laravel/tests/Fixtures/Models/TestModel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestModel extends Model
+{
+    protected $table = 'test_models';
+    protected $fillable = ['name'];
+}

--- a/src/Instrumentation/Laravel/tests/Fixtures/Models/TestModel.php
+++ b/src/Instrumentation/Laravel/tests/Fixtures/Models/TestModel.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @psalm-suppress UnusedClass
+ */
 class TestModel extends Model
 {
     protected $table = 'test_models';

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -87,16 +87,10 @@ class LaravelInstrumentationTest extends TestCase
     public function test_eloquent_operations(): void
     {
         /** @var class-string<\Illuminate\Database\Eloquent\Model> */
-        $modelClass = eval('
-            if (!class_exists("TestModel")) {
-                class TestModel extends \Illuminate\Database\Eloquent\Model
-                {
-                    protected $table = "test_models";
-                    protected $fillable = ["name"];
-                }
-            }
-            return TestModel::class;
-        ');
+        $model = new class() extends \Illuminate\Database\Eloquent\Model {
+            protected $table = 'test_models';
+            protected $fillable = ['name'];
+        };
 
         // Assert storage is empty before interacting with the database
         $this->assertCount(0, $this->storage);

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use OpenTelemetry\SemConv\TraceAttributes;
+use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel;
 
 /** @psalm-suppress UnusedClass */
 class LaravelInstrumentationTest extends TestCase
@@ -86,12 +87,6 @@ class LaravelInstrumentationTest extends TestCase
 
     public function test_eloquent_operations(): void
     {
-        /** @var class-string<\Illuminate\Database\Eloquent\Model> */
-        $model = new class() extends \Illuminate\Database\Eloquent\Model {
-            protected $table = 'test_models';
-            protected $fillable = ['name'];
-        };
-
         // Assert storage is empty before interacting with the database
         $this->assertCount(0, $this->storage);
 
@@ -103,16 +98,13 @@ class LaravelInstrumentationTest extends TestCase
             updated_at DATETIME
         )');
 
-        $this->router()->get('/eloquent', function () use ($modelClass) {
+        $this->router()->get('/eloquent', function () {
             try {
-                /** @var \Illuminate\Database\Eloquent\Model $model */
-                $model = new $modelClass();
-                
                 // Test create
-                $created = $modelClass::create(['name' => 'test']);
+                $created = TestModel::create(['name' => 'test']);
                 
                 // Test find
-                $found = $modelClass::find($created->id);
+                $found = TestModel::find($created->id);
                 
                 // Test update
                 $found->update(['name' => 'updated']);
@@ -161,8 +153,8 @@ class LaravelInstrumentationTest extends TestCase
         $createSpan = array_values(array_filter($eloquentSpans, function ($span) {
             return $span->getAttributes()->get('laravel.eloquent.operation') === 'create';
         }))[0];
-        $this->assertSame('TestModel::create', $createSpan->getName());
-        $this->assertSame('TestModel', $createSpan->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel::create', $createSpan->getName());
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $createSpan->getAttributes()->get('laravel.eloquent.model'));
         $this->assertSame('test_models', $createSpan->getAttributes()->get('laravel.eloquent.table'));
         $this->assertSame('create', $createSpan->getAttributes()->get('laravel.eloquent.operation'));
         
@@ -170,8 +162,8 @@ class LaravelInstrumentationTest extends TestCase
         $findSpan = array_values(array_filter($eloquentSpans, function ($span) {
             return $span->getAttributes()->get('laravel.eloquent.operation') === 'find';
         }))[0];
-        $this->assertSame('TestModel::find', $findSpan->getName());
-        $this->assertSame('TestModel', $findSpan->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel::find', $findSpan->getName());
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $findSpan->getAttributes()->get('laravel.eloquent.model'));
         $this->assertSame('test_models', $findSpan->getAttributes()->get('laravel.eloquent.table'));
         $this->assertSame('find', $findSpan->getAttributes()->get('laravel.eloquent.operation'));
         
@@ -179,8 +171,8 @@ class LaravelInstrumentationTest extends TestCase
         $updateSpan = array_values(array_filter($eloquentSpans, function ($span) {
             return $span->getAttributes()->get('laravel.eloquent.operation') === 'update';
         }))[0];
-        $this->assertSame('TestModel::update', $updateSpan->getName());
-        $this->assertSame('TestModel', $updateSpan->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel::update', $updateSpan->getName());
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $updateSpan->getAttributes()->get('laravel.eloquent.model'));
         $this->assertSame('test_models', $updateSpan->getAttributes()->get('laravel.eloquent.table'));
         $this->assertSame('update', $updateSpan->getAttributes()->get('laravel.eloquent.operation'));
         
@@ -188,8 +180,8 @@ class LaravelInstrumentationTest extends TestCase
         $deleteSpan = array_values(array_filter($eloquentSpans, function ($span) {
             return $span->getAttributes()->get('laravel.eloquent.operation') === 'delete';
         }))[0];
-        $this->assertSame('TestModel::delete', $deleteSpan->getName());
-        $this->assertSame('TestModel', $deleteSpan->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel::delete', $deleteSpan->getName());
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $deleteSpan->getAttributes()->get('laravel.eloquent.model'));
         $this->assertSame('test_models', $deleteSpan->getAttributes()->get('laravel.eloquent.table'));
         $this->assertSame('delete', $deleteSpan->getAttributes()->get('laravel.eloquent.operation'));
     }

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -13,6 +13,17 @@ use OpenTelemetry\SemConv\TraceAttributes;
 /** @psalm-suppress UnusedClass */
 class LaravelInstrumentationTest extends TestCase
 {
+    protected function getEnvironmentSetUp($app)
+    {
+        // Setup default database to use sqlite :memory:
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+
     public function test_request_response(): void
     {
         $this->router()->get('/', fn () => null);
@@ -71,6 +82,122 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertSame(9, $logRecord->getSeverityNumber());
         $this->assertArrayHasKey('context', $logRecord->getAttributes()->toArray());
         $this->assertSame(json_encode(['test' => true]), $logRecord->getAttributes()->toArray()['context']);
+    }
+
+    public function test_eloquent_operations(): void
+    {
+        /** @var class-string<\Illuminate\Database\Eloquent\Model> */
+        $modelClass = eval('
+            if (!class_exists("TestModel")) {
+                class TestModel extends \Illuminate\Database\Eloquent\Model
+                {
+                    protected $table = "test_models";
+                    protected $fillable = ["name"];
+                }
+            }
+            return TestModel::class;
+        ');
+
+        // Assert storage is empty before interacting with the database
+        $this->assertCount(0, $this->storage);
+
+        // Create the test_models table
+        DB::statement('CREATE TABLE IF NOT EXISTS test_models (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            created_at DATETIME,
+            updated_at DATETIME
+        )');
+
+        $this->router()->get('/eloquent', function () use ($modelClass) {
+            try {
+                /** @var \Illuminate\Database\Eloquent\Model $model */
+                $model = new $modelClass();
+                
+                // Test create
+                $created = $modelClass::create(['name' => 'test']);
+                
+                // Test find
+                $found = $modelClass::find($created->id);
+                
+                // Test update
+                $found->update(['name' => 'updated']);
+                
+                // Test delete
+                $found->delete();
+                
+                return response()->json(['status' => 'ok']);
+            } catch (\Exception $e) {
+                return response()->json([
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ], 500);
+            }
+        });
+
+        $response = $this->call('GET', '/eloquent');
+        if ($response->status() !== 200) {
+            $this->fail('Request failed: ' . $response->content());
+        }
+        $this->assertEquals(200, $response->status());
+        
+        // Verify spans for each Eloquent operation
+        /** @var array<int, \OpenTelemetry\SDK\Trace\ImmutableSpan> $spans */
+        $spans = array_values(array_filter(
+            iterator_to_array($this->storage),
+            fn ($item) => $item instanceof \OpenTelemetry\SDK\Trace\ImmutableSpan
+        ));
+        
+        // Filter out SQL spans and keep only Eloquent spans
+        $eloquentSpans = array_values(array_filter(
+            $spans,
+            fn ($span) => str_contains($span->getName(), '::')
+        ));
+        
+        // Sort spans by operation type to ensure consistent order
+        usort($eloquentSpans, function ($a, $b) {
+            $operations = ['create' => 0, 'find' => 1, 'update' => 2, 'delete' => 3];
+            $aOp = $a->getAttributes()->get('laravel.eloquent.operation');
+            $bOp = $b->getAttributes()->get('laravel.eloquent.operation');
+
+            return ($operations[$aOp] ?? 999) <=> ($operations[$bOp] ?? 999);
+        });
+        
+        // Create span
+        $createSpan = array_values(array_filter($eloquentSpans, function ($span) {
+            return $span->getAttributes()->get('laravel.eloquent.operation') === 'create';
+        }))[0];
+        $this->assertSame('TestModel::create', $createSpan->getName());
+        $this->assertSame('TestModel', $createSpan->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('test_models', $createSpan->getAttributes()->get('laravel.eloquent.table'));
+        $this->assertSame('create', $createSpan->getAttributes()->get('laravel.eloquent.operation'));
+        
+        // Find span
+        $findSpan = array_values(array_filter($eloquentSpans, function ($span) {
+            return $span->getAttributes()->get('laravel.eloquent.operation') === 'find';
+        }))[0];
+        $this->assertSame('TestModel::find', $findSpan->getName());
+        $this->assertSame('TestModel', $findSpan->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('test_models', $findSpan->getAttributes()->get('laravel.eloquent.table'));
+        $this->assertSame('find', $findSpan->getAttributes()->get('laravel.eloquent.operation'));
+        
+        // Update span
+        $updateSpan = array_values(array_filter($eloquentSpans, function ($span) {
+            return $span->getAttributes()->get('laravel.eloquent.operation') === 'update';
+        }))[0];
+        $this->assertSame('TestModel::update', $updateSpan->getName());
+        $this->assertSame('TestModel', $updateSpan->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('test_models', $updateSpan->getAttributes()->get('laravel.eloquent.table'));
+        $this->assertSame('update', $updateSpan->getAttributes()->get('laravel.eloquent.operation'));
+        
+        // Delete span
+        $deleteSpan = array_values(array_filter($eloquentSpans, function ($span) {
+            return $span->getAttributes()->get('laravel.eloquent.operation') === 'delete';
+        }))[0];
+        $this->assertSame('TestModel::delete', $deleteSpan->getName());
+        $this->assertSame('TestModel', $deleteSpan->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('test_models', $deleteSpan->getAttributes()->get('laravel.eloquent.table'));
+        $this->assertSame('delete', $deleteSpan->getAttributes()->get('laravel.eloquent.operation'));
     }
 
     public function test_low_cardinality_route_span_name(): void


### PR DESCRIPTION
This tracks the model interactions and allows a user to understand how the app interacts with the model classes.

It should be considered to to remove the event-based recording of SQL statements and fold them into this, or remove the sql bits completely and rely on the PDO instrumentation.