### PR TITLE
Laravel: fixing phan target php version to 8.1 to match composer.json.

### DIFF
--- a/src/Instrumentation/Laravel/.phan/config.php
+++ b/src/Instrumentation/Laravel/.phan/config.php
@@ -42,7 +42,7 @@ return [
     //
     // Note that the **only** effect of choosing `'5.6'` is to infer that functions removed in php 7.0 exist.
     // (See `backward_compatibility_checks` for additional options)
-    'target_php_version' => '8.0',
+    'target_php_version' => '8.1',
 
     // If enabled, missing properties will be created when
     // they are first seen. If false, we'll report an


### PR DESCRIPTION
Fix failing Laravel builds due to Phan version mismatch.