### PR TITLE
Fix for PHPUnit error in the OpenAIPHP instrumentation library

### DIFF
--- a/src/Instrumentation/OpenAIPHP/src/OpenAIPHPInstrumentation.php
+++ b/src/Instrumentation/OpenAIPHP/src/OpenAIPHPInstrumentation.php
@@ -193,7 +193,7 @@ final class OpenAIPHPInstrumentation
 
     private static function recordUsage(SpanInterface $span, object $response, ContextInterface $context)
     {
-        if (!property_exists($response, 'usage') || !method_exists($response->usage, 'toArray')) {
+        if (!property_exists($response, 'usage') || !isset($response->usage) || !method_exists($response->usage, 'toArray')) {
             return;
         }
 


### PR DESCRIPTION
split of #371

### OpenAIPHP

There is a PHPUnit error in the Instrumentation/OpenAIPHP library for the `openai_operation` (images) integration tests stating `method_exists` is being passed a null value. `OpenAI\Responses\Images\CreateResponse`defines a nullable `$usage` property, so in the instrumentation library's `recordUsage()`, I believe it is due to:

> As opposed with isset(), property_exists() returns true even if the property has the value null. [ref](https://www.php.net/manual/en/function.property-exists.php)

Adding an additional test to the conditional in `recordUsage()` resolves the test failure. `make all` passes with this change, but I do not know if there are other consequences.

cc @cedricziel @brettmc @agoallikmaa 