### PR TITLE
[ReactPHP] Add required HTTP Client Metric

### DIFF
--- a/src/Instrumentation/ReactPHP/README.md
+++ b/src/Instrumentation/ReactPHP/README.md
@@ -9,17 +9,22 @@ This is a read-only subtree split of https://github.com/open-telemetry/opentelem
 
 # OpenTelemetry ReactPHP HTTP Browser auto-instrumentation
 
+This is an OpenTelemetry auto-instrumentation package for the [ReactPHP HTTP library](https://reactphp.org/http/). Currently only the Browser (client) component is instrumented.
+
 Please read https://opentelemetry.io/docs/instrumentation/php/automatic/ for instructions on how to
 install and configure the extension and SDK.
 
 ## Overview
 
-Auto-instrumentation hooks are registered via composer, which will:
+This library is provides the following:
 
-* create spans automatically for each ReactPHP HTTP Browser request that is sent
-* add a `traceparent` header to the request to facilitate distributed tracing
+- OpenTelemetry Semantic Conventions v1.32.0:
+    - [HTTP Client Spans](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span) - required and HTTP header (opt-in) attributes only
+    - [HTTP Client Metrics](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#http-client) - required attributes only
+- W3C Trace Context:
+    - [Trace Context HTTP Request Headers](https://www.w3.org/TR/trace-context/#trace-context-http-headers-format)
 
-Note that span lifetime behavior differs based on how ReactPHP is utilized; see [examples/README.md](examples/README.md) for more information.
+> [!NOTE] HTTP Client Span lifetime behavior differs based on how ReactPHP is utilized; see [examples/README.md](examples/README.md) for more information.
 
 ## Configuration
 

--- a/src/Instrumentation/ReactPHP/README.md
+++ b/src/Instrumentation/ReactPHP/README.md
@@ -24,7 +24,8 @@ This library is provides the following:
 - W3C Trace Context:
     - [Trace Context HTTP Request Headers](https://www.w3.org/TR/trace-context/#trace-context-http-headers-format)
 
-> [!NOTE] HTTP Client Span lifetime behavior differs based on how ReactPHP is utilized; see [examples/README.md](examples/README.md) for more information.
+> [!NOTE]
+> HTTP Client Span lifetime behavior differs based on how ReactPHP is utilized; see [examples/README.md](examples/README.md) for more information.
 
 ## Configuration
 

--- a/src/Instrumentation/ReactPHP/src/ReactPHPInstrumentation.php
+++ b/src/Instrumentation/ReactPHP/src/ReactPHPInstrumentation.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Contrib\Instrumentation\ReactPHP;
 
 use Composer\InstalledVersions;
 use GuzzleHttp\Psr7\Query;
+use OpenTelemetry\API\Common\Time\Clock;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Trace\Span;
@@ -102,24 +103,28 @@ class ReactPHPInstrumentation
                     $request = $request->withoutHeader($field);
                 }
 
-                /** @var non-empty-string|null */
-                $method = self::canonizeMethod($request->getMethod());
+                /** @psalm-var array{'http.request.method':non-empty-string|null,'server.address':non-empty-string,'server.port':int} */
+                $requestMeta = [
+                    'http.request.method' => self::canonizeMethod($request->getMethod()),
+                    'server.address' => $request->getUri()->getHost(),
+                    'server.port' => $request->getUri()->getPort() ?? ($request->getUri()->getScheme() === 'https' ? 443 : 80),
+                ];
 
                 $spanBuilder = $instrumentation
                     ->tracer()
                     // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span
-                    ->spanBuilder($method ?? self::HTTP_REQUEST_METHOD_HTTP)
+                    ->spanBuilder($requestMeta['http.request.method'] ?? self::HTTP_REQUEST_METHOD_HTTP)
                     ->setParent($parentContext)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
-                    ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $method ?? TraceAttributeValues::HTTP_REQUEST_METHOD_OTHER)
-                    ->setAttribute(TraceAttributes::SERVER_ADDRESS, $request->getUri()->getHost())
-                    ->setAttribute(TraceAttributes::SERVER_PORT, $request->getUri()->getPort() ?? ($request->getUri()->getScheme() === 'https' ? 443 : 80))
+                    ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $requestMeta['http.request.method'] ?? TraceAttributeValues::HTTP_REQUEST_METHOD_OTHER)
+                    ->setAttribute(TraceAttributes::SERVER_ADDRESS, $requestMeta['server.address'])
+                    ->setAttribute(TraceAttributes::SERVER_PORT, $requestMeta['server.port'])
                     ->setAttribute(TraceAttributes::URL_FULL, self::sanitizeUrl($request->getUri()))
                     // https://opentelemetry.io/docs/specs/semconv/code/
                     ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, sprintf('%s::%s', $class, $function));
 
                 // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span
