### PR TITLE
Fix: Handle null request in CakePHP Server::run hook

### DIFF
--- a/src/Instrumentation/CakePHP/src/Hooks/Cake/Http/Server.php
+++ b/src/Instrumentation/CakePHP/src/Hooks/Cake/Http/Server.php
@@ -26,7 +26,7 @@ class Server implements CakeHook
             \Cake\Http\Server::class,
             'run',
             pre: function (\Cake\Http\Server $server, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
-                $request = $params[0];
+                $request = $params[0] ?? null;
                 assert($request === null || $request instanceof ServerRequestInterface);
 
                 $request = $this->buildSpan($request, $class, $function, $filename, $lineno);


### PR DESCRIPTION
## Issue

On CakePHP `5.2.4`, I get the following error:

```
Warning: Undefined array key 0 in /var/www/html/vendor/open-telemetry/opentelemetry-auto-cakephp/src/Hooks/Cake/Http/Server.php on line 29
```

## Solution

This PR introduces a null check for `$params[0]` before attempting to cast it to a `ServerRequestInterface`. If `$params[0]` is null, the `$request` variable is set to null, preventing the error and allowing the instrumentation to continue gracefully (albeit without request-specific attributes).
