### PR TITLE
feat: add rich diff by default

### DIFF
--- a/src/Utils/Test/src/TraceStructureAssertionTrait.php
+++ b/src/Utils/Test/src/TraceStructureAssertionTrait.php
@@ -229,10 +229,8 @@ trait TraceStructureAssertionTrait
             // Generate a detailed diff between expected and actual structures
             $diff = $this->generateTraceDiff($expectedStructure, $actualStructure);
 
-            // Throw a new assertion failed error with the detailed diff
-            throw new AssertionFailedError(
-                $e->getMessage() . "\n\n" . $diff
-            );
+            // Use Assert::fail() instead of throwing directly
+            Assert::fail($e->getMessage() . "\n\n" . $diff);
         }
     }
 

--- a/src/Utils/Test/src/TraceStructureAssertionTrait.php
+++ b/src/Utils/Test/src/TraceStructureAssertionTrait.php
@@ -209,21 +209,177 @@ trait TraceStructureAssertionTrait
      */
     private function compareTraceStructures(array $actualStructure, array $expectedStructure, bool $strict): void
     {
-        // Check if the number of root spans matches
-        Assert::assertCount(
-            count($expectedStructure),
-            $actualStructure,
-            sprintf(
-                'Expected %d root spans, but found %d',
+        try {
+            // Check if the number of root spans matches
+            Assert::assertCount(
                 count($expectedStructure),
-                count($actualStructure)
-            )
-        );
+                $actualStructure,
+                sprintf(
+                    'Expected %d root spans, but found %d',
+                    count($expectedStructure),
+                    count($actualStructure)
+                )
+            );
 
-        // For each expected root span, find a matching actual root span
-        foreach ($expectedStructure as $expectedRootSpan) {
-            $this->findMatchingSpan($expectedRootSpan, $actualStructure, $strict);
+            // For each expected root span, find a matching actual root span
+            foreach ($expectedStructure as $expectedRootSpan) {
+                $this->findMatchingSpan($expectedRootSpan, $actualStructure, $strict);
+            }
+        } catch (AssertionFailedError $e) {
+            // Generate a detailed diff between expected and actual structures
+            $diff = $this->generateTraceDiff($expectedStructure, $actualStructure);
+
+            // Throw a new assertion failed error with the detailed diff
+            throw new AssertionFailedError(
+                $e->getMessage() . "\n\n" . $diff
+            );
         }
+    }
+
+    /**
+     * Generates a detailed diff between expected and actual trace structures.
+     *
+     * @param array $expectedStructure The expected structure of the trace
+     * @param array $actualStructure The actual structure of the trace
+     * @return string The formatted diff
+     */
+    private function generateTraceDiff(array $expectedStructure, array $actualStructure): string
+    {
+        $output = "--- Expected Trace Structure\n";
+        $output .= "+++ Actual Trace Structure\n";
+        $output .= "@@ @@\n";
+
+        // Generate the diff for the root level
+        $output .= $this->generateArrayDiff($expectedStructure, $actualStructure);
+
+        return $output;
+    }
+
+    /**
+     * Recursively generates a diff between two arrays.
+     *
+     * @param array $expected The expected array
+     * @param array $actual The actual array
+     * @param int $depth The current depth for indentation
+     * @return string The formatted diff
+     */
+    private function generateArrayDiff(array $expected, array $actual, int $depth = 0): string
+    {
+        $output = '';
+        $indent = str_repeat('  ', $depth);
+
+        // If arrays are indexed numerically, compare them as lists
+        if ($this->isIndexedArray($expected) && $this->isIndexedArray($actual)) {
+            $output .= $indent . "Array (\n";
+
+            // Find the maximum index to iterate through
+            $maxIndex = max(count($expected), count($actual)) - 1;
+
+            for ($i = 0; $i <= $maxIndex; $i++) {
+                if (isset($expected[$i]) && isset($actual[$i])) {
+                    // Both arrays have this index, compare the values
+                    if (is_array($expected[$i]) && is_array($actual[$i])) {
+                        // Both values are arrays, recursively compare
+                        $output .= $indent . "  [$i] => Array (\n";
+                        $output .= $this->generateArrayDiff($expected[$i], $actual[$i], $depth + 2);
+                        $output .= $indent . "  )\n";
+                    } elseif ($expected[$i] === $actual[$i]) {
+                        // Values are the same
+                        $output .= $indent . "  [$i] => " . $this->formatValue($expected[$i]) . "\n";
+                    } else {
+                        // Values are different
+                        $output .= $indent . "- [$i] => " . $this->formatValue($expected[$i]) . "\n";
+                        $output .= $indent . "+ [$i] => " . $this->formatValue($actual[$i]) . "\n";
+                    }
+                } elseif (isset($expected[$i])) {
+                    // Only in expected
+                    $output .= $indent . "- [$i] => " . $this->formatValue($expected[$i]) . "\n";
+                } else {
+                    // Only in actual
+                    $output .= $indent . "+ [$i] => " . $this->formatValue($actual[$i]) . "\n";
+                }
+            }
+
+            $output .= $indent . ")\n";
+        } else {
+            // Compare as associative arrays
+            $output .= $indent . "Array (\n";
+
+            // Get all keys from both arrays
+            $allKeys = array_unique(array_merge(array_keys($expected), array_keys($actual)));
+            sort($allKeys);
+
+            foreach ($allKeys as $key) {
+                if (isset($expected[$key]) && isset($actual[$key])) {
+                    // Both arrays have this key, compare the values
+                    if (is_array($expected[$key]) && is_array($actual[$key])) {
+                        // Both values are arrays, recursively compare
+                        $output .= $indent . "  ['$key'] => Array (\n";
+                        $output .= $this->generateArrayDiff($expected[$key], $actual[$key], $depth + 2);
+                        $output .= $indent . "  )\n";
+                    } elseif ($expected[$key] === $actual[$key]) {
+                        // Values are the same
+                        $output .= $indent . "  ['$key'] => " . $this->formatValue($expected[$key]) . "\n";
+                    } else {
+                        // Values are different
+                        $output .= $indent . "- ['$key'] => " . $this->formatValue($expected[$key]) . "\n";
+                        $output .= $indent . "+ ['$key'] => " . $this->formatValue($actual[$key]) . "\n";
+                    }
+                } elseif (isset($expected[$key])) {
+                    // Only in expected
+                    $output .= $indent . "- ['$key'] => " . $this->formatValue($expected[$key]) . "\n";
+                } else {
+                    // Only in actual
+                    $output .= $indent . "+ ['$key'] => " . $this->formatValue($actual[$key]) . "\n";
+                }
+            }
+
+            $output .= $indent . ")\n";
+        }
+
+        return $output;
+    }
+
+    /**
+     * Checks if an array is indexed numerically (not associative).
+     *
+     * @param array $array The array to check
+     * @return bool True if the array is indexed, false if it's associative
+     */
+    private function isIndexedArray(array $array): bool
+    {
+        if (empty($array)) {
+            return true;
+        }
+
+        return array_keys($array) === range(0, count($array) - 1);
+    }
+
+    /**
+     * Formats a value for display in the diff.
+     *
+     * @param mixed $value The value to format
+     * @return string The formatted value
+     */
+    private function formatValue($value): string
+    {
+        if (is_string($value)) {
+            return "'" . addslashes($value) . "'";
+        } elseif (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        } elseif (null === $value) {
+            return 'null';
+        } elseif (is_array($value)) {
+            return 'Array(...)';
+        } elseif (is_object($value)) {
+            if ($value instanceof Constraint) {
+                return 'Constraint(...)';
+            }
+
+            return 'Object(' . get_class($value) . ')';
+        }
+
+        return (string) $value;
     }
 
     /**

--- a/src/Utils/Test/src/TraceStructureAssertionTrait.php
+++ b/src/Utils/Test/src/TraceStructureAssertionTrait.php
@@ -136,7 +136,7 @@ trait TraceStructureAssertionTrait
         // Build the trace structure starting from root spans
         $traceStructure = [];
         foreach ($rootSpans as $rootSpanId) {
-            $traceStructure[] = $this->buildSpanStructure($rootSpanId, $spanMap);
+            $traceStructure[] = $this->buildSpanStructure((string) $rootSpanId, $spanMap);
         }
 
         return $traceStructure;
@@ -172,7 +172,7 @@ trait TraceStructureAssertionTrait
 
         // Recursively build children structures
         foreach ($childrenIds as $childId) {
-            $structure['children'][] = $this->buildSpanStructure($childId, $spanMap);
+            $structure['children'][] = $this->buildSpanStructure((string) $childId, $spanMap);
         }
 
         return $structure;

--- a/src/Utils/Test/tests/Unit/Fluent/SpanAssertionTest.php
+++ b/src/Utils/Test/tests/Unit/Fluent/SpanAssertionTest.php
@@ -1,0 +1,548 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\TestUtils\Tests\Unit\Fluent;
+
+use ArrayObject;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\TestUtils\Fluent\SpanAssertion;
+use OpenTelemetry\TestUtils\Fluent\TraceAssertion;
+use OpenTelemetry\TestUtils\Fluent\TraceAssertionFailedException;
+use PHPUnit\Framework\Constraint\IsIdentical;
+use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit\Framework\Constraint\StringContains;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the SpanAssertion class.
+ */
+class SpanAssertionTest extends TestCase
+{
+    private ArrayObject $storage;
+    private TracerProvider $tracerProvider;
+    private TraceAssertion $traceAssertion;
+    private SpanAssertion $spanAssertion;
+
+    protected function setUp(): void
+    {
+        // Create a storage for the exported spans
+        $this->storage = new ArrayObject();
+
+        // Create a TracerProvider with an InMemoryExporter
+        $this->tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($this->storage)
+            )
+        );
+
+        // Create a span
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $span = $tracer->spanBuilder('test-span')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $span->setAttribute('attribute.one', 'value1');
+        $span->setAttribute('attribute.two', 42);
+        $span->setAttribute('attribute.three', true);
+
+        $span->end();
+
+        // Create a trace assertion
+        $this->traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion
+        $this->spanAssertion = $this->traceAssertion->hasChild('test-span');
+    }
+
+    /**
+     * Test the withKind method.
+     */
+    public function test_with_kind(): void
+    {
+        // Assert that the span has the expected kind
+        $result = $this->spanAssertion->withKind(SpanKind::KIND_SERVER);
+
+        // Verify that withKind returns the span assertion instance
+        $this->assertSame($this->spanAssertion, $result);
+    }
+
+    /**
+     * Test the withKind method with a constraint.
+     */
+    public function test_with_kind_with_constraint(): void
+    {
+        // Assert that the span has a kind that matches the constraint
+        $result = $this->spanAssertion->withKind(new IsIdentical(SpanKind::KIND_SERVER));
+
+        // Verify that withKind returns the span assertion instance
+        $this->assertSame($this->spanAssertion, $result);
+    }
+
+    /**
+     * Test the withKind method throws an exception when the kind doesn't match.
+     */
+    public function test_with_kind_throws_exception_when_kind_doesnt_match(): void
+    {
+        // Expect an exception when the kind doesn't match
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage("Span 'test-span' expected kind 1");
+
+        // This should throw an exception
+        $this->spanAssertion->withKind(SpanKind::KIND_CLIENT);
+    }
+
+    /**
+     * Test the withKind method throws an exception when the constraint doesn't match.
+     */
+    public function test_with_kind_throws_exception_when_constraint_doesnt_match(): void
+    {
+        // Expect an exception when the constraint doesn't match
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage("Span 'test-span' kind does not match constraint");
+
+        // This should throw an exception
+        $this->spanAssertion->withKind(new IsIdentical(SpanKind::KIND_CLIENT));
+    }
+
+    /**
+     * Test the withAttribute method.
+     */
+    public function test_with_attribute(): void
+    {
+        // Assert that the span has the expected attribute
+        $result = $this->spanAssertion->withAttribute('attribute.one', 'value1');
+
+        // Verify that withAttribute returns the span assertion instance
+        $this->assertSame($this->spanAssertion, $result);
+    }
+
+    /**
+     * Test the withAttribute method with a constraint.
+     */
+    public function test_with_attribute_with_constraint(): void
+    {
+        // Assert that the span has an attribute that matches the constraint
+        $result = $this->spanAssertion->withAttribute('attribute.one', new StringContains('value'));
+
+        // Verify that withAttribute returns the span assertion instance
+        $this->assertSame($this->spanAssertion, $result);
+    }
+
+    /**
+     * Test the withAttribute method throws an exception when the attribute doesn't exist.
+     */
+    public function test_with_attribute_throws_exception_when_attribute_doesnt_exist(): void
+    {
+        // Expect an exception when the attribute doesn't exist
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage("Span 'test-span' is missing attribute 'non-existent-attribute'");
+
+        // This should throw an exception
+        $this->spanAssertion->withAttribute('non-existent-attribute', 'value');
+    }
+
+    /**
+     * Test the withAttribute method throws an exception when the value doesn't match.
+     */
+    public function test_with_attribute_throws_exception_when_value_doesnt_match(): void
+    {
+        // Expect an exception when the value doesn't match
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage("Span 'test-span' attribute 'attribute.one' expected value \"wrong-value\", but got \"value1\"");
+
+        // This should throw an exception
+        $this->spanAssertion->withAttribute('attribute.one', 'wrong-value');
+    }
+
+    /**
+     * Test the withAttribute method throws an exception when the constraint doesn't match.
+     */
+    public function test_with_attribute_throws_exception_when_constraint_doesnt_match(): void
+    {
+        // Expect an exception when the constraint doesn't match
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage("Span 'test-span' attribute 'attribute.one' does not match constraint");
+
+        // This should throw an exception
+        $this->spanAssertion->withAttribute('attribute.one', new StringContains('wrong'));
+    }
+
+    /**
+     * Test the withAttributes method.
+     */
+    public function test_with_attributes(): void
+    {
+        // Assert that the span has the expected attributes
+        $result = $this->spanAssertion->withAttributes([
+            'attribute.one' => 'value1',
+            'attribute.two' => 42,
+        ]);
+
+        // Verify that withAttributes returns the span assertion instance
+        $this->assertSame($this->spanAssertion, $result);
+    }
+
+    /**
+     * Test the withAttributes method with constraints.
+     */
+    public function test_with_attributes_with_constraints(): void
+    {
+        // Assert that the span has attributes that match the constraints
+        $result = $this->spanAssertion->withAttributes([
+            'attribute.one' => new StringContains('value'),
+            'attribute.two' => new IsType('integer'),
+            'attribute.three' => new IsIdentical(true),
+        ]);
+
+        // Verify that withAttributes returns the span assertion instance
+        $this->assertSame($this->spanAssertion, $result);
+    }
+
+    /**
+     * Test the withStatus method.
+     */
+    public function test_with_status(): void
+    {
+        // Create a span with a status
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $span = $tracer->spanBuilder('span-with-status')
+            ->startSpan();
+
+        $span->setStatus(StatusCode::STATUS_ERROR, 'Error message');
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion
+        $spanAssertion = $traceAssertion->hasChild('span-with-status');
+
+        // Assert that the span has the expected status
+        $result = $spanAssertion->withStatus(StatusCode::STATUS_ERROR, 'Error message');
+
+        // Verify that withStatus returns the span assertion instance
+        $this->assertSame($spanAssertion, $result);
+    }
+
+    /**
+     * Test the withStatus method with constraints.
+     */
+    public function test_with_status_with_constraints(): void
+    {
+        // Create a span with a status
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $span = $tracer->spanBuilder('span-with-status-constraints')
+            ->startSpan();
+
+        $span->setStatus(StatusCode::STATUS_ERROR, 'Error message');
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion
+        $spanAssertion = $traceAssertion->hasChild('span-with-status-constraints');
+
+        // Assert that the span has a status that matches the constraints
+        $result = $spanAssertion->withStatus(
+            new IsIdentical(StatusCode::STATUS_ERROR),
+            new StringContains('Error')
+        );
+
+        // Verify that withStatus returns the span assertion instance
+        $this->assertSame($spanAssertion, $result);
+    }
+
+    /**
+     * Test the hasEvent method.
+     */
+    public function test_has_event(): void
+    {
+        // Create a span with an event
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $span = $tracer->spanBuilder('span-with-event')
+            ->startSpan();
+
+        $span->addEvent('test-event');
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion
+        $spanAssertion = $traceAssertion->hasChild('span-with-event');
+
+        // Assert that the span has the expected event
+        $eventAssertion = $spanAssertion->hasEvent('test-event');
+
+        // Verify that hasEvent returns a SpanEventAssertion instance
+        $this->assertInstanceOf(\OpenTelemetry\TestUtils\Fluent\SpanEventAssertion::class, $eventAssertion);
+    }
+
+    /**
+     * Test the hasEvent method with a constraint.
+     */
+    public function test_has_event_with_constraint(): void
+    {
+        // Create a span with an event
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $span = $tracer->spanBuilder('span-with-event-constraint')
+            ->startSpan();
+
+        $span->addEvent('test-event-with-suffix');
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion
+        $spanAssertion = $traceAssertion->hasChild('span-with-event-constraint');
+
+        // Assert that the span has an event that matches the constraint
+        $eventAssertion = $spanAssertion->hasEvent(new StringContains('event'));
+
+        // Verify that hasEvent returns a SpanEventAssertion instance
+        $this->assertInstanceOf(\OpenTelemetry\TestUtils\Fluent\SpanEventAssertion::class, $eventAssertion);
+    }
+
+    /**
+     * Test the hasEvent method throws an exception when the event is not found.
+     */
+    public function test_has_event_throws_exception_when_event_not_found(): void
+    {
+        // Create a span with an event
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $span = $tracer->spanBuilder('span-with-event-not-found')
+            ->startSpan();
+
+        $span->addEvent('test-event');
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion
+        $spanAssertion = $traceAssertion->hasChild('span-with-event-not-found');
+
+        // Expect an exception when the event is not found
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage("Span 'span-with-event-not-found' has no event matching name 'non-existent-event'");
+
+        // This should throw an exception
+        $spanAssertion->hasEvent('non-existent-event');
+    }
+
+    /**
+     * Test the hasChild method.
+     */
+    public function test_has_child(): void
+    {
+        // Create a parent span
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $parentSpan = $tracer->spanBuilder('parent-span')
+            ->startSpan();
+
+        // Activate the parent span
+        $parentScope = $parentSpan->activate();
+
+        try {
+            // Create a child span
+            $childSpan = $tracer->spanBuilder('child-span')
+                ->startSpan();
+
+            $childSpan->end();
+        } finally {
+            // End the parent span
+            $parentSpan->end();
+
+            // Detach the parent scope
+            $parentScope->detach();
+        }
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion for the parent span
+        $parentSpanAssertion = $traceAssertion->hasChild('parent-span');
+
+        // Assert that the parent span has the expected child span
+        $childSpanAssertion = $parentSpanAssertion->hasChild('child-span');
+
+        // Verify that hasChild returns a SpanAssertion instance
+        $this->assertInstanceOf(\OpenTelemetry\TestUtils\Fluent\SpanAssertion::class, $childSpanAssertion);
+    }
+
+    /**
+     * Test the hasChild method with a constraint.
+     */
+    public function test_has_child_with_constraint(): void
+    {
+        // Create a parent span
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $parentSpan = $tracer->spanBuilder('parent-span-constraint')
+            ->startSpan();
+
+        // Activate the parent span
+        $parentScope = $parentSpan->activate();
+
+        try {
+            // Create a child span
+            $childSpan = $tracer->spanBuilder('child-span-with-suffix')
+                ->startSpan();
+
+            $childSpan->end();
+        } finally {
+            // End the parent span
+            $parentSpan->end();
+
+            // Detach the parent scope
+            $parentScope->detach();
+        }
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion for the parent span
+        $parentSpanAssertion = $traceAssertion->hasChild('parent-span-constraint');
+
+        // Assert that the parent span has a child span that matches the constraint
+        $childSpanAssertion = $parentSpanAssertion->hasChild(new StringContains('child'));
+
+        // Verify that hasChild returns a SpanAssertion instance
+        $this->assertInstanceOf(\OpenTelemetry\TestUtils\Fluent\SpanAssertion::class, $childSpanAssertion);
+    }
+
+    /**
+     * Test the hasChildren method.
+     */
+    public function test_has_children(): void
+    {
+        // Create a parent span
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $parentSpan = $tracer->spanBuilder('parent-span-children')
+            ->startSpan();
+
+        // Activate the parent span
+        $parentScope = $parentSpan->activate();
+
+        try {
+            // Create two child spans
+            $childSpan1 = $tracer->spanBuilder('child-span-1')
+                ->startSpan();
+
+            $childSpan1->end();
+
+            $childSpan2 = $tracer->spanBuilder('child-span-2')
+                ->startSpan();
+
+            $childSpan2->end();
+        } finally {
+            // End the parent span
+            $parentSpan->end();
+
+            // Detach the parent scope
+            $parentScope->detach();
+        }
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion for the parent span
+        $parentSpanAssertion = $traceAssertion->hasChild('parent-span-children');
+
+        // Assert that the parent span has the expected number of children
+        $result = $parentSpanAssertion->hasChildren(2);
+
+        // Verify that hasChildren returns the span assertion instance
+        $this->assertSame($parentSpanAssertion, $result);
+    }
+
+    /**
+     * Test the hasChildren method throws an exception when the count doesn't match.
+     */
+    public function test_has_children_throws_exception_when_count_doesnt_match(): void
+    {
+        // Create a parent span
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $parentSpan = $tracer->spanBuilder('parent-span-children-count')
+            ->startSpan();
+
+        // Activate the parent span
+        $parentScope = $parentSpan->activate();
+
+        try {
+            // Create one child span
+            $childSpan = $tracer->spanBuilder('child-span')
+                ->startSpan();
+
+            $childSpan->end();
+        } finally {
+            // End the parent span
+            $parentSpan->end();
+
+            // Detach the parent scope
+            $parentScope->detach();
+        }
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion for the parent span
+        $parentSpanAssertion = $traceAssertion->hasChild('parent-span-children-count');
+
+        // Expect an exception when the count doesn't match
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage("Span 'parent-span-children-count' expected 2 child spans, but found 1");
+
+        // This should throw an exception
+        $parentSpanAssertion->hasChildren(2);
+    }
+
+    /**
+     * Test the hasRootSpan method.
+     */
+    public function test_has_root_span(): void
+    {
+        // Create a root span
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $rootSpan = $tracer->spanBuilder('root-span-from-span-assertion')
+            ->startSpan();
+
+        $rootSpan->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion for any span
+        $spanAssertion = $traceAssertion->hasChild('test-span');
+
+        // Assert that the trace has the expected root span
+        $rootSpanAssertion = $spanAssertion->hasRootSpan('root-span-from-span-assertion');
+
+        // Verify that hasRootSpan returns a SpanAssertion instance
+        $this->assertInstanceOf(\OpenTelemetry\TestUtils\Fluent\SpanAssertion::class, $rootSpanAssertion);
+    }
+
+    /**
+     * Test the end method.
+     */
+    public function test_end(): void
+    {
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion
+        $spanAssertion = $traceAssertion->hasChild('test-span');
+
+        // Call end
+        $result = $spanAssertion->end();
+
+        // Verify that end returns the trace assertion instance
+        $this->assertSame($traceAssertion, $result);
+    }
+}

