### PR TITLE
Update WordPress example

### DIFF
--- a/examples/instrumentation/Wordpress/autoinstrumented-wordpress.dockerfile
+++ b/examples/instrumentation/Wordpress/autoinstrumented-wordpress.dockerfile
@@ -1,9 +1,9 @@
 # Pull in dependencies with composer
-FROM composer:2.5 as build
+FROM composer:2.8 as build
 COPY composer.json ./
 RUN composer install --ignore-platform-reqs
 
-FROM wordpress:6.7.1
+FROM wordpress:6.8
 # Install the opentelemetry and protobuf extensions
 RUN pecl install opentelemetry protobuf
 COPY otel.php.ini $PHP_INI_DIR/conf.d/.

--- a/examples/instrumentation/Wordpress/compose.yaml
+++ b/examples/instrumentation/Wordpress/compose.yaml
@@ -42,7 +42,7 @@ services:
   # OpenTelemetry collector. Make sure you set USERID and GOOGLE_APPLICATION_CREDENTIALS
   # environment variables for your container to authenticate correctly
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.91.0
+    image: otel/opentelemetry-collector-contrib:0.132.0
     volumes:
       - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
 

--- a/examples/instrumentation/Wordpress/composer.json
+++ b/examples/instrumentation/Wordpress/composer.json
@@ -5,13 +5,14 @@
 	"minimum-stability": "beta",
 	"require": {
 		"open-telemetry/opentelemetry-auto-wordpress": "^0.0.16",
-		"open-telemetry/sdk": "^1.1",
-		"open-telemetry/exporter-otlp": "^1.1",
+		"open-telemetry/sdk": "^1.7",
+		"open-telemetry/exporter-otlp": "^1.3",
 		"php-http/guzzle7-adapter": "^1.1"
 	},
 	"config": {
 		"allow-plugins": {
-			"php-http/discovery": true
+			"php-http/discovery": true,
+			"tbachert/spi": true
 		}
 	}
 }

--- a/examples/instrumentation/Wordpress/otel-collector-config.yaml
+++ b/examples/instrumentation/Wordpress/otel-collector-config.yaml
@@ -2,6 +2,7 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:


### PR DESCRIPTION
## Update
I updated the WordPress example to the current versions.

1. Update `composer.json`: to update the current dependencies.
2. Update Docker file: Composer is 2.8, WordPress is 6.8
3. Update `compose.yaml `opentelemetry-collector is 0.132
4. Added `endpoint: 0.0.0.0:4318`to `otel-collector-config.yaml`. See 104 release: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.104.0

## Testing

In a shell, run:

```sh
docker-compose up --build --abort-on-container-exit
```

Then, go to http://localhost:8080 to set up Wordpress. Click around the finished site and you
should see traces in Jaeger at http://localhost:16686
