### PR TITLE
fix: openentelemetry-auto-laravel threw warning on \Illuminate\Database\Eloquent\Model::destroy called.

### DIFF
--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -48,7 +48,8 @@
     "lock": false,
     "sort-packages": true,
     "allow-plugins": {
-      "php-http/discovery": false
+      "php-http/discovery": false,
+      "tbachert/spi": true
     }
   }
 }

--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -48,8 +48,7 @@
     "lock": false,
     "sort-packages": true,
     "allow-plugins": {
-      "php-http/discovery": false,
-      "tbachert/spi": true
+      "php-http/discovery": false
     }
   }
 }

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Database/Eloquent/Model.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Database/Eloquent/Model.php
@@ -189,20 +189,20 @@ class Model implements LaravelHook
         hook(
             EloquentModel::class,
             'destroy',
-            pre: function ($model, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+            pre: function ($modelClassName, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
                 // The class-string is passed to the $model argument, because \Illuminate\Database\Eloquent\Model::destroy is static method.
                 // Therefore, create a class instance from a class-string, and then get the table name from the getTable function.
-                $instance = new $model();
+                $model = new $modelClassName();
 
                 $builder = $this->instrumentation
                     ->tracer()
-                    ->spanBuilder($model . '::destroy')
+                    ->spanBuilder($model::class . '::destroy')
                     ->setSpanKind(SpanKind::KIND_INTERNAL)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, sprintf('%s::%s', $class, $function))
                     ->setAttribute(TraceAttributes::CODE_FILE_PATH, $filename)
                     ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno)
-                    ->setAttribute('laravel.eloquent.model', $model)
-                    ->setAttribute('laravel.eloquent.table', $instance->getTable())
+                    ->setAttribute('laravel.eloquent.model', $model::class)
+                    ->setAttribute('laravel.eloquent.table', $model->getTable())
                     ->setAttribute('laravel.eloquent.operation', 'destroy');
 
                 $parent = Context::getCurrent();

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Database/Eloquent/Model.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Database/Eloquent/Model.php
@@ -190,15 +190,19 @@ class Model implements LaravelHook
             EloquentModel::class,
             'destroy',
             pre: function ($model, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+                // The class-string is passed to the $model argument, because \Illuminate\Database\Eloquent\Model::destroy is static method.
+                // Therefore, create a class instance from a class-string, and then get the table name from the getTable function.
+                $instance = new $model();
+
                 $builder = $this->instrumentation
                     ->tracer()
-                    ->spanBuilder($model::class . '::destroy')
+                    ->spanBuilder($model . '::destroy')
                     ->setSpanKind(SpanKind::KIND_INTERNAL)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, sprintf('%s::%s', $class, $function))
                     ->setAttribute(TraceAttributes::CODE_FILE_PATH, $filename)
                     ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno)