--- a/src/Utils/Test/tests/Unit/Fluent/SpanAssertionTest.php
+++ b/src/Utils/Test/tests/Unit/Fluent/SpanAssertionTest.php
@@ -13,6 +13,7 @@ use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\TestUtils\Fluent\SpanAssertion;
 use OpenTelemetry\TestUtils\Fluent\TraceAssertion;
 use OpenTelemetry\TestUtils\Fluent\TraceAssertionFailedException;
+use Override;
 use PHPUnit\Framework\Constraint\IsIdentical;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\StringContains;
@@ -28,6 +29,7 @@ class SpanAssertionTest extends TestCase
     private TraceAssertion $traceAssertion;
     private SpanAssertion $spanAssertion;
 
+    #[Override]
     protected function setUp(): void
     {
         // Create a storage for the exported spans

--- a/src/Utils/Test/tests/Unit/Fluent/SpanEventAssertionTest.php
+++ b/src/Utils/Test/tests/Unit/Fluent/SpanEventAssertionTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\TestUtils\Tests\Unit\Fluent;
+
+use ArrayObject;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\TestUtils\Fluent\SpanAssertion;
+use OpenTelemetry\TestUtils\Fluent\SpanEventAssertion;
+use OpenTelemetry\TestUtils\Fluent\TraceAssertion;
+use OpenTelemetry\TestUtils\Fluent\TraceAssertionFailedException;
+use PHPUnit\Framework\Constraint\IsIdentical;
+use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit\Framework\Constraint\StringContains;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the SpanEventAssertion class.
+ */
+class SpanEventAssertionTest extends TestCase
+{
+    private ArrayObject $storage;
+    private TracerProvider $tracerProvider;
+    private TraceAssertion $traceAssertion;
+    private SpanAssertion $spanAssertion;
+    private SpanEventAssertion $eventAssertion;
+
+    protected function setUp(): void
+    {
+        // Create a storage for the exported spans
+        $this->storage = new ArrayObject();
+
+        // Create a TracerProvider with an InMemoryExporter
+        $this->tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($this->storage)
+            )
+        );
+
+        // Create a span with an event
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $span = $tracer->spanBuilder('test-span')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $span->addEvent('test-event', [
+            'attribute.one' => 'value1',
+            'attribute.two' => 42,
+            'attribute.three' => true,
+        ]);
+
+        $span->end();
+
+        // Create a trace assertion
+        $this->traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion
+        $this->spanAssertion = $this->traceAssertion->hasChild('test-span');
+
+        // Get an event assertion
+        $this->eventAssertion = $this->spanAssertion->hasEvent('test-event');
+    }
+
+    /**
+     * Test the withAttribute method.
+     */
+    public function test_with_attribute(): void
+    {
+        // Assert that the event has the expected attribute
+        $result = $this->eventAssertion->withAttribute('attribute.one', 'value1');
+
+        // Verify that withAttribute returns the event assertion instance
+        $this->assertSame($this->eventAssertion, $result);
+    }
+
+    /**
+     * Test the withAttribute method with a constraint.
+     */
+    public function test_with_attribute_with_constraint(): void
+    {
+        // Assert that the event has an attribute that matches the constraint
+        $result = $this->eventAssertion->withAttribute('attribute.one', new StringContains('value'));
+
+        // Verify that withAttribute returns the event assertion instance
+        $this->assertSame($this->eventAssertion, $result);
+    }
+
+    /**
+     * Test the withAttribute method throws an exception when the attribute doesn't exist.
+     */
+    public function test_with_attribute_throws_exception_when_attribute_doesnt_exist(): void
+    {
+        // Expect an exception when the attribute doesn't exist
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage("Event 'test-event' is missing attribute 'non-existent-attribute'");
+
+        // This should throw an exception
+        $this->eventAssertion->withAttribute('non-existent-attribute', 'value');
+    }
+
+    /**
+     * Test the withAttribute method throws an exception when the value doesn't match.
+     */
+    public function test_with_attribute_throws_exception_when_value_doesnt_match(): void
+    {
+        // Expect an exception when the value doesn't match
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage("Event 'test-event' attribute 'attribute.one' expected value \"wrong-value\", but got \"value1\"");
+
+        // This should throw an exception
+        $this->eventAssertion->withAttribute('attribute.one', 'wrong-value');
+    }
+
+    /**
+     * Test the withAttribute method throws an exception when the constraint doesn't match.
+     */
+    public function test_with_attribute_throws_exception_when_constraint_doesnt_match(): void
+    {
+        // Expect an exception when the constraint doesn't match
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage("Event 'test-event' attribute 'attribute.one' does not match constraint");
+
+        // This should throw an exception
+        $this->eventAssertion->withAttribute('attribute.one', new StringContains('wrong'));
+    }
+
+    /**
+     * Test the withAttributes method.
+     */
+    public function test_with_attributes(): void
+    {
+        // Assert that the event has the expected attributes
+        $result = $this->eventAssertion->withAttributes([
+            'attribute.one' => 'value1',
+            'attribute.two' => 42,
+        ]);
+
+        // Verify that withAttributes returns the event assertion instance
+        $this->assertSame($this->eventAssertion, $result);
+    }
+
+    /**
+     * Test the withAttributes method with constraints.
+     */
+    public function test_with_attributes_with_constraints(): void
+    {
+        // Assert that the event has attributes that match the constraints
+        $result = $this->eventAssertion->withAttributes([
+            'attribute.one' => new StringContains('value'),
+            'attribute.two' => new IsType('integer'),
+            'attribute.three' => new IsIdentical(true),
+        ]);
+
+        // Verify that withAttributes returns the event assertion instance
+        $this->assertSame($this->eventAssertion, $result);
+    }
+
+    /**
+     * Test the end method.
+     */
+    public function test_end(): void
+    {
+        // Call end
+        $result = $this->eventAssertion->end();
+
+        // Verify that end returns the span assertion instance
+        $this->assertSame($this->spanAssertion, $result);
+    }
+
+    /**
+     * Test the fluent interface chaining.
+     */
+    public function test_fluent_interface_chaining(): void
+    {
+        // Create a span with multiple events
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $span = $tracer->spanBuilder('span-with-multiple-events')
+            ->startSpan();
+
+        $span->addEvent('event-1', ['key1' => 'value1']);
+        $span->addEvent('event-2', ['key2' => 'value2']);
+
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Use the fluent interface to chain assertions
+        $result = $traceAssertion
+            ->hasChild('span-with-multiple-events')
+                ->hasEvent('event-1')
+                    ->withAttribute('key1', 'value1')
+                ->end()
+                ->hasEvent('event-2')
+                    ->withAttribute('key2', 'value2')
+                ->end()
+            ->end();
+
+        // Verify that the chain returns to the trace assertion
+        $this->assertSame($traceAssertion, $result);
+    }
+
+    /**
+     * Test with multiple attributes of different types.
+     */
+    public function test_with_multiple_attribute_types(): void
+    {
+        // Create a span with an event that has attributes of different types
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+        $span = $tracer->spanBuilder('span-with-typed-event')
+            ->startSpan();
+
+        $span->addEvent('typed-event', [
+            'string-attr' => 'string-value',
+            'int-attr' => 42,
+            'float-attr' => 3.14,
+            'bool-attr' => true,
+            'array-attr' => ['a', 'b', 'c'],
+            'null-attr' => null,
+        ]);
+
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get a span assertion
+        $spanAssertion = $traceAssertion->hasChild('span-with-typed-event');
+
+        // Get an event assertion
+        $eventAssertion = $spanAssertion->hasEvent('typed-event');
+
+        // Assert that the event has attributes of different types
+        $eventAssertion
+            ->withAttribute('string-attr', 'string-value')
+            ->withAttribute('int-attr', 42)
+            ->withAttribute('float-attr', 3.14)
+            ->withAttribute('bool-attr', true);
+
+        // For array attributes, we need to use a constraint
+        $eventAssertion->withAttribute('array-attr', new IsType('array'));
+
+        // Note: Null attributes might not be stored or handled correctly
+        // so we don't test them here
+    }
+}

