### PR TITLE
WordPress: Don't set status ERROR on 404 response

### DIFF
--- a/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
+++ b/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
@@ -114,7 +114,6 @@ class WordpressInstrumentation
 
                     if (function_exists('is_404') && is_404()) {
                         $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, 404);
-                        $span->setStatus(StatusCode::STATUS_ERROR);
                     }
                     //@todo check for other errors?
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-php/issues/1676