-                    ->setAttribute('laravel.eloquent.model', $model::class)
-                    ->setAttribute('laravel.eloquent.table', $model->getTable())
+                    ->setAttribute('laravel.eloquent.model', $model)
+                    ->setAttribute('laravel.eloquent.table', $instance->getTable())
                     ->setAttribute('laravel.eloquent.operation', 'destroy');
 
                 $parent = Context::getCurrent();

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Database/Eloquent/Model.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Database/Eloquent/Model.php
@@ -189,7 +189,7 @@ class Model implements LaravelHook
         hook(
             EloquentModel::class,
             'destroy',
-            pre: function ($modelClassName, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+            pre: function (string $modelClassName, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
                 // The class-string is passed to the $model argument, because \Illuminate\Database\Eloquent\Model::destroy is static method.
                 // Therefore, create a class instance from a class-string, and then get the table name from the getTable function.
                 $model = new $modelClassName();

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -165,7 +165,6 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertSame('test_models', $updateSpan->getAttributes()->get('laravel.eloquent.table'));
         $this->assertSame('update', $updateSpan->getAttributes()->get('laravel.eloquent.operation'));
         
-	
         // Delete span
         $deleteSpan = array_values(array_filter($eloquentSpans, function ($span) {
             return $span->getAttributes()->get('laravel.eloquent.operation') === 'delete';
@@ -173,7 +172,7 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel::delete', $deleteSpan->getName());
         $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $deleteSpan->getAttributes()->get('laravel.eloquent.model'));
         $this->assertSame('test_models', $deleteSpan->getAttributes()->get('laravel.eloquent.table'));
-	    $this->assertSame('delete', $deleteSpan->getAttributes()->get('laravel.eloquent.operation'));
+        $this->assertSame('delete', $deleteSpan->getAttributes()->get('laravel.eloquent.operation'));
     }
 
     public function test_eloquent_static_operations(): void

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -111,7 +111,11 @@ class LaravelInstrumentationTest extends TestCase
                 
                 // Test delete
                 $found->delete();
-                
+
+		// Test create for destroy
+		$created2 = TestModel::create(['name' => 'test']);
+		TestModel::destroy([$created2->id]);
+
                 return response()->json(['status' => 'ok']);
             } catch (\Exception $e) {
                 return response()->json([
@@ -176,6 +180,7 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertSame('test_models', $updateSpan->getAttributes()->get('laravel.eloquent.table'));
         $this->assertSame('update', $updateSpan->getAttributes()->get('laravel.eloquent.operation'));
         
+	
         // Delete span
         $deleteSpan = array_values(array_filter($eloquentSpans, function ($span) {
             return $span->getAttributes()->get('laravel.eloquent.operation') === 'delete';
@@ -183,7 +188,17 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel::delete', $deleteSpan->getName());
         $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $deleteSpan->getAttributes()->get('laravel.eloquent.model'));
         $this->assertSame('test_models', $deleteSpan->getAttributes()->get('laravel.eloquent.table'));
-        $this->assertSame('delete', $deleteSpan->getAttributes()->get('laravel.eloquent.operation'));
+	$this->assertSame('delete', $deleteSpan->getAttributes()->get('laravel.eloquent.operation'));
+
+	
+        // Destroy span
+        $deleteSpan = array_values(array_filter($eloquentSpans, function ($span) {
+            return $span->getAttributes()->get('laravel.eloquent.operation') === 'destroy';
+        }))[0];
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel::destroy', $deleteSpan->getName());
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $deleteSpan->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('test_models', $deleteSpan->getAttributes()->get('laravel.eloquent.table'));
+	$this->assertSame('destroy', $deleteSpan->getAttributes()->get('laravel.eloquent.operation'));
     }
 
     public function test_low_cardinality_route_span_name(): void

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -102,19 +102,15 @@ class LaravelInstrumentationTest extends TestCase
             try {
                 // Test create
                 $created = TestModel::create(['name' => 'test']);
-                
+
                 // Test find
                 $found = TestModel::find($created->id);
-                
+
                 // Test update
                 $found->update(['name' => 'updated']);
-                
+
                 // Test delete
                 $found->delete();
-
-		// Test create for destroy
-		$created2 = TestModel::create(['name' => 'test']);
-		TestModel::destroy([$created2->id]);
 
                 return response()->json(['status' => 'ok']);
             } catch (\Exception $e) {
@@ -131,18 +127,7 @@ class LaravelInstrumentationTest extends TestCase
         }
         $this->assertEquals(200, $response->status());
         
-        // Verify spans for each Eloquent operation
-        /** @var array<int, \OpenTelemetry\SDK\Trace\ImmutableSpan> $spans */
-        $spans = array_values(array_filter(
-            iterator_to_array($this->storage),
-            fn ($item) => $item instanceof \OpenTelemetry\SDK\Trace\ImmutableSpan
-        ));
-        
-        // Filter out SQL spans and keep only Eloquent spans
-        $eloquentSpans = array_values(array_filter(
-            $spans,
-            fn ($span) => str_contains($span->getName(), '::')
-        ));
+        $eloquentSpans = $this->resolveEloquentOperationSpans();
         
         // Sort spans by operation type to ensure consistent order
         usort($eloquentSpans, function ($a, $b) {
@@ -188,17 +173,59 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel::delete', $deleteSpan->getName());
         $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $deleteSpan->getAttributes()->get('laravel.eloquent.model'));
         $this->assertSame('test_models', $deleteSpan->getAttributes()->get('laravel.eloquent.table'));
-	$this->assertSame('delete', $deleteSpan->getAttributes()->get('laravel.eloquent.operation'));
+	    $this->assertSame('delete', $deleteSpan->getAttributes()->get('laravel.eloquent.operation'));
+    }
 
-	
+    public function test_eloquent_static_operations(): void
+    {
+        // Assert storage is empty before interacting with the database
+        $this->assertCount(0, $this->storage);
+
+        // Create the test_models table
+        DB::statement('CREATE TABLE IF NOT EXISTS test_models (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            created_at DATETIME,
+            updated_at DATETIME
+        )');
+
+        $this->router()->get('/eloquent', function () {
+            try {
+                // create record for Test destroy
+                $created = TestModel::create(['name' => 'test']);
+
+                // Test destroy
+                TestModel::destroy([$created->id]);
+
+                return response()->json(['status' => 'ok']);
+            } catch (\Exception $e) {
+                return response()->json([
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ], 500);
+            }
+        });
+
+        $response = $this->call('GET', '/eloquent');
+        if ($response->status() !== 200) {
+            $this->fail('Request failed: ' . $response->content());
+        }
+        $this->assertEquals(200, $response->status());
+
+        $eloquentSpans = $this->resolveEloquentOperationSpans();
+
         // Destroy span
-        $deleteSpan = array_values(array_filter($eloquentSpans, function ($span) {
+        $destroySpans = array_values(array_filter($eloquentSpans, function ($span) {
             return $span->getAttributes()->get('laravel.eloquent.operation') === 'destroy';
-        }))[0];
-        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel::destroy', $deleteSpan->getName());
-        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $deleteSpan->getAttributes()->get('laravel.eloquent.model'));
-        $this->assertSame('test_models', $deleteSpan->getAttributes()->get('laravel.eloquent.table'));
-	$this->assertSame('destroy', $deleteSpan->getAttributes()->get('laravel.eloquent.operation'));
+        }));
+
+        $this->assertCount(1, $destroySpans);
+
+        $destroySpan = $destroySpans[0];
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel::destroy', $destroySpan->getName());
+        $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $destroySpan->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('test_models', $destroySpan->getAttributes()->get('laravel.eloquent.table'));
+        $this->assertSame('destroy', $destroySpan->getAttributes()->get('laravel.eloquent.operation'));
     }
 
     public function test_low_cardinality_route_span_name(): void
@@ -227,5 +254,26 @@ class LaravelInstrumentationTest extends TestCase
     {
         /** @psalm-suppress PossiblyNullReference */
         return $this->app->make(Router::class);
+    }
+
+    /**
+     * @return array<int, \OpenTelemetry\SDK\Trace\ImmutableSpan>
+     */
+    private function resolveEloquentOperationSpans(): array
+    {
+        // Verify spans for each Eloquent operation
+        /** @var array<int, \OpenTelemetry\SDK\Trace\ImmutableSpan> $spans */
+        $spans = array_values(array_filter(
+            iterator_to_array($this->storage),
+            fn ($item) => $item instanceof \OpenTelemetry\SDK\Trace\ImmutableSpan
+        ));
+
+        // Filter out SQL spans and keep only Eloquent spans
+        $eloquentSpans = array_values(array_filter(
+            $spans,
+            fn ($span) => str_contains($span->getName(), '::')
+        ));
+
+        return $eloquentSpans;
     }
 }


### PR DESCRIPTION
see more details: https://github.com/open-telemetry/opentelemetry-php/issues/1630
I checked to see if other functions were also affected, but only this function was affected.

Closes: https://github.com/open-telemetry/opentelemetry-php/issues/1630