### PR TITLE
fix: matching will be strict

### DIFF
--- a/src/Utils/Test/src/TraceStructureAssertionTrait.php
+++ b/src/Utils/Test/src/TraceStructureAssertionTrait.php
@@ -451,7 +451,12 @@ trait TraceStructureAssertionTrait
                 // If we get here, the span and its children match
                 return;
             } catch (AssertionFailedError $e) {
-                // This span didn't match, try the next one
+                // If the error is about an unexpected field in the status, rethrow it
+                if (strpos($e->getMessage(), 'Unexpected field') !== false) {
+                    throw $e;
+                }
+
+                // Otherwise, this span didn't match, try the next one
                 continue;
             }
         }
@@ -653,32 +658,43 @@ trait TraceStructureAssertionTrait
     /**
      * Compares the status of an expected span with the status of an actual span.
      *
-     * @param array $expectedStatus
-     * @param array $actualStatus
-     * @param bool $strict
-     * @param string $spanName
+     * @param mixed $expectedStatus The expected status (multiple formats supported)
+     * @param array $actualStatus The actual status
+     * @param bool $strict Whether to perform strict matching
+     * @param string $spanName The name of the span being compared
      * @throws AssertionFailedError
      * @return void
      */
-    private function compareStatus(array $expectedStatus, array $actualStatus, bool $strict, string $spanName): void
+    private function compareStatus($expectedStatus, array $actualStatus, bool $strict, string $spanName): void
     {
-        // In strict mode, verify that all fields in expected status are also in actual status
-        if ($strict) {
-            // Check if code is specified in expected status
-            if (!isset($expectedStatus['code']) && $actualStatus['code'] !== 0) {
-                Assert::fail(sprintf('Actual status has non-default code but expected status does not specify code for span "%s"', $spanName));
-            }
+        // Case 1: Constraint directly on status code
+        if ($this->isConstraint($expectedStatus)) {
+            Assert::assertThat(
+                $actualStatus['code'],
+                $expectedStatus,
+                sprintf('Status code does not match constraint for span "%s"', $spanName)
+            );
 
-            // Check if description is specified in expected status
-            if (!isset($expectedStatus['description']) && $actualStatus['description'] !== '') {
-                Assert::fail(sprintf('Actual status has description but expected status does not specify description for span "%s"', $spanName));
-            }
+            return;
         }
 
-        // Compare status code if specified
-        if (isset($expectedStatus['code'])) {
-            $expectedCode = $expectedStatus['code'];
+        // Case 2: Scalar value (direct status code comparison)
+        if (is_scalar($expectedStatus)) {
+            Assert::assertSame(
+                $expectedStatus,
+                $actualStatus['code'],
+                sprintf('Status code does not match for span "%s"', $spanName)
+            );
 
+            return;
+        }
+
+        // Case 3: Simple indexed array [code, description]
+        if (is_array($expectedStatus) && array_keys($expectedStatus) === [0, 1] && count($expectedStatus) === 2) {
+            $expectedCode = $expectedStatus[0];
+            $expectedDescription = $expectedStatus[1];
+
+            // Compare code
             if ($this->isConstraint($expectedCode)) {
                 Assert::assertThat(
                     $actualStatus['code'],
@@ -692,12 +708,8 @@ trait TraceStructureAssertionTrait
                     sprintf('Status code does not match for span "%s"', $spanName)
                 );
             }
-        }
 
-        // Compare status description if specified
-        if (isset($expectedStatus['description'])) {
-            $expectedDescription = $expectedStatus['description'];
-
+            // Compare description
             if ($this->isConstraint($expectedDescription)) {
                 Assert::assertThat(
                     $actualStatus['description'],
@@ -710,6 +722,69 @@ trait TraceStructureAssertionTrait
                     $actualStatus['description'],
                     sprintf('Status description does not match for span "%s"', $spanName)
                 );
+            }
+
+            return;
+        }
+
+        // Case 4: Traditional associative array with keys
+        if (is_array($expectedStatus)) {
+            // In strict mode, verify that the expected status doesn't have unexpected fields
+            if ($strict) {
+                // Check for unexpected fields in expected status
+                foreach (array_keys($expectedStatus) as $key) {
+                    if (!in_array($key, ['code', 'description'])) {
+                        Assert::fail(sprintf('Unexpected field "%s" in expected status for span "%s"', $key, $spanName));
+                    }
+                }
+
+                // Check if code is specified in expected status
+                if (!isset($expectedStatus['code']) && $actualStatus['code'] !== 0) {
+                    Assert::fail(sprintf('Actual status has non-default code but expected status does not specify code for span "%s"', $spanName));
+                }
+
+                // Check if description is specified in expected status
+                if (!isset($expectedStatus['description']) && $actualStatus['description'] !== '') {
+                    Assert::fail(sprintf('Actual status has description but expected status does not specify description for span "%s"', $spanName));
+                }
+            }
+
+            // Compare status code if specified
+            if (isset($expectedStatus['code'])) {
+                $expectedCode = $expectedStatus['code'];
+
+                if ($this->isConstraint($expectedCode)) {
+                    Assert::assertThat(
+                        $actualStatus['code'],
+                        $expectedCode,
+                        sprintf('Status code does not match constraint for span "%s"', $spanName)
+                    );
+                } else {
+                    Assert::assertSame(
+                        $expectedCode,
+                        $actualStatus['code'],
+                        sprintf('Status code does not match for span "%s"', $spanName)
+                    );
+                }
+            }
+
+            // Compare status description if specified
+            if (isset($expectedStatus['description'])) {
+                $expectedDescription = $expectedStatus['description'];
+
+                if ($this->isConstraint($expectedDescription)) {
+                    Assert::assertThat(
+                        $actualStatus['description'],
+                        $expectedDescription,
+                        sprintf('Status description does not match constraint for span "%s"', $spanName)
+                    );
+                } else {
+                    Assert::assertSame(
+                        $expectedDescription,
+                        $actualStatus['description'],
+                        sprintf('Status description does not match for span "%s"', $spanName)
+                    );
+                }
             }
         }
     }

--- a/src/Utils/Test/src/TraceStructureAssertionTrait.php
+++ b/src/Utils/Test/src/TraceStructureAssertionTrait.php
@@ -584,17 +584,12 @@ trait TraceStructureAssertionTrait
     private function compareAttributes(array $expectedAttributes, array $actualAttributes, bool $strict, string $spanName): void
     {
         foreach ($expectedAttributes as $key => $expectedValue) {
-            // In strict mode, all attributes must be present and match
-            if ($strict) {
-                Assert::assertArrayHasKey(
-                    $key,
-                    $actualAttributes,
-                    sprintf('Attribute "%s" not found in span "%s"', $key, $spanName)
-                );
-            } elseif (!isset($actualAttributes[$key])) {
-                // In non-strict mode, if the attribute is not present, skip it
-                continue;
-            }
+            // Both in strict and non-strict mode, all expected attributes must be present
+            Assert::assertArrayHasKey(
+                $key,
+                $actualAttributes,
+                sprintf('Attribute "%s" not found in span "%s"', $key, $spanName)
+            );
 
             // Get the actual value
             $actualValue = $actualAttributes[$key];

--- a/src/Utils/Test/tests/Unit/TraceStructureAssertionTraitTest.php
+++ b/src/Utils/Test/tests/Unit/TraceStructureAssertionTraitTest.php
@@ -198,17 +198,45 @@ class TraceStructureAssertionTraitTest extends TestCase
                     'attribute.two' => 42,
                     'attribute.three' => true,
                 ],
-                'events' => [], // Empty events array
-                'children' => [], // Empty children array
                 'status' => [
-                    'code' => 'Unset', // Default status code
-                    'description' => '', // Default status description
+                    'code' => StatusCode::STATUS_UNSET, // Default status code
+                    'description' => '', // Correct field name
                 ],
             ],
         ];
 
         // Assert the trace structure with strict matching (should pass)
         $this->assertTraceStructure($this->storage, $expectedStructureStrict, true);
+    }
+
+    /**
+     * Test that strict mode fails when status has an unexpected field.
+     */
+    public function test_assert_fails_with_unexpected_status_field_in_strict_mode(): void
+    {
+        $tracer = $this->tracerProvider->getTracer('test-tracer');
+
+        // Create a span with default status
+        $span = $tracer->spanBuilder('test-span')
+            ->startSpan();
+        $span->end();
+
+        // Define expected structure with a typo in the status field name
+        $expectedStructure = [
+            [
+                'name' => 'test-span',
+                'status' => [
+                    'code' => StatusCode::STATUS_UNSET,
+                    'descriptions' => '', // Typo: should be 'description'
+                ],
+            ],
+        ];
+
+        // Expect assertion to fail in strict mode due to unexpected field
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->expectExceptionMessage('Unexpected field "descriptions" in expected status');
+
+        $this->assertTraceStructure($this->storage, $expectedStructure, true);
     }
 
     /**
@@ -968,6 +996,214 @@ class TraceStructureAssertionTraitTest extends TestCase
         ];
 
         // Assert the trace structure with matchers
+        $this->assertTraceStructure($storage, $expectedStructure);
+    }
+
+    /**
+     * Test asserting a trace structure with status as a constraint.
+     */
+    public function test_assert_trace_structure_with_status_as_constraint(): void
+    {
+        // Create a new test setup
+        $storage = new ArrayObject();
+        $tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($storage)
+            )
+        );
+
+        $tracer = $tracerProvider->getTracer('test-tracer');
+
+        // Create a span with default status (UNSET)
+        $span = $tracer->spanBuilder('default-status-span')
+            ->startSpan();
+        $span->end();
+
+        // Test Format 1: Constraint directly on status code
+        $expectedStructure = [
+            [
+                'name' => 'default-status-span',
+                'status' => new IsIdentical(StatusCode::STATUS_UNSET),
+            ],
+        ];
+        $this->assertTraceStructure($storage, $expectedStructure);
+    }
+
+    /**
+     * Test asserting a trace structure with status as a scalar value.
+     */
+    public function test_assert_trace_structure_with_status_as_scalar(): void
+    {
+        // Create a new test setup
+        $storage = new ArrayObject();
+        $tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($storage)
+            )
+        );
+
+        $tracer = $tracerProvider->getTracer('test-tracer');
+
+        // Create a span with error status
+        $span = $tracer->spanBuilder('error-status-span')
+            ->startSpan();
+        $span->setStatus(StatusCode::STATUS_ERROR, 'Something went wrong');
+        $span->end();
+
+        // Test Format 2: Scalar value (direct status code comparison)
+        $expectedStructure = [
+            [
+                'name' => 'error-status-span',
+                'status' => StatusCode::STATUS_ERROR,
+            ],
+        ];
+        $this->assertTraceStructure($storage, $expectedStructure);
+    }
+
+    /**
+     * Test asserting a trace structure with status as an indexed array.
+     */
+    public function test_assert_trace_structure_with_status_as_indexed_array(): void
+    {
+        // Create a new test setup
+        $storage = new ArrayObject();
+        $tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($storage)
+            )
+        );
+
+        $tracer = $tracerProvider->getTracer('test-tracer');
+
+        // Create a span with error status
+        $span = $tracer->spanBuilder('error-status-span')
+            ->startSpan();
+        $span->setStatus(StatusCode::STATUS_ERROR, 'Something went wrong');
+        $span->end();
+
+        // Test Format 3: Simple indexed array [code, description]
+        $expectedStructure = [
+            [
+                'name' => 'error-status-span',
+                'status' => [StatusCode::STATUS_ERROR, 'Something went wrong'],
+            ],
+        ];
+        $this->assertTraceStructure($storage, $expectedStructure);
+    }
+
+    /**
+     * Test asserting a trace structure with status as an indexed array with constraint.
+     */
+    public function test_assert_trace_structure_with_status_as_indexed_array_with_constraint(): void
+    {
+        // Create a new test setup
+        $storage = new ArrayObject();
+        $tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($storage)
+            )
+        );
+
+        $tracer = $tracerProvider->getTracer('test-tracer');
+
+        // Create a span with error status
+        $span = $tracer->spanBuilder('error-status-span')
+            ->startSpan();
+        $span->setStatus(StatusCode::STATUS_ERROR, 'Something went wrong');
+        $span->end();
+
+        // Test Format 3 with constraint for description
+        $expectedStructure = [
+            [
+                'name' => 'error-status-span',
+                'status' => [StatusCode::STATUS_ERROR, new StringContains('went wrong')],
+            ],
+        ];
+        $this->assertTraceStructure($storage, $expectedStructure);
+    }
+
+    /**
+     * Test asserting a trace structure with status as an associative array.
+     */
+    public function test_assert_trace_structure_with_status_as_associative_array(): void
+    {
+        // Create a new test setup
+        $storage = new ArrayObject();
+        $tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($storage)
+            )
+        );
+
+        $tracer = $tracerProvider->getTracer('test-tracer');
+
+        // Create a span with OK status
+        $span = $tracer->spanBuilder('ok-status-span')
+            ->startSpan();
+        $span->setStatus(StatusCode::STATUS_OK, '');
+        $span->end();
+
+        // Test Format 4: Traditional associative array with keys
+        $expectedStructure = [
+            [
+                'name' => 'ok-status-span',
+                'status' => [
+                    'code' => StatusCode::STATUS_OK,
+                    'description' => '',
+                ],
+            ],
+        ];
+        $this->assertTraceStructure($storage, $expectedStructure);
+    }
+
+    /**
+     * Test asserting a trace structure with multiple spans and different status formats.
+     */
+    public function test_assert_trace_structure_with_multiple_spans_and_status_formats(): void
+    {
+        // Create a new test setup
+        $storage = new ArrayObject();
+        $tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($storage)
+            )
+        );
+
+        $tracer = $tracerProvider->getTracer('test-tracer');
+
+        // Create spans with different status codes
+        // Span 1: Default status (UNSET)
+        $defaultSpan = $tracer->spanBuilder('default-status-span')
+            ->startSpan();
+        $defaultSpan->end();
+
+        // Span 2: Error status with description
+        $errorSpan = $tracer->spanBuilder('error-status-span')
+            ->startSpan();
+        $errorSpan->setStatus(StatusCode::STATUS_ERROR, 'Something went wrong');
+        $errorSpan->end();
+
+        // Span 3: OK status
+        $okSpan = $tracer->spanBuilder('ok-status-span')
+            ->startSpan();
+        $okSpan->setStatus(StatusCode::STATUS_OK, '');
+        $okSpan->end();
+
+        // Test multiple spans with different status formats in one assertion
+        $expectedStructure = [
+            [
+                'name' => 'default-status-span',
+                'status' => new IsIdentical(StatusCode::STATUS_UNSET),
+            ],
+            [
+                'name' => 'error-status-span',
+                'status' => [StatusCode::STATUS_ERROR, new StringContains('went wrong')],
+            ],
+            [
+                'name' => 'ok-status-span',
+                'status' => StatusCode::STATUS_OK,
+            ],
+        ];
         $this->assertTraceStructure($storage, $expectedStructure);
     }
 }


### PR DESCRIPTION
This changes the behavior with the strict parameter:

* by default, all attributes must match
* with the strict parameter, the assertion will do an exhaustive check on _all_ attributes in the actual, not just the expected attributes, making it more suitable for integration tests