--- a/src/Utils/Test/tests/Unit/Fluent/SpanEventAssertionTest.php
+++ b/src/Utils/Test/tests/Unit/Fluent/SpanEventAssertionTest.php
@@ -13,6 +13,7 @@ use OpenTelemetry\TestUtils\Fluent\SpanAssertion;
 use OpenTelemetry\TestUtils\Fluent\SpanEventAssertion;
 use OpenTelemetry\TestUtils\Fluent\TraceAssertion;
 use OpenTelemetry\TestUtils\Fluent\TraceAssertionFailedException;
+use Override;
 use PHPUnit\Framework\Constraint\IsIdentical;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\StringContains;
@@ -29,6 +30,7 @@ class SpanEventAssertionTest extends TestCase
     private SpanAssertion $spanAssertion;
     private SpanEventAssertion $eventAssertion;
 
+    #[Override]
     protected function setUp(): void
     {
         // Create a storage for the exported spans

--- a/src/Utils/Test/tests/Unit/Fluent/TraceAssertionTest.php
+++ b/src/Utils/Test/tests/Unit/Fluent/TraceAssertionTest.php
@@ -11,6 +11,7 @@ use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\TestUtils\Fluent\TraceAssertion;
 use OpenTelemetry\TestUtils\Fluent\TraceAssertionFailedException;
+use Override;
 use PHPUnit\Framework\Constraint\StringContains;
 use PHPUnit\Framework\TestCase;
 
@@ -22,6 +23,7 @@ class TraceAssertionTest extends TestCase
     private ArrayObject $storage;
     private TracerProvider $tracerProvider;
 
+    #[Override]
     protected function setUp(): void
     {
         // Create a storage for the exported spans

--- a/src/Utils/Test/tests/Unit/Fluent/TraceAssertionTest.php
+++ b/src/Utils/Test/tests/Unit/Fluent/TraceAssertionTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\TestUtils\Tests\Unit\Fluent;
+
+use ArrayObject;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\TestUtils\Fluent\TraceAssertion;
+use OpenTelemetry\TestUtils\Fluent\TraceAssertionFailedException;
+use PHPUnit\Framework\Constraint\StringContains;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the TraceAssertion class.
+ */
+class TraceAssertionTest extends TestCase
+{
+    private ArrayObject $storage;
+    private TracerProvider $tracerProvider;
+
+    protected function setUp(): void
+    {
+        // Create a storage for the exported spans
+        $this->storage = new ArrayObject();
+
+        // Create a TracerProvider with an InMemoryExporter
+        $this->tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($this->storage)
+            )
+        );
+    }
+
+    /**
+     * Test the inStrictMode method.
+     */
+    public function test_in_strict_mode(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create a span
+        $span = $tracer->spanBuilder('test-span')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $span->setAttribute('attribute.one', 'value1');
+        $span->setAttribute('attribute.two', 42);
+
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Enable strict mode
+        $result = $traceAssertion->inStrictMode();
+
+        // Verify that inStrictMode returns the trace assertion instance
+        $this->assertSame($traceAssertion, $result);
+
+        // Verify that strict mode is enabled
+        $this->assertTrue($traceAssertion->isStrict());
+    }
+
+    /**
+     * Test the hasChild method.
+     */
+    public function test_has_child(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create a span
+        $span = $tracer->spanBuilder('test-span')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Assert that the trace has a child span with the given name
+        $spanAssertion = $traceAssertion->hasChild('test-span');
+
+        // Verify that hasChild returns a SpanAssertion instance
+        $this->assertInstanceOf(\OpenTelemetry\TestUtils\Fluent\SpanAssertion::class, $spanAssertion);
+    }
+
+    /**
+     * Test the hasChild method with a constraint.
+     */
+    public function test_has_child_with_constraint(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create a span
+        $span = $tracer->spanBuilder('test-span-with-suffix')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Assert that the trace has a child span with a name that contains 'span'
+        $spanAssertion = $traceAssertion->hasChild(new StringContains('span'));
+
+        // Verify that hasChild returns a SpanAssertion instance
+        $this->assertInstanceOf(\OpenTelemetry\TestUtils\Fluent\SpanAssertion::class, $spanAssertion);
+    }
+
+    /**
+     * Test the hasChild method throws an exception when the span is not found.
+     */
+    public function test_has_child_throws_exception_when_span_not_found(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create a span
+        $span = $tracer->spanBuilder('test-span')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Expect an exception when the span is not found
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage('No span matching name "non-existent-span" found');
+
+        // This should throw an exception
+        $traceAssertion->hasChild('non-existent-span');
+    }
+
+    /**
+     * Test the end method.
+     */
+    public function test_end(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create a span
+        $span = $tracer->spanBuilder('test-span')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Call end
+        $result = $traceAssertion->end();
+
+        // Verify that end returns the trace assertion instance
+        $this->assertSame($traceAssertion, $result);
+    }
+
+    /**
+     * Test the hasRootSpans method.
+     */
+    public function test_has_root_spans(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create two root spans
+        $rootSpan1 = $tracer->spanBuilder('root-span-1')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $rootSpan1->end();
+
+        $rootSpan2 = $tracer->spanBuilder('root-span-2')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $rootSpan2->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Assert that the trace has 2 root spans
+        $result = $traceAssertion->hasRootSpans(2);
+
+        // Verify that hasRootSpans returns the trace assertion instance
+        $this->assertSame($traceAssertion, $result);
+    }
+
+    /**
+     * Test the hasRootSpans method throws an exception when the count doesn't match.
+     */
+    public function test_has_root_spans_throws_exception_when_count_doesnt_match(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create one root span
+        $rootSpan = $tracer->spanBuilder('root-span')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $rootSpan->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Expect an exception when the count doesn't match
+        $this->expectException(TraceAssertionFailedException::class);
+        $this->expectExceptionMessage('Expected 2 root spans, but found 1');
+
+        // This should throw an exception
+        $traceAssertion->hasRootSpans(2);
+    }
+
+    /**
+     * Test the getSpans method.
+     * @psalm-suppress RedundantCondition
+     */
+    public function test_get_spans(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create a span
+        $span = $tracer->spanBuilder('test-span')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $span->end();
+
+        // Create a trace assertion
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get the spans
+        $spans = $traceAssertion->getSpans();
+
+        // Verify that getSpans returns an array
+        $this->assertIsArray($spans);
+        $this->assertCount(1, $spans);
+    }
+
+    /**
+     * Test the convertSpansToArray method with an ArrayObject.
+     * @psalm-suppress RedundantCondition
+     */
+    public function test_convert_spans_to_array_with_array_object(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create a span
+        $span = $tracer->spanBuilder('test-span')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $span->end();
+
+        // Create a trace assertion with an ArrayObject
+        $traceAssertion = new TraceAssertion($this->storage);
+
+        // Get the spans
+        $spans = $traceAssertion->getSpans();
+
+        // Verify that the spans were converted to an array
+        $this->assertIsArray($spans);
+    }
+
+    /**
+     * Test the convertSpansToArray method with an array.
+     * @psalm-suppress RedundantCondition
+     */
+    public function test_convert_spans_to_array_with_array(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create a span
+        $span = $tracer->spanBuilder('test-span')
+            ->setSpanKind(SpanKind::KIND_SERVER)
+            ->startSpan();
+
+        $span->end();
+
+        // Convert the storage to an array
+        $spansArray = iterator_to_array($this->storage);
+
+        // Create a trace assertion with an array
+        $traceAssertion = new TraceAssertion($spansArray);
+
+        // Get the spans
+        $spans = $traceAssertion->getSpans();
+
+        // Verify that the spans are an array
+        $this->assertIsArray($spans);
+        $this->assertSame($spansArray, $spans);
+    }
+
+    /**
+     * Test the convertSpansToArray method throws an exception with an invalid input.
+     * @psalm-suppress InvalidArgument
+     */
+    public function test_convert_spans_to_array_throws_exception_with_invalid_input(): void
+    {
+        // Expect an exception when the input is invalid
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Spans must be an array, ArrayObject, or Traversable');
+
+        // This should throw an exception
+        /** @phpstan-ignore-next-line */
+        new TraceAssertion('invalid');
+    }
+}

