### PR TITLE
fix doctrine statement execution error

### DIFF
--- a/src/Instrumentation/Doctrine/src/DoctrineInstrumentation.php
+++ b/src/Instrumentation/Doctrine/src/DoctrineInstrumentation.php
@@ -180,7 +180,7 @@ class DoctrineInstrumentation
 
                 Context::storage()->attach($span->storeInContext($parent));
             },
-            post: static function (\Doctrine\DBAL\Driver\Statement $statement, array $params, ResultInterface $result, ?Throwable $exception) {
+            post: static function (\Doctrine\DBAL\Driver\Statement $statement, array $params, ?ResultInterface $result, ?Throwable $exception) {
                 self::end($exception);
             }
         );


### PR DESCRIPTION
the post callback function signature was incorrect for the case where an exception occurs, ResultInterface should be nullable

Reference: https://github.com/open-telemetry/opentelemetry-php/issues/1578#issuecomment-3018116655