-                if ($method === null) {
+                if ($requestMeta['http.request.method'] === null) {
                     $spanBuilder->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD_ORIGINAL, $request->getMethod());
                 }
 
@@ -133,7 +138,8 @@ class ReactPHPInstrumentation
                     $spanBuilder->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno);
                 }
 
-                $span = $spanBuilder->startSpan();
+                $requestStart = Clock::getDefault()->now();
+                $span = $spanBuilder->setStartTimestamp($requestStart)->startSpan();
                 $context = $span->storeInContext($parentContext);
                 $propagator->inject($request, HeadersPropagator::instance(), $context);
 
@@ -146,11 +152,13 @@ class ReactPHPInstrumentation
                     }
                 }
 
-                Context::storage()->attach($context);
+                $scope = Context::storage()->attach($context);
+                $scope->offsetSet('requestMeta', $requestMeta);
+                $scope->offsetSet('requestStart', $requestStart);
 
                 return [$request];
             },
-            post: static function (Transaction $transaction, array $params, PromiseInterface $promise): PromiseInterface {
+            post: static function (Transaction $transaction, array $params, PromiseInterface $promise) use ($instrumentation): PromiseInterface {
                 $scope = Context::storage()->scope();
                 $scope?->detach();
 
@@ -164,17 +172,29 @@ class ReactPHPInstrumentation
                     return $promise;
                 }
 
+                /** @psalm-var array{'http.request.method':non-empty-string|null,'server.address':non-empty-string,'server.port':int} */
+                $requestMeta = $scope->offsetGet('requestMeta');
+                $requestMeta['http.request.method'] ??= '_OTHER';
+                $requestStart = $scope->offsetGet('requestStart');
+
                 return $promise->then(
-                    onFulfilled: function (ResponseInterface $response) use ($span) {
+                    onFulfilled: function (ResponseInterface $response) use ($instrumentation, $requestMeta, $requestStart, $span) {
+                        $requestEnd = Clock::getDefault()->now();
+                        /** @psalm-var array{'http.response.status_code':int,'network.protocol.version':non-empty-string,'error.type'?:non-empty-string} */
+                        $responseMeta = [
+                            'http.response.status_code' => $response->getStatusCode(),
+                            'network.protocol.version' => $response->getProtocolVersion(),
+                        ];
                         // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span
                         $span
-                            ->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode())
-                            ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $response->getProtocolVersion());
+                            ->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $responseMeta['http.response.status_code'])
+                            ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $responseMeta['network.protocol.version']);
 
-                        if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 600) {
+                        if ($responseMeta['http.response.status_code'] >= 400 && $responseMeta['http.response.status_code'] < 600) {
                             $span
                                 ->setStatus(StatusCode::STATUS_ERROR)
-                                ->setAttribute(TraceAttributes::ERROR_TYPE, (string) $response->getStatusCode());
+                                ->setAttribute(TraceAttributes::ERROR_TYPE, (string) $responseMeta['http.response.status_code']);
+                            $responseMeta['error.type'] = (string) $responseMeta['http.response.status_code'];
                         }
 
                         foreach (explode(',', $_ENV[self::ENV_HTTP_RESPONSE_HEADERS] ?? '') as $header) {
@@ -186,19 +206,34 @@ class ReactPHPInstrumentation
                             }
                         }
 
-                        $span->end();
+                        $span->end($requestEnd);
+
+                        //https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#http-client
+                        $instrumentation->meter()->createHistogram(
+                            'http.client.request.duration',
+                            's',
+                            'Duration of HTTP client requests.',
+                            ['ExplicitBucketBoundaries' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]]
+                        )->record($requestEnd - $requestStart, array_merge($requestMeta, $responseMeta));
 
                         return $response;
                     },