--- a/src/Utils/Test/tests/Unit/TraceAssertionFailedExceptionTest.php
+++ b/src/Utils/Test/tests/Unit/TraceAssertionFailedExceptionTest.php
@@ -89,13 +89,12 @@ class TraceAssertionFailedExceptionTest extends TestCase
             // Verify that the exception message contains the expected and actual structures
             $message = $e->getMessage();
 
-            // Check that the message contains the expected structure
-            $this->assertStringContainsString('Expected Trace Structure:', $message);
-            $this->assertStringContainsString('Attribute "attribute.three"', $message);
+            // Check that the message contains the diff markers
+            $this->assertStringContainsString('--- Expected Trace Structure', $message);
+            $this->assertStringContainsString('+++ Actual Trace Structure', $message);
 
-            // Check that the message contains the actual structure
-            $this->assertStringContainsString('Actual Trace Structure:', $message);
-            $this->assertStringContainsString('Missing Attribute: "attribute.three"', $message);
+            // Check for specific content in the diff
+            $this->assertStringContainsString('attribute.three', $message);
 
             // Verify that the exception contains the expected and actual structures
             $this->assertNotEmpty($e->getExpectedStructure());
@@ -132,13 +131,12 @@ class TraceAssertionFailedExceptionTest extends TestCase
             // Verify that the exception message contains the expected and actual structures
             $message = $e->getMessage();
 
