### PR TITLE
feat(lambda): read cloud.account.id from symlink in Lambda detector

### DIFF
--- a/src/Aws/src/Lambda/Detector.php
+++ b/src/Aws/src/Lambda/Detector.php
@@ -37,7 +37,7 @@ class Detector implements ResourceDetectorInterface
     private const LAMBDA_VERSION_ENV = 'AWS_LAMBDA_FUNCTION_VERSION';
     private const AWS_REGION_ENV = 'AWS_REGION';
     private const CLOUD_PROVIDER = 'aws';
-    private const ACCOUNT_ID_SYMLINK_PATH = '/tmp/.otel-account-id';
+    private const ACCOUNT_ID_SYMLINK_PATH = '/tmp/.otel-aws-account-id';
 
     public function getResource(): ResourceInfo
     {

--- a/src/Aws/src/Lambda/Detector.php
+++ b/src/Aws/src/Lambda/Detector.php
@@ -37,6 +37,7 @@ class Detector implements ResourceDetectorInterface
     private const LAMBDA_VERSION_ENV = 'AWS_LAMBDA_FUNCTION_VERSION';
     private const AWS_REGION_ENV = 'AWS_REGION';
     private const CLOUD_PROVIDER = 'aws';
+    private const ACCOUNT_ID_SYMLINK_PATH = '/tmp/.otel-account-id';
 
     public function getResource(): ResourceInfo
     {
@@ -51,13 +52,23 @@ class Detector implements ResourceDetectorInterface
         $functionVersion = $functionVersion ? $functionVersion : null;
         $awsRegion = $awsRegion ? $awsRegion : null;
 
-        return !$lambdaName && !$awsRegion && !$functionVersion
+        $accountId = null;
+        $symlinkPath = self::ACCOUNT_ID_SYMLINK_PATH;
+        if (is_link($symlinkPath)) {
+            $target = readlink($symlinkPath);
+            if ($target !== false) {
+                $accountId = $target;
+            }
+        }
+
+        return !$lambdaName && !$awsRegion && !$functionVersion && !$accountId
             ? ResourceInfoFactory::emptyResource()
             : ResourceInfo::create(Attributes::create([
                 ResourceAttributes::FAAS_NAME => $lambdaName,
                 ResourceAttributes::FAAS_VERSION => $functionVersion,
                 ResourceAttributes::CLOUD_REGION => $awsRegion,
                 ResourceAttributes::CLOUD_PROVIDER => self::CLOUD_PROVIDER,
+                ResourceAttributes::CLOUD_ACCOUNT_ID => $accountId,
             ]));
     }
 }

--- a/src/Aws/tests/Unit/Lambda/DetectorTest.php
+++ b/src/Aws/tests/Unit/Lambda/DetectorTest.php
@@ -100,7 +100,7 @@ class DetectorTest extends TestCase
         putenv(self::AWS_REGION_ENV);
     }
 
-    private const ACCOUNT_ID_SYMLINK_PATH = '/tmp/.otel-account-id';
+    private const ACCOUNT_ID_SYMLINK_PATH = '/tmp/.otel-aws-account-id';
 
     private function removeSymlinkIfExists(): ?string
     {


### PR DESCRIPTION
## Summary

- Reads `cloud.account.id` from the symlink at `/tmp/.otel-aws-account-id` created by the OTel Lambda Extension
- Uses `is_link()` + `readlink()` to read the symlink target
- Silently skips if the symlink doesn't exist (null attribute skipped by Attributes builder)

## Depends on

- open-telemetry/opentelemetry-lambda#2127 (extension creates the symlink)

## Changes

- `Detector.php` — Added readlink logic with `ACCOUNT_ID_SYMLINK_PATH` constant
- `DetectorTest.php` — Happy path and missing symlink tests

## Test plan

- [x] Unit test: symlink exists → `cloud.account.id` set correctly
- [x] Unit test: missing symlink → attribute absent, no error