### PR TITLE
fix: allow switching php version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,11 @@
 services:
   php:
+    image: opentelemetry-php:local-${PHP_VERSION}-cli
     build:
       context: ./docker
       dockerfile: Dockerfile
       args:
-        - PHP_VERSION
+        - PHP_VERSION:${PHP_VERSION}
     volumes:
     - ./:/usr/src/myapp
     user: "${PHP_USER}:root"


### PR DESCRIPTION
This uses the PHP_VERSION variable to allow switching the php version.

Previously, the image was only built once and changing the variable would mandate rebuilding the image.

This change creates one local image per version.