### PR TITLE
Added pg_query_params to  PostgreSQL instrumentation

### DIFF
--- a/src/Instrumentation/PostgreSql/src/PostgreSqlInstrumentation.php
+++ b/src/Instrumentation/PostgreSql/src/PostgreSqlInstrumentation.php
@@ -139,6 +139,17 @@ class PostgreSqlInstrumentation
 
         hook(
             null,
+            'pg_query_params',
+            pre: static function (...$args) use ($instrumentation, $tracker) {
+                return self::basicPreHookWithContextPropagator('pg_query_params', $instrumentation, $tracker, ...$args);
+            },
+            post: static function (...$args) use ($instrumentation, $tracker) {
+                self::queryPostHook($instrumentation, $tracker, ...$args);
+            }
+        );
+
+        hook(
+            null,
             'pg_select',
             pre: static function (...$args) use ($instrumentation, $tracker) {
                 self::basicPreHook('pg_select', $instrumentation, $tracker, ...$args);


### PR DESCRIPTION
The README already documents that this function is instrumented, but it is not.

I have not instrumented the query parameters as this is not done for `pg_send_query_params`.
I've implemented this locally and it works with the SQL commenter.