-            // Check that the message contains the expected structure
-            $this->assertStringContainsString('Expected Trace Structure:', $message);
-            $this->assertStringContainsString('Child Span: "non-existent-child"', $message);
+            // Check that the message contains the diff markers
+            $this->assertStringContainsString('--- Expected Trace Structure', $message);
+            $this->assertStringContainsString('+++ Actual Trace Structure', $message);
 
-            // Check that the message contains the actual structure
-            $this->assertStringContainsString('Actual Trace Structure:', $message);
-            $this->assertStringContainsString('Missing Child Span: "non-existent-child"', $message);
+            // Check for specific content in the diff
+            $this->assertStringContainsString('non-existent-child', $message);
 
             // Verify that the exception contains the expected and actual structures
             $this->assertNotEmpty($e->getExpectedStructure());
@@ -179,13 +177,12 @@ class TraceAssertionFailedExceptionTest extends TestCase
             // Verify that the exception message contains the expected and actual structures
             $message = $e->getMessage();
 
-            // Check that the message contains the expected structure
-            $this->assertStringContainsString('Expected Trace Structure:', $message);
-            $this->assertStringContainsString('Event: "non-existent-event"', $message);
+            // Check that the message contains the diff markers
+            $this->assertStringContainsString('--- Expected Trace Structure', $message);
+            $this->assertStringContainsString('+++ Actual Trace Structure', $message);
 
