### PR TITLE
Fixes for PHPUnit errors in the Curl instrumentation library

### DIFF
--- a/src/Instrumentation/Curl/src/CurlInstrumentation.php
+++ b/src/Instrumentation/Curl/src/CurlInstrumentation.php
@@ -35,7 +35,7 @@ class CurlInstrumentation
          *                         'handles'=>
          *                              WeakMap[CurlHandle] => {
          *                                  'finished' => bool,
-         *                                  'span' => WeakReference<SpanInterface>
+         *                                  'span' => SpanInterface
          *                              }
          *                      )
          */
@@ -327,7 +327,7 @@ class CurlInstrumentation
                             }
                             $curlSetOptInstrumentationSuppressed = false;
 
-                            $metadata['span'] = WeakReference::create($span);
+                            $metadata['span'] = $span;
                         }
                         $mHandle['started'] = true;
                     }
@@ -339,7 +339,7 @@ class CurlInstrumentation
                         foreach ($handles as $cHandle => &$metadata) {
                             if ($metadata['finished'] == false) {
                                 $metadata['finished'] = true;
-                                self::finishMultiSpan(CURLE_OK, $cHandle, $curlHandleToAttributes, $metadata['span']?->get()); // there is no way to get information if it was OK or not without calling curl_multi_info_read
+                                self::finishMultiSpan(CURLE_OK, $cHandle, $curlHandleToAttributes, $metadata['span']); // there is no way to get information if it was OK or not without calling curl_multi_info_read
                             }
                         }
 
@@ -379,7 +379,7 @@ class CurlInstrumentation
 
                         /** @psalm-suppress PossiblyNullArrayAccess */
                         $currentHandle['finished'] = true;
-                        self::finishMultiSpan($retVal['result'], $retVal['handle'], $curlHandleToAttributes, $currentHandle['span']?->get());
+                        self::finishMultiSpan($retVal['result'], $retVal['handle'], $curlHandleToAttributes, $currentHandle['span']);
                     }
                 }
             }

--- a/src/Instrumentation/Curl/src/CurlInstrumentation.php
+++ b/src/Instrumentation/Curl/src/CurlInstrumentation.php
@@ -18,7 +18,6 @@ use OpenTelemetry\SDK\Common\Configuration\Configuration;
 use OpenTelemetry\SemConv\TraceAttributes;
 use OpenTelemetry\SemConv\Version;
 use WeakMap;
-use WeakReference;
 
 class CurlInstrumentation
 {

--- a/src/Instrumentation/OpenAIPHP/src/OpenAIPHPInstrumentation.php
+++ b/src/Instrumentation/OpenAIPHP/src/OpenAIPHPInstrumentation.php
@@ -193,7 +193,7 @@ final class OpenAIPHPInstrumentation
 
     private static function recordUsage(SpanInterface $span, object $response, ContextInterface $context)
     {
-        if (!property_exists($response, 'usage') || !method_exists($response->usage, 'toArray')) {
+        if (!property_exists($response, 'usage') || !isset($response->usage) || !method_exists($response->usage, 'toArray')) {
             return;
         }
 

--- a/src/Instrumentation/OpenAIPHP/src/OpenAIPHPInstrumentation.php
+++ b/src/Instrumentation/OpenAIPHP/src/OpenAIPHPInstrumentation.php
@@ -193,7 +193,7 @@ final class OpenAIPHPInstrumentation
 
     private static function recordUsage(SpanInterface $span, object $response, ContextInterface $context)
     {
-        if (!property_exists($response, 'usage') || !isset($response->usage) || !method_exists($response->usage, 'toArray')) {
+        if (!property_exists($response, 'usage') || !method_exists($response->usage, 'toArray')) {
             return;
         }
 


### PR DESCRIPTION
### Curl

There are intermittent PHPUnit errors in the Instrumentation/Curl library for the `curl_multi` integration tests stating the asserted span count is 1 instead of 2. Tracking it down, the WeakReference the for the cURL handle sub-span was sometimes being destroyed too early, causing `finishMultiSpan()` to bail, the scope to never detach, and the span to never be added to storage. I believe it is due to:

> The original object will be destroyed when the refcount for it drops to zero; creating weak references does not increase the refcount of the object being referenced. [ref](https://www.php.net/manual/en/class.weakreference.php)

Changing the sub-span to be directly assigned to the `handles` WeakMap resolves the test failures. `make all` passes with this change, but I do not know if there are other consequences.

cc @intuibase

_Edit: split OpenAIPHP component to #375_