### PR TITLE
support mongodb 2.0

### DIFF
--- a/src/Instrumentation/MongoDB/composer.json
+++ b/src/Instrumentation/MongoDB/composer.json
@@ -8,9 +8,9 @@
   "license": "Apache-2.0",
   "require": {
     "php": ">=8.1",
-    "ext-mongodb": "^1.13",
+    "ext-mongodb": "^1.13 | ^2.0",
     "ext-json": "*",
-    "mongodb/mongodb": "^1.15",
+    "mongodb/mongodb": "^1.15 || ^2.0",
     "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.30"
   },

--- a/src/Instrumentation/MongoDB/src/MongoDBInstrumentationSubscriber.php
+++ b/src/Instrumentation/MongoDB/src/MongoDBInstrumentationSubscriber.php
@@ -60,7 +60,7 @@ final class MongoDBInstrumentationSubscriber implements CommandSubscriber, SDAMS
 
     /**
      * @psalm-suppress MixedAssignment,MixedArrayTypeCoercion,MixedArrayOffset,MixedArgument
-     * @phan-suppress PhanDeprecatedFunctionInternal
+     * @phan-suppress PhanDeprecatedFunctionInternal,PhanUndeclaredMethod
      */
     public function commandStarted(CommandStartedEvent $event): void
     {


### PR DESCRIPTION
update composer to allow mongodb 2.0, and add an extra phan suppression for the now-removed CommandStartedEvent.getServer