### PR TITLE
update slim instrumentation to semconv 1.36.0

### DIFF
--- a/src/Instrumentation/Slim/composer.json
+++ b/src/Instrumentation/Slim/composer.json
@@ -13,7 +13,7 @@
     "ext-opentelemetry": "*",
     "ext-reflection": "*",
     "open-telemetry/api": "^1.0",
-    "open-telemetry/sem-conv": "^1.32",
+    "open-telemetry/sem-conv": "^1.36",
     "slim/slim": "^4"
   },
   "require-dev": {


### PR DESCRIPTION
note that there is still one use of a deprecated class, as network semconv's were missed in our 1.36.0 build