### PR TITLE
Add selective instrumentation configuration

### DIFF
--- a/src/Instrumentation/Laravel/README.md
+++ b/src/Instrumentation/Laravel/README.md
@@ -22,3 +22,55 @@ The extension can be disabled via [runtime configuration](https://opentelemetry.
 ```shell
 OTEL_PHP_DISABLED_INSTRUMENTATIONS=laravel
 ```
+
+### Selective Instrumentation
+
+You can selectively enable or disable specific instrumentations using the following environment variables:
+
+| Environment Variable | Description |
+|---------------------|-------------|
+| `OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS` | Comma-separated list of instrumentations to enable (only these will be active) |
+| `OTEL_LARAVEL_DISABLED_INSTRUMENTATIONS` | Comma-separated list of instrumentations to disable |
+
+#### Available Instrumentation Names
+
+| Name | Description |
+|------|-------------|
+| `http` | HTTP request/response handling |
+| `console` | Artisan CLI commands |
+| `queue` | Queue jobs (push, process, worker) |
+| `eloquent` | Eloquent ORM operations |
+| `serve` | Local development server (`php artisan serve`) |
+| `cache` | Cache events (hit, miss, write, forget) |
+| `db` | Database queries |
+| `http-client` | HTTP client requests (external API calls) |
+| `exception` | Exception recording |
+| `log` | Log messages |
+| `redis` | Redis commands |
+
+#### Group Aliases
+
+| Alias | Expands To |
+|-------|------------|
+| `all` | All instrumentations |
+| `watchers` | `cache`, `db`, `http-client`, `exception`, `log`, `redis` |
+
+#### Priority
+
+- If neither variable is set: all instrumentations are enabled (default behavior)
+- If only `OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS` is set: only specified instrumentations are enabled
+- If only `OTEL_LARAVEL_DISABLED_INSTRUMENTATIONS` is set: specified instrumentations are disabled
+- If both are set: `OTEL_LARAVEL_DISABLED_INSTRUMENTATIONS` takes priority (disabled items are removed from enabled list)
+
+#### Examples
+
+```shell
+# Enable only HTTP and Queue instrumentation
+OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS=http,queue
+
+# Disable only Redis and Log (all others remain enabled)
+OTEL_LARAVEL_DISABLED_INSTRUMENTATIONS=redis,log
+
+# Enable only watchers (cache, db, http-client, exception, log, redis)
+OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS=watchers
+```

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Foundation/Application.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Foundation/Application.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Foundation\Application as FoundationalApplication;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHook;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHookTrait;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\InstrumentationConfig;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\CacheWatcher;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\ClientRequestWatcher;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\ExceptionWatcher;
@@ -24,17 +25,31 @@ class Application implements LaravelHook
 
     public function instrument(): void
     {
+        $config = InstrumentationConfig::getInstance();
+
         /** @psalm-suppress UnusedFunctionCall */
         hook(
             FoundationalApplication::class,
             '__construct',
-            post: function (FoundationalApplication $application, array $_params, mixed $_returnValue, ?Throwable $_exception) {
-                $this->registerWatchers($application, new CacheWatcher());
-                $this->registerWatchers($application, new ClientRequestWatcher($this->instrumentation));
-                $this->registerWatchers($application, new ExceptionWatcher());
-                $this->registerWatchers($application, new LogWatcher($this->instrumentation));
-                $this->registerWatchers($application, new QueryWatcher($this->instrumentation));
-                $this->registerWatchers($application, new RedisCommandWatcher($this->instrumentation));
+            post: function (FoundationalApplication $application, array $_params, mixed $_returnValue, ?Throwable $_exception) use ($config) {
+                if ($config->isInstrumentationEnabled(InstrumentationConfig::CACHE)) {
+                    $this->registerWatchers($application, new CacheWatcher());
+                }
+                if ($config->isInstrumentationEnabled(InstrumentationConfig::HTTP_CLIENT)) {
+                    $this->registerWatchers($application, new ClientRequestWatcher($this->instrumentation));
+                }
+                if ($config->isInstrumentationEnabled(InstrumentationConfig::EXCEPTION)) {
+                    $this->registerWatchers($application, new ExceptionWatcher());
+                }
+                if ($config->isInstrumentationEnabled(InstrumentationConfig::LOG)) {
+                    $this->registerWatchers($application, new LogWatcher($this->instrumentation));
+                }
+                if ($config->isInstrumentationEnabled(InstrumentationConfig::DB)) {
+                    $this->registerWatchers($application, new QueryWatcher($this->instrumentation));
+                }
+                if ($config->isInstrumentationEnabled(InstrumentationConfig::REDIS)) {
+                    $this->registerWatchers($application, new RedisCommandWatcher($this->instrumentation));
+                }
             },
         );
     }

--- a/src/Instrumentation/Laravel/src/InstrumentationConfig.php
+++ b/src/Instrumentation/Laravel/src/InstrumentationConfig.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel;
+
+use OpenTelemetry\SDK\Common\Configuration\Configuration;
+
+final class InstrumentationConfig
+{
+    public const HTTP = 'http';
+    public const CONSOLE = 'console';
+    public const QUEUE = 'queue';
+    public const ELOQUENT = 'eloquent';
+    public const SERVE = 'serve';
+    public const CACHE = 'cache';
+    public const DB = 'db';
+    public const HTTP_CLIENT = 'http-client';
+    public const EXCEPTION = 'exception';
+    public const LOG = 'log';
+    public const REDIS = 'redis';
+
+    private const GROUP_WATCHERS = [
+        self::CACHE,
+        self::DB,
+        self::HTTP_CLIENT,
+        self::EXCEPTION,
+        self::LOG,
+        self::REDIS,
+    ];
+
+    private const ALL_INSTRUMENTATIONS = [
+        self::HTTP,
+        self::CONSOLE,
+        self::QUEUE,
+        self::ELOQUENT,
+        self::SERVE,
+        self::CACHE,
+        self::DB,
+        self::HTTP_CLIENT,
+        self::EXCEPTION,
+        self::LOG,
+        self::REDIS,
+    ];
+
+    private const ALIASES = [
+        'all' => self::ALL_INSTRUMENTATIONS,
+        'watchers' => self::GROUP_WATCHERS,
+    ];
+
+    private const ENV_ENABLED = 'OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS';
+    private const ENV_DISABLED = 'OTEL_LARAVEL_DISABLED_INSTRUMENTATIONS';
+
+    private static ?self $instance = null;
+
+    /** @var array<string> */
+    private array $enabledInstrumentations;
+
+    private function __construct()
+    {
+        $this->enabledInstrumentations = $this->resolveEnabledInstrumentations();
+    }
+
+    public static function getInstance(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    public function isInstrumentationEnabled(string $name): bool
+    {
+        return in_array($name, $this->enabledInstrumentations, true);
+    }
+
+    public function hasAnyWatcherEnabled(): bool
+    {
+        return !empty(array_intersect(self::GROUP_WATCHERS, $this->enabledInstrumentations));
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function resolveEnabledInstrumentations(): array
+    {
+        $enabled = $this->expandAliases($this->getConfigList(self::ENV_ENABLED));
+        $disabled = $this->expandAliases($this->getConfigList(self::ENV_DISABLED));
+
+        return array_values(array_diff($enabled ?: self::ALL_INSTRUMENTATIONS, $disabled));
+    }
+
+    /**
+     * @param array<string> $names
+     * @return array<string>
+     */
+    private function expandAliases(array $names): array
+    {
+        $result = [];
+        foreach ($names as $name) {
+            $name = trim($name);
+            $result = array_merge($result, self::ALIASES[$name] ?? ($name !== '' ? [$name] : []));
+        }
+
+        return array_unique($result);
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getConfigList(string $key): array
+    {
+        if (class_exists(Configuration::class)) {
+            return Configuration::getList($key, []);
+        }
+
+        $value = $_ENV[$key] ?? getenv($key);
+
+        return ($value !== false && $value !== '') ? explode(',', $value) : [];
+    }
+
+    /**
+     * Reset the singleton instance (for testing purposes).
+     */
+    public static function reset(): void
+    {
+        self::$instance = null;
+    }
+}

--- a/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
@@ -20,16 +20,35 @@ class LaravelInstrumentation
             'https://opentelemetry.io/schemas/1.32.0',
         );
 
-        Hooks\Illuminate\Console\Command::hook($instrumentation);
-        Hooks\Illuminate\Contracts\Console\Kernel::hook($instrumentation);
-        Hooks\Illuminate\Contracts\Http\Kernel::hook($instrumentation);
-        Hooks\Illuminate\Contracts\Queue\Queue::hook($instrumentation);
-        Hooks\Illuminate\Foundation\Application::hook($instrumentation);
-        Hooks\Illuminate\Foundation\Console\ServeCommand::hook($instrumentation);
-        Hooks\Illuminate\Queue\SyncQueue::hook($instrumentation);
-        Hooks\Illuminate\Queue\Queue::hook($instrumentation);
-        Hooks\Illuminate\Queue\Worker::hook($instrumentation);
-        Hooks\Illuminate\Database\Eloquent\Model::hook($instrumentation);
+        $config = InstrumentationConfig::getInstance();
+
+        if ($config->isInstrumentationEnabled(InstrumentationConfig::HTTP)) {
+            Hooks\Illuminate\Contracts\Http\Kernel::hook($instrumentation);
+        }
+
+        if ($config->isInstrumentationEnabled(InstrumentationConfig::CONSOLE)) {
+            Hooks\Illuminate\Console\Command::hook($instrumentation);
+            Hooks\Illuminate\Contracts\Console\Kernel::hook($instrumentation);
+        }
+
+        if ($config->isInstrumentationEnabled(InstrumentationConfig::QUEUE)) {
+            Hooks\Illuminate\Contracts\Queue\Queue::hook($instrumentation);
+            Hooks\Illuminate\Queue\SyncQueue::hook($instrumentation);
+            Hooks\Illuminate\Queue\Queue::hook($instrumentation);
+            Hooks\Illuminate\Queue\Worker::hook($instrumentation);
+        }
+
+        if ($config->isInstrumentationEnabled(InstrumentationConfig::ELOQUENT)) {
+            Hooks\Illuminate\Database\Eloquent\Model::hook($instrumentation);
+        }
+
+        if ($config->isInstrumentationEnabled(InstrumentationConfig::SERVE)) {
+            Hooks\Illuminate\Foundation\Console\ServeCommand::hook($instrumentation);
+        }
+
+        if ($config->hasAnyWatcherEnabled()) {
+            Hooks\Illuminate\Foundation\Application::hook($instrumentation);
+        }
     }
 
     public static function shouldTraceCli(): bool

--- a/src/Instrumentation/Laravel/tests/Unit/InstrumentationConfigTest.php
+++ b/src/Instrumentation/Laravel/tests/Unit/InstrumentationConfigTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Unit;
+
+use OpenTelemetry\Contrib\Instrumentation\Laravel\InstrumentationConfig;
+use PHPUnit\Framework\TestCase;
+
+class InstrumentationConfigTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        InstrumentationConfig::reset();
+        putenv('OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS');
+        putenv('OTEL_LARAVEL_DISABLED_INSTRUMENTATIONS');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        putenv('OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS');
+        putenv('OTEL_LARAVEL_DISABLED_INSTRUMENTATIONS');
+        InstrumentationConfig::reset();
+    }
+
+    public function testAllEnabledByDefault(): void
+    {
+        $config = InstrumentationConfig::getInstance();
+
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::CONSOLE));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::QUEUE));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::ELOQUENT));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::SERVE));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::CACHE));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::DB));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP_CLIENT));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::EXCEPTION));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::LOG));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::REDIS));
+    }
+
+    public function testEnabledOnlySpecified(): void
+    {
+        putenv('OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS=http,queue');
+
+        $config = InstrumentationConfig::getInstance();
+
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::QUEUE));
+        $this->assertFalse($config->isInstrumentationEnabled(InstrumentationConfig::ELOQUENT));
+        $this->assertFalse($config->isInstrumentationEnabled(InstrumentationConfig::CACHE));
+        $this->assertFalse($config->isInstrumentationEnabled(InstrumentationConfig::CONSOLE));
+    }
+
+    public function testDisabledRemovesFromEnabled(): void
+    {
+        putenv('OTEL_LARAVEL_DISABLED_INSTRUMENTATIONS=cache,redis');
+
+        $config = InstrumentationConfig::getInstance();
+
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::QUEUE));
+        $this->assertFalse($config->isInstrumentationEnabled(InstrumentationConfig::CACHE));
+        $this->assertFalse($config->isInstrumentationEnabled(InstrumentationConfig::REDIS));
+    }
+
+    public function testDisabledPriorityOverEnabled(): void
+    {
+        putenv('OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS=all');
+        putenv('OTEL_LARAVEL_DISABLED_INSTRUMENTATIONS=redis,log');
+
+        $config = InstrumentationConfig::getInstance();
+
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::QUEUE));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::CACHE));
+        $this->assertFalse($config->isInstrumentationEnabled(InstrumentationConfig::REDIS));
+        $this->assertFalse($config->isInstrumentationEnabled(InstrumentationConfig::LOG));
+    }
+
+    public function testWatchersAliasExpands(): void
+    {
+        putenv('OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS=http,watchers');
+
+        $config = InstrumentationConfig::getInstance();
+
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::CACHE));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::DB));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP_CLIENT));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::EXCEPTION));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::LOG));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::REDIS));
+        $this->assertFalse($config->isInstrumentationEnabled(InstrumentationConfig::QUEUE));
+        $this->assertFalse($config->isInstrumentationEnabled(InstrumentationConfig::CONSOLE));
+    }
+
+    public function testAllAliasExpands(): void
+    {
+        putenv('OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS=all');
+
+        $config = InstrumentationConfig::getInstance();
+
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::CONSOLE));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::QUEUE));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::ELOQUENT));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::SERVE));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::CACHE));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::DB));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP_CLIENT));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::EXCEPTION));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::LOG));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::REDIS));
+    }
+
+    public function testHasAnyWatcherEnabledWhenWatcherEnabled(): void
+    {
+        putenv('OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS=http,cache');
+
+        $config = InstrumentationConfig::getInstance();
+
+        $this->assertTrue($config->hasAnyWatcherEnabled());
+    }
+
+    public function testHasAnyWatcherEnabledWhenNoWatcherEnabled(): void
+    {
+        putenv('OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS=http,queue');
+
+        $config = InstrumentationConfig::getInstance();
+
+        $this->assertFalse($config->hasAnyWatcherEnabled());
+    }
+
+    public function testTrimsWhitespace(): void
+    {
+        putenv('OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS= http , queue ');
+
+        $config = InstrumentationConfig::getInstance();
+
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP));
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::QUEUE));
+    }
+
+    public function testUnknownInstrumentationIsIncludedIfSpecified(): void
+    {
+        putenv('OTEL_LARAVEL_ENABLED_INSTRUMENTATIONS=http,unknown-instrumentation');
+
+        $config = InstrumentationConfig::getInstance();
+
+        $this->assertTrue($config->isInstrumentationEnabled(InstrumentationConfig::HTTP));
+        // Unknown instrumentations are still added to the enabled list if specified
+        $this->assertTrue($config->isInstrumentationEnabled('unknown-instrumentation'));
+        // But other known instrumentations are not enabled
+        $this->assertFalse($config->isInstrumentationEnabled(InstrumentationConfig::QUEUE));
+    }
+}


### PR DESCRIPTION
I've added a feature to selectively enable or disable Laravel auto-instrumentations via environment variables. This is required for me to disable db instrumentation as it has some weird bug. It will also help improve performance when the application doesn't require specific traces.

This selective instrumentation approach is inspired by [auto-instrumentations-node](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node)

This is my first PR to this community, so please let me know if there's anything I should fix or improve.