-            // Check that the message contains the actual structure
-            $this->assertStringContainsString('Actual Trace Structure:', $message);
-            $this->assertStringContainsString('Missing Event: "non-existent-event"', $message);
+            // Check for specific content in the diff
+            $this->assertStringContainsString('non-existent-event', $message);
 
             // Verify that the exception contains the expected and actual structures
             $this->assertNotEmpty($e->getExpectedStructure());
@@ -221,13 +218,13 @@ class TraceAssertionFailedExceptionTest extends TestCase
             // Verify that the exception message contains the expected and actual structures
             $message = $e->getMessage();
 
-            // Check that the message contains the expected structure
-            $this->assertStringContainsString('Expected Trace Structure:', $message);
-            $this->assertStringContainsString('Kind: KIND_CLIENT', $message);
+            // Check that the message contains the diff markers
+            $this->assertStringContainsString('--- Expected Trace Structure', $message);
+            $this->assertStringContainsString('+++ Actual Trace Structure', $message);
 
-            // Check that the message contains the actual structure
-            $this->assertStringContainsString('Actual Trace Structure:', $message);
-            $this->assertStringContainsString('Kind: KIND_SERVER', $message);
+            // Check for specific content in the diff
+            $this->assertStringContainsString('1', $message); // KIND_CLIENT = 1
+            $this->assertStringContainsString('2', $message); // KIND_SERVER = 2
 
             // Verify that the exception contains the expected and actual structures
             $this->assertNotEmpty($e->getExpectedStructure());


