### PR TITLE
Slim: adding stable http server metrics

### DIFF
--- a/src/Instrumentation/Slim/composer.json
+++ b/src/Instrumentation/Slim/composer.json
@@ -13,7 +13,7 @@
     "ext-opentelemetry": "*",
     "ext-reflection": "*",
     "open-telemetry/api": "^1.0",
-    "open-telemetry/sem-conv": "^1.32",
+    "open-telemetry/sem-conv": ">= 1.32.1",
     "slim/slim": "^4"
   },
   "require-dev": {

--- a/src/Instrumentation/Slim/phpstan.neon.dist
+++ b/src/Instrumentation/Slim/phpstan.neon.dist
@@ -10,3 +10,8 @@ parameters:
     excludePaths:
         analyseAndScan:
             - tests/Unit
+    ignoreErrors:
+        -
+            message: "#Access to an undefined property .*#"
+            paths:
+                - tests/Integration/SlimInstrumentationTest.php

--- a/src/Instrumentation/Slim/src/PsrServerRequestMetrics.php
+++ b/src/Instrumentation/Slim/src/PsrServerRequestMetrics.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Slim;
+
+use OpenTelemetry\API\Metrics\HistogramInterface;
+use OpenTelemetry\API\Metrics\MeterInterface;
+use OpenTelemetry\SemConv\Metrics\HttpMetrics;
+use OpenTelemetry\SemConv\TraceAttributes;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+class PsrServerRequestMetrics
+{
+    private static ?HistogramInterface $serverRequestDuration;
+
+    /**
+     * Generate HTTP Server Request metrics.
+     * It implements the stable http.server.request.duration metric, along with required and recommended attributes as of SemConv 1.34.0
+     *
+     * @see https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration
+     */
+    public static function generate(MeterInterface $meter, ServerRequestInterface $request, ?ResponseInterface $response, ?Throwable $exception): void
+    {
+        self::$serverRequestDuration ??= $meter->createHistogram(HttpMetrics::HTTP_SERVER_REQUEST_DURATION, 's', 'Duration of HTTP server requests');
+
+        $startTime = $request->getServerParams()['REQUEST_TIME_FLOAT'] ?? null;
+        if ($startTime === null) {
+            // without start time, we cannot measure the request duration
+            return;
+        }
+
+        if (self::$serverRequestDuration->isEnabled()) {
+            $duration = (microtime(true) - (float) $startTime);
+            $attributes = [
+                TraceAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
+                TraceAttributes::URL_SCHEME => $request->getUri()->getScheme(),
+            ];
+            if ($response && $response->getStatusCode() >= 500) {
+                //@see https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+                $attributes[TraceAttributes::EXCEPTION_TYPE] = (string) $response->getStatusCode();
+            } elseif ($exception) {
+                $attributes[TraceAttributes::EXCEPTION_TYPE] = $exception::class;
+            }
+            if ($response) {
+                $attributes[TraceAttributes::HTTP_RESPONSE_BODY_SIZE] = (int) $response->getHeaderLine('Content-Length');
+                $attributes[TraceAttributes::NETWORK_PROTOCOL_VERSION] = $response->getProtocolVersion();
+                $attributes[TraceAttributes::HTTP_RESPONSE_STATUS_CODE] = $response->getStatusCode();
+            }
+            /** @psalm-suppress PossiblyInvalidArgument */
+            self::$serverRequestDuration->record($duration, $attributes);
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public static function reset(): void
+    {
+        self::$serverRequestDuration = null;
+    }
+}

--- a/src/Instrumentation/Slim/tests/Integration/SlimInstrumentationTest.php
+++ b/src/Instrumentation/Slim/tests/Integration/SlimInstrumentationTest.php
@@ -10,9 +10,15 @@ use Nyholm\Psr7\Response;
 use Nyholm\Psr7\ServerRequest;
 use OpenTelemetry\API\Instrumentation\Configurator;
 use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\Contrib\Instrumentation\Slim\PsrServerRequestMetrics;
+use OpenTelemetry\SDK\Metrics\Data\HistogramDataPoint;
+use OpenTelemetry\SDK\Metrics\MeterProvider;
+use OpenTelemetry\SDK\Metrics\MetricExporter\InMemoryExporter as InMemoryMetricsExporter;
+use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
 use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\SemConv\TraceAttributes;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -28,25 +34,32 @@ use Slim\Routing\RouteContext;
 class SlimInstrumentationTest extends TestCase
 {
     private ScopeInterface $scope;
-    private ArrayObject $storage;
+    private ArrayObject $traces;
+    private ArrayObject $metrics;
+    private ExportingReader $reader;
 
     public function setUp(): void
     {
-        $this->storage = new ArrayObject();
+        $this->traces = new ArrayObject();
+        $this->metrics = new ArrayObject();
         $tracerProvider = new TracerProvider(
             new SimpleSpanProcessor(
-                new InMemoryExporter($this->storage)
+                new InMemoryExporter($this->traces)
             )
         );
+        $this->reader = new ExportingReader(new InMemoryMetricsExporter($this->metrics));
+        $meterProvider = MeterProvider::builder()->addReader($this->reader)->build();
 
         $this->scope = Configurator::create()
             ->withTracerProvider($tracerProvider)
+            ->withMeterProvider($meterProvider)
             ->activate();
     }
 
     public function tearDown(): void
     {
         $this->scope->detach();
+        PsrServerRequestMetrics::reset();
     }
 
     /**
@@ -67,8 +80,8 @@ class SlimInstrumentationTest extends TestCase
             $routingMiddleware
         );
         $app->handle($request->withAttribute(RouteContext::ROUTE, $route));
-        $this->assertCount(1, $this->storage);
-        $span = $this->storage->offsetGet(0); // @var ImmutableSpan $span
+        $this->assertCount(1, $this->traces);
+        $span = $this->traces->offsetGet(0); // @var ImmutableSpan $span
         $this->assertSame($expected, $span->getName());
     }
 
@@ -97,7 +110,7 @@ class SlimInstrumentationTest extends TestCase
     public function test_invocation_strategy(): void
     {
         $strategy = $this->createMockStrategy();
-        $this->assertCount(0, $this->storage);
+        $this->assertCount(0, $this->traces);
         $strategy->__invoke(
             function (): ResponseInterface {
                 return new Response();
@@ -106,7 +119,7 @@ class SlimInstrumentationTest extends TestCase
             $this->createMock(ResponseInterface::class),
             []
         );
-        $this->assertCount(1, $this->storage);
+        $this->assertCount(1, $this->traces);
     }
 
     public function test_routing_exception(): void
@@ -129,8 +142,8 @@ class SlimInstrumentationTest extends TestCase
         } catch (\Exception $e) {
             $this->assertSame('routing failed', $e->getMessage());
         }
-        $this->assertCount(1, $this->storage);
-        $span = $this->storage->offsetGet(0); // @var ImmutableSpan $span
+        $this->assertCount(1, $this->traces);
+        $span = $this->traces->offsetGet(0); // @var ImmutableSpan $span
         $this->assertSame('GET', $span->getName(), 'span name was not updated because routing failed');
     }
 
@@ -143,11 +156,61 @@ class SlimInstrumentationTest extends TestCase
         $request = (new ServerRequest('GET', 'https://example.com/foo'));
         $app = $this->createMockApp(new Response(200, ['X-Foo' => 'foo']));
         $response = $app->handle($request);
-        $this->assertCount(1, $this->storage);
+        $this->assertCount(1, $this->traces);
         $this->assertArrayHasKey('X-Foo', $response->getHeaders());
         $this->assertArrayHasKey('server-timing', $response->getHeaders());
         $this->assertStringStartsWith('traceparent;desc=', $response->getHeaderLine('server-timing'));
         $this->assertArrayHasKey('traceresponse', $response->getHeaders());
+    }
+
+    /**
+     * @psalm-suppress NoInterfaceProperties
+     */
+    public function test_generate_metrics(): void
+    {
+        $request = (new ServerRequest(
+            method: 'GET',
+            uri: 'http://example.com/foo',
+            serverParams: [
+                'REQUEST_TIME_FLOAT' => microtime(true),
+            ],
+        ))->withHeader('Content-Length', '999');
+        $route = Mockery::mock(RouteInterface::class)->allows([
+            'getName' => 'route.name',
+            'getPattern' => '/foo',
+        ]);
+
+        $routingMiddleware = new class($this->createMock(RouteResolverInterface::class), $this->createMock(RouteParserInterface::class)) extends RoutingMiddleware {
+            public function performRouting(ServerRequestInterface $request): ServerRequestInterface
+            {
+                return $request;
+            }
+        };
+        $app = $this->createMockApp(
+            (new Response())->withHeader('Content-Length', '999'),
+            $routingMiddleware
+        );
+        //execute twice to generate 2 data point  values
+        $app->handle($request->withAttribute(RouteContext::ROUTE, $route));
+        $app->handle($request->withAttribute(RouteContext::ROUTE, $route));
+        $this->assertCount(0, $this->metrics);
+        $this->reader->collect();
+        $this->assertCount(1, $this->metrics);
+        $metric = $this->metrics->offsetGet(0);
+        assert($metric instanceof \OpenTelemetry\SDK\Metrics\Data\Metric);
+        $this->assertSame('http.server.request.duration', $metric->name);
+        $this->assertCount(1, $metric->data->dataPoints);
+        $dataPoint = $metric->data->dataPoints[0];
+        assert($dataPoint instanceof HistogramDataPoint);
+        $this->assertSame(2, $dataPoint->count);
+        $attributes = $dataPoint->attributes->toArray();
+        $this->assertEqualsCanonicalizing([
+            TraceAttributes::HTTP_REQUEST_METHOD => 'GET',
+            TraceAttributes::URL_SCHEME => 'http',
+            TraceAttributes::HTTP_RESPONSE_BODY_SIZE => 999,
+            TraceAttributes::NETWORK_PROTOCOL_VERSION => '1.1',
+            TraceAttributes::HTTP_RESPONSE_STATUS_CODE => 200,
+        ], $attributes);
     }
 
     public function createMockStrategy(): InvocationStrategyInterface


### PR DESCRIPTION
I've just implemented the one stable metric along with recommended attributes here. The metrics generation uses PSR interfaces, so I think we can eventually split it out into its own package and it should work with other frameworks.