### PR TITLE
Enable context-flattening to support context field searching

### DIFF
--- a/src/Instrumentation/Laravel/README.md
+++ b/src/Instrumentation/Laravel/README.md
@@ -22,3 +22,27 @@ The extension can be disabled via [runtime configuration](https://opentelemetry.
 ```shell
 OTEL_PHP_DISABLED_INSTRUMENTATIONS=laravel
 ```
+
+### Log Context Attributes
+
+By default, log context is JSON-encoded into a single `context` attribute. This can make it difficult to search for specific context values in observability backends like SigNoz.
+
+To flatten log context into individual, searchable attributes, enable:
+
+```shell
+OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN=true
+```
+
+**Default behavior (off):**
+```
+context: {"http":{"method":"GET","path":"/users"},"user_id":"123"}
+```
+
+**With flattening enabled:**
+```
+http.method: GET
+http.path: /users
+user_id: 123
+```
+
+Nested arrays are flattened using dot notation, making each value individually searchable in your observability backend.

--- a/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
@@ -8,16 +8,28 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Log\LogManager;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Instrumentation\ConfigurationResolver;
 use OpenTelemetry\API\Logs\Severity;
+use Stringable;
 use Throwable;
 use TypeError;
 
 class LogWatcher extends Watcher
 {
+    /**
+     * When enabled, log context attributes are spread as individual OTLP attributes
+     * instead of being JSON-encoded into a single 'context' attribute.
+     * This improves searchability in observability backends like SigNoz.
+     */
+    public const OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN = 'OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN';
+
     private LogManager $logger;
+    private bool $flattenAttributes;
+
     public function __construct(
         private CachedInstrumentation $instrumentation,
     ) {
+        $this->flattenAttributes = $this->shouldFlattenAttributes();
     }
 
     /** @psalm-suppress UndefinedInterfaceMethod */
@@ -56,20 +68,28 @@ class LogWatcher extends Watcher
             ->logger()
             ->logRecordBuilder();
 
-        $context = array_filter($log->context, static fn ($value) => $value !== null);
+        $contextToProcess = array_filter($log->context, static fn ($value) => $value !== null);
         $exception = $this->getExceptionFromContext($log->context);
 
         if ($exception !== null) {
             $logBuilder->setException($exception);
 
-            unset($context['exception']);
+            unset($contextToProcess['exception']);
         }
 
         $logBuilder->setBody($log->message)
             ->setSeverityText($log->level)
-            ->setSeverityNumber(Severity::fromPsr3($log->level))
-            ->setAttribute('context', $context)
-            ->emit();
+            ->setSeverityNumber(Severity::fromPsr3($log->level));
+
+        if ($this->flattenAttributes) {
+            foreach ($this->buildFlattenedAttributes($contextToProcess) as $key => $value) {
+                $logBuilder->setAttribute($key, $value);
+            }
+        } else {
+            $logBuilder->setAttribute('context', json_encode($contextToProcess));
+        }
+
+        $logBuilder->emit();
     }
 
     private function getExceptionFromContext(array $context): ?Throwable
@@ -82,5 +102,68 @@ class LogWatcher extends Watcher
         }
 
         return $context['exception'];
+    }
+
+    private function shouldFlattenAttributes(): bool
+    {
+        $resolver = new ConfigurationResolver();
+
+        return $resolver->has(self::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN)
+            && $resolver->getBoolean(self::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN);
+    }
+
+    /**
+     * Build flattened attributes from context array.
+     * Nested arrays are flattened with dot notation for better searchability.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildFlattenedAttributes(array $context): array
+    {
+        $attributes = [];
+
+        foreach ($context as $key => $value) {
+            if (is_array($value)) {
+                $this->flattenArray((string) $key, $value, $attributes);
+            } else {
+                $attributes[(string) $key] = $this->normalizeValue($value);
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Recursively flatten a nested array into dot-notation keys.
+     */
+    private function flattenArray(string $prefix, array $array, array &$result): void
+    {
+        foreach ($array as $key => $value) {
+            $newKey = $prefix . '.' . $key;
+
+            if (is_array($value)) {
+                $this->flattenArray($newKey, $value, $result);
+            } else {
+                $result[$newKey] = $this->normalizeValue($value);
+            }
+        }
+    }
+
+    /**
+     * Normalize a value for OTLP attributes.
+     * OTLP attributes support: string, bool, int, float, and arrays of these.
+     */
+    private function normalizeValue(mixed $value): string|bool|int|float|null
+    {
+        if ($value === null || is_scalar($value)) {
+            return $value;
+        }
+
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        // For objects that can't be stringified, JSON encode them
+        return json_encode($value);
     }
 }