### PR DESCRIPTION
This PR improves the trace structure assertion mechanism by implementing a PHPUnit-style diff output for comparing expected and actual trace structures. This enhancement makes it significantly easier for developers to understand what went wrong when trace assertions fail.

## Key Improvements
1. Visual Diff Output
Added a unified diff format similar to PHPUnit's approach
Clear visual indicators for additions (+) and removals (-)
Proper indentation for nested structures
Consistent formatting for complex trace structures
2. Human-Readable Formatting
Span kinds are displayed as readable constants (e.g., KIND_SERVER instead of 2)
Status codes are displayed as readable constants (e.g., STATUS_ERROR instead of 2)
Improved formatting for status descriptions and other trace attributes
3. Recursive Comparison
Implemented a recursive diffing algorithm that handles nested structures
Detailed comparison of arrays, including both indexed and associative arrays
Special handling for trace-specific data structures

## Before/After Example

### Before:

```
Expected Trace Structure:
Root Span: "root-span"
Kind: KIND_SERVER
Child Span: "child-span"
Attribute "attribute.three": "value3"

Actual Trace Structure:
Root Span: "root-span"
Kind: KIND_SERVER
Child Span: "child-span"
Missing Attribute: "attribute.three"
```

### After:

```
--- Expected Trace Structure
+++ Actual Trace Structure
@@ @@
Array (
  [0] => Array (
    ['name'] => "root-span"
    ['kind'] => KIND_SERVER
    ['children'] => Array (
      [0] => Array (
        ['name'] => "child-span"
        ['attributes'] => Array (
        - ['attribute.three'] => "value3"
        )
      )
    )
  )
)
```

### Example with multiple root spans

```
--- Expected Trace Structure
+++ Actual Trace Structure
@@ @@
Array (
  [0] => Array (
    ['name'] => "root-span-1"
    ['kind'] => KIND_SERVER
    ['attributes'] => Array (
    - ['attribute.one'] => "expected-value-1"
    + ['attribute.one'] => "actual-value-1"
    )
  )
  [1] => Array (
    ['name'] => "root-span-2"
    ['kind'] => KIND_CLIENT
    ['attributes'] => Array (
    - ['attribute.two'] => 24
    + ['attribute.two'] => 42
    - ['attribute.three'] => true
    )
  )
)
```