### PR TITLE
[ReactPHP] Add user-option for redacting query parameters

### DIFF
--- a/src/Instrumentation/ReactPHP/README.md
+++ b/src/Instrumentation/ReactPHP/README.md
@@ -29,10 +29,16 @@ The extension can be disabled via [runtime configuration](https://opentelemetry.
 OTEL_PHP_DISABLED_INSTRUMENTATIONS=reactphp
 ```
 
-Custom HTTP methods can replace the known methods via environment variables, e.g.:
+Custom HTTP methods can replace the known methods via an environment variable, e.g.:
 
 ```shell
 OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS="GET,HEAD,POST,PUT,DELETE,CONNECT,OPTIONS,TRACE,PATCH,MyCustomMethod"
+```
+
+Additional HTTP query string parameters can be redacted via an environment variable, e.g.,
+
+```shell
+OTEL_PHP_INSTRUMENTATION_URL_SANITIZE_FIELD_NAMES="password,passwd,pwd,secret"
 ```
 
 Request and/or response headers can be added as span attributes via environment variables, e.g.:

--- a/src/Instrumentation/ReactPHP/phpunit.xml.dist
+++ b/src/Instrumentation/ReactPHP/phpunit.xml.dist
@@ -32,6 +32,7 @@
         <env name="OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS" value="GET,HEAD,POST,PUT,DELETE,CONNECT,OPTIONS,TRACE,PATCH,CUSTOM" />
         <env name="OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS" value="traceparent" />
         <env name="OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS" value="Content-Type" />
+        <env name="OTEL_PHP_INSTRUMENTATION_URL_SANITIZE_FIELD_NAMES" value="password,passwd,pwd,secret" />
         <ini name="date.timezone" value="UTC" />
         <ini name="display_errors" value="On" />
         <ini name="display_startup_errors" value="On" />

--- a/src/Instrumentation/ReactPHP/src/ReactPHPInstrumentation.php
+++ b/src/Instrumentation/ReactPHP/src/ReactPHPInstrumentation.php
@@ -55,6 +55,15 @@ class ReactPHPInstrumentation
      */
     private const ENV_HTTP_RESPONSE_HEADERS = 'OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS';
     /**
+     * The environment variable which adds to the URL query parameter keys to redact the values for.
+     * This supports a comma-separated list of case-sensitive known HTTP methods.
+     *
+     * Note that this is not currently defined in OTel SemConv, and therefore subject to change.
+     *
+     * @see https://github.com/open-telemetry/semantic-conventions/issues/877
+     */
+    private const ENV_URL_SANITIZE_FIELD_NAMES = 'OTEL_PHP_INSTRUMENTATION_URL_SANITIZE_FIELD_NAMES';
+    /**
      * The `{method}` component of the span name when the original method is not known to the instrumentation.
      *
      * @see https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name
@@ -259,6 +268,12 @@ class ReactPHPInstrumentation
             $uri = $uri->withUserInfo(self::URL_REDACTION);
         }
 
+        $sanitizeFields = self::URL_QUERY_REDACT_KEYS;
+        $customFields = $_ENV[self::ENV_URL_SANITIZE_FIELD_NAMES] ?? '';
+        if (!empty($customFields)) {
+            $sanitizeFields = array_merge($sanitizeFields, explode(',', $customFields));
+        }
+
         $queryString = $uri->getQuery();
         // http_build_query(parse_str()) is not idempotent, so using Guzzle’s Query class for now
         if ($queryString !== '') {
@@ -267,7 +282,7 @@ class ReactPHPInstrumentation
                 $queryParameters,
                 array_intersect_key(
                     array_fill_keys(
-                        self::URL_QUERY_REDACT_KEYS,
+                        $sanitizeFields,
                         self::URL_REDACTION
                     ),
                     $queryParameters

--- a/src/Instrumentation/ReactPHP/tests/Integration/ReactPHPInstrumentationTest.php
+++ b/src/Instrumentation/ReactPHP/tests/Integration/ReactPHPInstrumentationTest.php
@@ -111,7 +111,7 @@ class ReactPHPInstrumentationTest extends TestCase
         $this->assertSame(['text/plain; charset=utf-8'], $span->getAttributes()->get(sprintf('%s.%s', TraceAttributes::HTTP_RESPONSE_HEADER, 'content-type')));
     }
 
-    public function test_fulfilled_promise_with_redactions(): void
+    public function test_fulfilled_promise_with_required_redactions(): void
     {
         $this->browser->request('GET', 'http://username@example.com/success')->then();
 
@@ -122,6 +122,14 @@ class ReactPHPInstrumentationTest extends TestCase
 
         $span = $this->storage->offsetGet(1);
         $this->assertSame('http://REDACTED:REDACTED@example.com/success?Signature=REDACTED', $span->getAttributes()->get(TraceAttributes::URL_FULL));
+    }
+
+    public function test_fulfilled_promise_with_custom_redactions(): void
+    {
+        $this->browser->request('GET', 'http://example.com/success?password=private')->then();
+
+        $span = $this->storage->offsetGet(0);
+        $this->assertSame('http://example.com/success?password=REDACTED', $span->getAttributes()->get(TraceAttributes::URL_FULL));
     }
 
     public function test_fulfilled_promise_with_overridden_methods(): void


### PR DESCRIPTION
Related to the general issue tracked in https://github.com/open-telemetry/semantic-conventions/issues/877

There have been related PRs for OpenTelemetry Semantic Conventions in an attempt to define this, but it seems they were too broad to gain consensus. However, I have not seen any comments contrary to the specific feature implemented by this PR, exemplified here:

> For users who want to change the default behavior, OpenTelemetry should provide a consistent way instead of let the user struggle in a jungle of 20+ instrumentation libraries where each have different ways of doing redaction. [ref](https://github.com/open-telemetry/semantic-conventions/pull/961#issuecomment-2079761854)

and here:

>> we discussed the idea of having generalized SDK capabilities for redaction, is this still something we want? If so I am happy to work towards a proposal for that.
> 
> I'd definitely answer that with a yes. Users might want to have redaction capabilities they can use for data that doesn't conform to OTel semantic conventions. [ref](https://github.com/open-telemetry/semantic-conventions/pull/971#issuecomment-2082811589)

Since that has not yet come to fruition, but these is still a need, I propose implementing this PR for at a minimum this PHP auto-instrumentation library, with the goal of aligning the mechanism with what SemConv decides in the future.

Note that this PR does not allow for overriding the required query keys defined in footnote 6 here: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/url.md#url-query but allows the user of this library to add additional keys to the redaction list.

Slack conversation specifically for this PR: https://cloud-native.slack.com/archives/C01NFPCV44V/p1748367527296729