### PR TITLE
fix: phan and psalm and PHPStan issues

### DIFF
--- a/src/Instrumentation/Symfony/composer.json
+++ b/src/Instrumentation/Symfony/composer.json
@@ -22,6 +22,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",
+    "open-telemetry/opentelemetry-propagation-traceresponse": "*",
     "phan/phan": "^5.0",
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
@@ -48,7 +49,8 @@
   },
   "config": {
     "allow-plugins": {
-      "php-http/discovery": false
+      "php-http/discovery": false,
+      "tbachert/spi": true
     }
   }
 }

--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -107,6 +107,7 @@ final class SymfonyInstrumentation
             }
         );
 
+        /** @psalm-suppress UnusedFunctionCall */
         hook(
             HttpKernel::class,
             'terminate',

--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -100,9 +100,7 @@ final class SymfonyInstrumentation
 
                 $span = Span::fromContext($scope->context());
                 $scope->detach();
-                $span->recordException($exception, [
-                    TraceAttributes::EXCEPTION_ESCAPED => true,
-                ]);
+                $span->recordException($exception);
                 if (null !== $response && $response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
                     $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
                 }

--- a/src/Instrumentation/Symfony/tests/Integration/SymfonyInstrumentationTest.php
+++ b/src/Instrumentation/Symfony/tests/Integration/SymfonyInstrumentationTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration;
 
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\Contrib\Propagation\TraceResponse\TraceResponsePropagator;
 use OpenTelemetry\SemConv\TraceAttributes;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;

--- a/src/Sampler/RuleBased/phpstan.neon.dist
+++ b/src/Sampler/RuleBased/phpstan.neon.dist
@@ -7,3 +7,9 @@ parameters:
     paths:
         - src
         - tests
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        -
+            message: "#Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface::.*#"
+            paths:
+                - src/

--- a/src/Sampler/RuleBased/phpstan.neon.dist
+++ b/src/Sampler/RuleBased/phpstan.neon.dist
@@ -7,8 +7,3 @@ parameters:
     paths:
         - src
         - tests
-    ignoreErrors:
-        -
-            message: "#Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface::.*#"
-            paths:
-                - src/

--- a/src/Sampler/RuleBased/psalm.xml.dist
+++ b/src/Sampler/RuleBased/psalm.xml.dist
@@ -15,11 +15,6 @@
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
     <issueHandlers>
-        <UndefinedInterfaceMethod>
-            <errorLevel type="suppress">
-                <directory name="src/ComponentProvider"/>
-            </errorLevel>
-        </UndefinedInterfaceMethod>
         <MoreSpecificImplementedParamType>
             <errorLevel type="suppress">
                 <directory name="src/ComponentProvider"/>

--- a/src/Sampler/RuleBased/psalm.xml.dist
+++ b/src/Sampler/RuleBased/psalm.xml.dist
@@ -4,6 +4,7 @@
     cacheDirectory="var/cache/psalm"
     findUnusedBaselineEntry="false"
     findUnusedCode="false"
+    findUnusedIssueHandlerSuppression="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
@@ -15,6 +16,11 @@
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
     <issueHandlers>
+        <UndefinedInterfaceMethod>
+            <errorLevel type="suppress">
+                <directory name="src/ComponentProvider"/>
+            </errorLevel>
+        </UndefinedInterfaceMethod>
         <MoreSpecificImplementedParamType>
             <errorLevel type="suppress">
                 <directory name="src/ComponentProvider"/>


### PR DESCRIPTION
This PR fixes the current PHP Psalm and Phan issues on `main`.

---

### 1. Psalm: `src/Sampler/RuleBased/psalm.xml.dist`

* **Issue:** `UndefinedInterfaceMethod` is needed only for PHP 8.1. For newer PHP versions, Psalm reports:

  ```
  ERROR: UnusedIssueHandlerSuppression - /opentelemetry-php-contrib/src/Sampler/RuleBased/psalm.xml.dist:0:0 - Suppressed issue type "UndefinedInterfaceMethod" for /src/ComponentProvider/ was not thrown. (see https://psalm.dev/326)
  ```

* **Fix:** Disable `findUnusedIssueHandlerSuppression` to prevent the “Suppression not used” error.
  Reference: [[Psalm docs](https://psalm.dev/docs/running_psalm/issues/UnusedIssueHandlerSuppression/)](https://psalm.dev/docs/running_psalm/issues/UnusedIssueHandlerSuppression/)

---

### 2. PHPStan: `src/Sampler/RuleBased/phpstan.neon.dist`

* **Issue:** `NodeParentInterface` suppression is needed for PHP 8.1, but for newer versions, PHPStan reports:

  ```
  Error: Ignored error pattern #Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::.*# in path /home/runner/work/opentelemetry-php-contrib/opentelemetry-php-contrib/src/Sampler/RuleBased/src was not matched in reported errors.
  ```

* **Fix:** Add `reportUnmatchedIgnoredErrors: false`.
  Reference: [[PHPStan ignoring errors guide](https://phpstan.org/user-guide/ignoring-errors#reporting-unused-ignores)](https://phpstan.org/user-guide/ignoring-errors#reporting-unused-ignores)

---

### 3. Phan: `src/SymfonyInstrumentation.php`

* **Remove deprecated constant:**

  ```php
  TraceAttributes::EXCEPTION_ESCAPED => true
  ```

* **Reason:**

  ```
  src/SymfonyInstrumentation.php:104 PhanDeprecatedClassConstant Reference to deprecated class constant \OpenTelemetry\SemConv\TraceAttributes::EXCEPTION_ESCAPED defined at vendor/open-telemetry/sem-conv/TraceAttributes.php:1492 (Deprecated because: {"note": "It's no longer recommended to record exceptions that are handled and do not escape the scope of a span.\n", "reason": "obsoleted"})
  ```

---

### 4. Psalm: Suppress unused function call

* **Issue:** Psalm reports an unused function call for the terminate hook:

  ```
  src/SymfonyInstrumentation.php:110:9: UnusedFunctionCall: The call to opentelemetry\instrumentation\hook is not used (see https://psalm.dev/206)
  ```

* **Fix:** Add an `UnusedFunctionCall` suppression for this line.

---

### 5. Dev Dependencies

* **Issue:** Psalm cannot see certain classes in tests:

  ```
  Error: tests/Integration/SymfonyInstrumentationTest.php:37:13: UndefinedClass: Class, interface or enum named OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration\TraceResponsePropagator does not exist (see https://psalm.dev/019)
  ```

* **Fix:** Add `open-telemetry/opentelemetry-propagation-traceresponse` as a dev dependency.