--- a/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Log\LogManager;
+use Illuminate\Support\Arr;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Instrumentation\ConfigurationResolver;
 use OpenTelemetry\API\Logs\Severity;
@@ -86,7 +87,7 @@ class LogWatcher extends Watcher
                 $logBuilder->setAttribute($key, $value);
             }
         } else {
-            $logBuilder->setAttribute('context', json_encode($contextToProcess));
+            $logBuilder->setAttribute('context', json_encode($contextToProcess) ?: '{}');
         }
 
         $logBuilder->emit();
@@ -120,33 +121,7 @@ class LogWatcher extends Watcher
      */
     private function buildFlattenedAttributes(array $context): array
     {
-        $attributes = [];
-
-        foreach ($context as $key => $value) {
-            if (is_array($value)) {
-                $this->flattenArray((string) $key, $value, $attributes);
-            } else {
-                $attributes[(string) $key] = $this->normalizeValue($value);
-            }
-        }
-
-        return $attributes;
-    }
-
-    /**
-     * Recursively flatten a nested array into dot-notation keys.
-     */
-    private function flattenArray(string $prefix, array $array, array &$result): void
-    {
-        foreach ($array as $key => $value) {
-            $newKey = $prefix . '.' . $key;
-
-            if (is_array($value)) {
-                $this->flattenArray($newKey, $value, $result);
-            } else {
-                $result[$newKey] = $this->normalizeValue($value);
-            }
-        }
+        return array_map(fn ($value) => $this->normalizeValue($value), Arr::dot($context));
     }
 
     /**
@@ -164,6 +139,6 @@ class LogWatcher extends Watcher
         }
 
         // For objects that can't be stringified, JSON encode them
-        return json_encode($value);
+        return json_encode($value) ?: null;
     }
 }

--- a/src/Instrumentation/Laravel/tests/Unit/Watchers/LogWatcherTest.php
+++ b/src/Instrumentation/Laravel/tests/Unit/Watchers/LogWatcherTest.php
@@ -193,7 +193,7 @@ class LogWatcherTest extends TestCase
 
         $watcher = $this->createLogWatcher();
 
-        $stringable = new class implements Stringable {
+        $stringable = new class() implements Stringable {
             public function __toString(): string
             {
                 return 'stringable-value';

--- a/src/Instrumentation/Laravel/tests/Unit/Watchers/LogWatcherTest.php
+++ b/src/Instrumentation/Laravel/tests/Unit/Watchers/LogWatcherTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Unit\Watchers;
+
+use ArrayObject;
+use Exception;
+use Illuminate\Log\Events\MessageLogged;
+use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Instrumentation\Configurator;
+use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\LogWatcher;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeFactory;
+use OpenTelemetry\SDK\Logs\Exporter\InMemoryExporter;
+use OpenTelemetry\SDK\Logs\LoggerProvider;
+use OpenTelemetry\SDK\Logs\Processor\SimpleLogRecordProcessor;
+use PHPUnit\Framework\TestCase;
+use Stringable;
+
+class LogWatcherTest extends TestCase
+{
+    private ScopeInterface $scope;
+    private ArrayObject $storage;
+    private LoggerProvider $loggerProvider;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Clear environment variable before each test
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN);
+
+        $this->storage = new ArrayObject();
+        $this->loggerProvider = new LoggerProvider(
+            new SimpleLogRecordProcessor(
+                new InMemoryExporter($this->storage),
+            ),
+            new InstrumentationScopeFactory(Attributes::factory())
+        );
+
+        $this->scope = Configurator::create()
+            ->withLoggerProvider($this->loggerProvider)
+            ->activate();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->scope->detach();
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN);
+    }
+
+    public function test_default_behavior_json_encodes_context(): void
+    {
+        $watcher = $this->createLogWatcher();
+
+        $log = new MessageLogged('info', 'Test message', [
+            'user_id' => '123',
+            'action' => 'login',
+        ]);
+
+        $watcher->recordLog($log);
+
+        $this->assertCount(1, $this->storage);
+        $logRecord = $this->storage[0];
+
+        $attributes = $logRecord->getAttributes()->toArray();
+        $this->assertArrayHasKey('context', $attributes);
+        $this->assertSame('{"user_id":"123","action":"login"}', $attributes['context']);
+    }
+
+    public function test_flattened_mode_spreads_context_as_individual_attributes(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
+
+        $watcher = $this->createLogWatcher();
+
+        $log = new MessageLogged('info', 'Test message', [
+            'user_id' => '123',
+            'action' => 'login',
+        ]);
+
+        $watcher->recordLog($log);
+
+        $this->assertCount(1, $this->storage);
+        $logRecord = $this->storage[0];
+
+        $attributes = $logRecord->getAttributes()->toArray();
+        $this->assertArrayNotHasKey('context', $attributes);
+        $this->assertSame('123', $attributes['user_id']);
+        $this->assertSame('login', $attributes['action']);
+    }
+
+    public function test_flattened_mode_flattens_nested_arrays_with_dot_notation(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
+
+        $watcher = $this->createLogWatcher();
+
+        $log = new MessageLogged('info', 'HTTP request', [
+            'http' => [
+                'method' => 'GET',
+                'path' => '/users',
+                'status' => 200,
+            ],
+            'duration_ms' => 123.45,
+        ]);
+
+        $watcher->recordLog($log);
+
+        $this->assertCount(1, $this->storage);
+        $logRecord = $this->storage[0];
+
+        $attributes = $logRecord->getAttributes()->toArray();
+        $this->assertArrayNotHasKey('context', $attributes);
+        $this->assertArrayNotHasKey('http', $attributes);
+        $this->assertSame('GET', $attributes['http.method']);
+        $this->assertSame('/users', $attributes['http.path']);
+        $this->assertSame(200, $attributes['http.status']);
+        $this->assertSame(123.45, $attributes['duration_ms']);
+    }
+
+    public function test_flattened_mode_handles_deeply_nested_arrays(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
+
+        $watcher = $this->createLogWatcher();
+
+        $log = new MessageLogged('info', 'Nested test', [
+            'request' => [
+                'headers' => [
+                    'content_type' => 'application/json',
+                    'accept' => 'application/json',
+                ],
+            ],
+        ]);
+
+        $watcher->recordLog($log);
+
+        $attributes = $this->storage[0]->getAttributes()->toArray();
+        $this->assertSame('application/json', $attributes['request.headers.content_type']);
+        $this->assertSame('application/json', $attributes['request.headers.accept']);
+    }
+
+    public function test_exception_attributes_preserved_in_default_mode(): void
+    {
+        $watcher = $this->createLogWatcher();
+
+        $exception = new Exception('Test exception');
+        $log = new MessageLogged('error', 'Error occurred', [
+            'exception' => $exception,
+            'user_id' => '123',
+        ]);
+
+        $watcher->recordLog($log);
+
+        $attributes = $this->storage[0]->getAttributes()->toArray();
+        $this->assertArrayHasKey('context', $attributes);
+        $this->assertSame('{"user_id":"123"}', $attributes['context']);
+        $this->assertSame(Exception::class, $attributes['exception.type']);
+        $this->assertSame('Test exception', $attributes['exception.message']);
+        $this->assertArrayHasKey('exception.stacktrace', $attributes);
+    }
+
+    public function test_exception_attributes_preserved_in_flattened_mode(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
+
+        $watcher = $this->createLogWatcher();
+
+        $exception = new Exception('Test exception');
+        $log = new MessageLogged('error', 'Error occurred', [
+            'exception' => $exception,
+            'user_id' => '123',
+        ]);
+
+        $watcher->recordLog($log);
+
+        $attributes = $this->storage[0]->getAttributes()->toArray();
+        $this->assertArrayNotHasKey('context', $attributes);
+        $this->assertSame('123', $attributes['user_id']);
+        $this->assertSame(Exception::class, $attributes['exception.type']);
+        $this->assertSame('Test exception', $attributes['exception.message']);
+        $this->assertArrayHasKey('exception.stacktrace', $attributes);
+    }
+
+    public function test_flattened_mode_handles_stringable_objects(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
+
+        $watcher = $this->createLogWatcher();
+
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'stringable-value';
+            }
+        };
+
+        $log = new MessageLogged('info', 'Test', [
+            'object' => $stringable,
+        ]);
+
+        $watcher->recordLog($log);
+
+        $attributes = $this->storage[0]->getAttributes()->toArray();
+        $this->assertSame('stringable-value', $attributes['object']);
+    }
+
+    public function test_flattened_mode_handles_null_values(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
+
+        $watcher = $this->createLogWatcher();
+
+        $log = new MessageLogged('info', 'Test', [
+            'nullable' => null,
+            'present' => 'value',
+        ]);
+
+        $watcher->recordLog($log);
+
+        // array_filter removes null by default, so 'nullable' won't be present
+        $attributes = $this->storage[0]->getAttributes()->toArray();
+        $this->assertArrayNotHasKey('nullable', $attributes);
+        $this->assertSame('value', $attributes['present']);
+    }
+
+    public function test_flattened_mode_handles_boolean_values(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
+
+        $watcher = $this->createLogWatcher();
+
+        $log = new MessageLogged('info', 'Test', [
+            'is_admin' => true,
+            'is_guest' => false,
+            'name' => 'test',
+        ]);
+
+        $watcher->recordLog($log);
+
+        $attributes = $this->storage[0]->getAttributes()->toArray();
+        $this->assertTrue($attributes['is_admin']);
+        // false is filtered out by array_filter
+        $this->assertArrayNotHasKey('is_guest', $attributes);
+        $this->assertSame('test', $attributes['name']);
+    }
+
+    public function test_log_severity_is_set_correctly(): void
+    {
+        $watcher = $this->createLogWatcher();
+
+        $log = new MessageLogged('warning', 'Warning message', []);
+
+        $watcher->recordLog($log);
+
+        $logRecord = $this->storage[0];
+        $this->assertSame('warning', $logRecord->getSeverityText());
+        $this->assertSame(13, $logRecord->getSeverityNumber());
+    }
+
+    public function test_log_body_is_set_correctly(): void
+    {
+        $watcher = $this->createLogWatcher();
+
+        $log = new MessageLogged('info', 'Test log message body', []);
+
+        $watcher->recordLog($log);
+
+        $logRecord = $this->storage[0];
+        $this->assertSame('Test log message body', $logRecord->getBody());
+    }
+
+    private function createLogWatcher(): LogWatcher
+    {
+        $instrumentation = new CachedInstrumentation(
+            'test.log.watcher',
+            null,
+            'https://opentelemetry.io/schemas/1.32.0',
+        );
+
+        return new LogWatcher($instrumentation);
+    }
+}

--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -100,9 +100,7 @@ final class SymfonyInstrumentation
 
                 $span = Span::fromContext($scope->context());
                 $scope->detach();
-                $span->recordException($exception, [
-                    TraceAttributes::EXCEPTION_ESCAPED => true,
-                ]);
+                $span->recordException($exception);
                 if (null !== $response && $response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
                     $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
                 }


### PR DESCRIPTION

 Description

  Resolves open-telemetry/opentelemetry-php#1837

  This PR adds an optional configuration to flatten log context attributes into individual OTLP attributes, improving searchability in observability backends.

  Problem

  The Laravel LogWatcher currently JSON-encodes the entire log context into a single context attribute:

  context: {"http":{"method":"GET","path":"/users","status":200},"user_id":"123"}

  This makes it impossible to search/filter by specific values (e.g., http.method = "GET") in backends like SigNoz, Jaeger, or Grafana.

  Solution

  A new configuration option OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN that, when enabled, spreads context as individual attributes with dot-notation for nested arrays:

  http.method: GET
  http.path: /users
  http.status: 200
  user_id: 123

  Changes

  - src/Watchers/LogWatcher.php: Added flattening logic with ConfigurationResolver, dot-notation for nested arrays, and proper handling of Stringable objects
  - README.md: Documented the new configuration option with examples
  - tests/Unit/Watchers/LogWatcherTest.php: Added 11 unit tests covering default behavior, flattened mode, nested arrays, exceptions, and edge cases

  Backward Compatibility

  - Default behavior unchanged (off by default)
  - Existing tests continue to pass

  Testing

  ./vendor/bin/phpunit --testsuite=unit      # 18 tests, 42 assertions
  ./vendor/bin/phpunit --testsuite=integration  # 21 tests, 120 assertions
  
  Screenshot
  
  
<img width="766" height="727" alt="Screenshot 2025-12-17 at 6 56 35 PM" src="https://github.com/user-attachments/assets/4343b62c-0151-4153-be8b-0bdb428d9580" />