-                    onRejected: function (Throwable $t) use ($span) {
+                    onRejected: function (Throwable $t) use ($instrumentation, $requestMeta, $requestStart, $span) {
+                        $requestEnd = Clock::getDefault()->now();
                         $span->recordException($t);
                         if (is_a($t, ResponseException::class)) {
+                            /** @psalm-var array{'http.response.status_code':int,'network.protocol.version':non-empty-string,'error.type':non-empty-string} */
+                            $responseMeta = [
+                                'error.type' => (string) $t->getCode(),
+                                'http.response.status_code' => $t->getCode(),
+                                'network.protocol.version' => $t->getResponse()->getProtocolVersion(),
+                            ];
                             // https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span
                             $span
                                 ->setStatus(StatusCode::STATUS_ERROR)
-                                ->setAttribute(TraceAttributes::ERROR_TYPE, (string) $t->getCode())
-                                ->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $t->getCode())
-                                ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $t->getResponse()->getProtocolVersion());
+                                ->setAttribute(TraceAttributes::ERROR_TYPE, $responseMeta['error.type'])
+                                ->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $responseMeta['http.response.status_code'])
+                                ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $responseMeta['network.protocol.version']);
 
                             foreach (explode(',', $_ENV[self::ENV_HTTP_RESPONSE_HEADERS] ?? '') as $header) {
                                 if ($t->getResponse()->hasHeader($header)) {
@@ -209,12 +244,24 @@ class ReactPHPInstrumentation
                                 }
                             }
                         } else {
+                            /** @psalm-var array{'error.type':non-empty-string} */
+                            $responseMeta = [
+                                'error.type' => $t::class,
+                            ];
                             $span
                                 ->setStatus(StatusCode::STATUS_ERROR, $t->getMessage())
-                                ->setAttribute(TraceAttributes::ERROR_TYPE, $t::class);
+                                ->setAttribute(TraceAttributes::ERROR_TYPE, $responseMeta['error.type']);
                         }
 
-                        $span->end();
+                        $span->end($requestEnd);
+
+                        //https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#http-client
+                        $instrumentation->meter()->createHistogram(
+                            'http.client.request.duration',
+                            's',
+                            'Duration of HTTP client requests.',
+                            ['ExplicitBucketBoundaries' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]]
+                        )->record($requestEnd - $requestStart, array_merge($requestMeta, $responseMeta));
 
                         throw $t;
                     }

--- a/src/Instrumentation/ReactPHP/src/ReactPHPInstrumentation.php
+++ b/src/Instrumentation/ReactPHP/src/ReactPHPInstrumentation.php
@@ -104,7 +104,7 @@ class ReactPHPInstrumentation
                     $request = $request->withoutHeader($field);
                 }
 
-                /** @psalm-var array{'http.request.method':non-empty-string|null,'server.address':non-empty-string,'server.port':int} */
+                /** @var array{'http.request.method':non-empty-string|null,'server.address':non-empty-string,'server.port':int} $requestMeta */
                 $requestMeta = [
                     'http.request.method' => self::canonizeMethod($request->getMethod()),
                     'server.address' => $request->getUri()->getHost(),
@@ -181,16 +181,16 @@ class ReactPHPInstrumentation
                     ['ExplicitBucketBoundaries' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]]
                 );
 
-                /** @psalm-var array{'http.request.method':non-empty-string|null,'server.address':non-empty-string,'server.port':int} */
+                /** @var array{'http.request.method':non-empty-string|null,'server.address':non-empty-string,'server.port':int} $requestMeta */
                 $requestMeta = $scope->offsetGet('requestMeta');
                 $requestMeta['http.request.method'] ??= '_OTHER';
-                /** @var int */
+                /** @var int $requestStart */
                 $requestStart = $scope->offsetGet('requestStart');
 
                 return $promise->then(
                     onFulfilled: function (ResponseInterface $response) use ($requestDurationHistogram, $requestMeta, $requestStart, $span) {
                         $requestEnd = Clock::getDefault()->now();
-                        /** @psalm-var array{'http.response.status_code':int,'network.protocol.version':non-empty-string,'error.type'?:non-empty-string} */
+                        /** @var array{'http.response.status_code':int,'network.protocol.version':non-empty-string,'error.type'?:non-empty-string} $responseMeta */
                         $responseMeta = [
                             'http.response.status_code' => $response->getStatusCode(),
                             'network.protocol.version' => $response->getProtocolVersion(),
@@ -229,7 +229,7 @@ class ReactPHPInstrumentation
                         $requestEnd = Clock::getDefault()->now();
                         $span->recordException($t);
                         if (is_a($t, ResponseException::class)) {
-                            /** @psalm-var array{'http.response.status_code':int,'network.protocol.version':non-empty-string,'error.type':non-empty-string} */
+                            /** @var array{'http.response.status_code':int,'network.protocol.version':non-empty-string,'error.type':non-empty-string} $responseMeta */
                             $responseMeta = [
                                 'error.type' => (string) $t->getCode(),
                                 'http.response.status_code' => $t->getCode(),
@@ -251,7 +251,7 @@ class ReactPHPInstrumentation
                                 }
                             }
                         } else {
-                            /** @psalm-var array{'error.type':non-empty-string} */
+                            /** @var array{'error.type':non-empty-string} $responseMeta */
                             $responseMeta = [
                                 'error.type' => $t::class,
                             ];


### PR DESCRIPTION
This PR adds the SemConv required [`http.client.request.duration`](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpclientrequestduration) metric to the ReactPHP auto-instrumentation library.