### PR TITLE
Revert "Remove `LogWatcher` in favor of `logger-monolog` Instrumentation"

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Foundation/Application.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Foundation/Application.php
@@ -11,6 +11,7 @@ use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHookTrait;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\CacheWatcher;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\ClientRequestWatcher;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\ExceptionWatcher;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\LogWatcher;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\QueryWatcher;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\RedisCommand\RedisCommandWatcher;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\Watcher;
@@ -31,6 +32,7 @@ class Application implements LaravelHook
                 $this->registerWatchers($application, new CacheWatcher());
                 $this->registerWatchers($application, new ClientRequestWatcher($this->instrumentation));
                 $this->registerWatchers($application, new ExceptionWatcher());
+                $this->registerWatchers($application, new LogWatcher($this->instrumentation));
                 $this->registerWatchers($application, new QueryWatcher($this->instrumentation));
                 $this->registerWatchers($application, new RedisCommandWatcher($this->instrumentation));
             },

--- a/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Log\LogManager;
+use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Logs\Severity;
+use Throwable;
+use TypeError;
+
+class LogWatcher extends Watcher
+{
+    private LogManager $logger;
+    public function __construct(
+        private CachedInstrumentation $instrumentation,
+    ) {
+    }
+
+    /** @psalm-suppress UndefinedInterfaceMethod */
+    public function register(Application $app): void
+    {
+        /** @phan-suppress-next-line PhanTypeArraySuspicious */
+        $app['events']->listen(MessageLogged::class, [$this, 'recordLog']);
+
+        /** @phan-suppress-next-line PhanTypeArraySuspicious */
+        $this->logger = $app['log'];
+    }
+
+    /**
+     * Record a log.
+     * @phan-suppress PhanDeprecatedFunction
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function recordLog(MessageLogged $log): void
+    {
+        $underlyingLogger = $this->logger->getLogger();
+
+        /**
+         * This assumes that the underlying logger (expected to be monolog) would accept `$log->level` as a string.
+         * With monolog < 3.x, this method would fail. Let's prevent this blowing up in Laravel<10.x.
+         */
+        try {
+            /** @phan-suppress-next-line PhanUndeclaredMethod */
+            if (method_exists($underlyingLogger, 'isHandling') && !$underlyingLogger->isHandling($log->level)) {
+                return;
+            }
+        } catch (TypeError) {
+            // Should this fail, we should continue to emit the LogRecord.
+        }
+
+        $logBuilder = $this->instrumentation
+            ->logger()
+            ->logRecordBuilder();
+
+        $context = array_filter($log->context, static fn ($value) => $value !== null);
+        $exception = $this->getExceptionFromContext($log->context);
+
+        if ($exception !== null) {
+            $logBuilder->setException($exception);
+
+            unset($context['exception']);
+        }
+
+        $logBuilder->setBody($log->message)
+            ->setSeverityText($log->level)
+            ->setSeverityNumber(Severity::fromPsr3($log->level))
+            ->setAttribute('context', $context)
+            ->emit();
+    }
+
+    private function getExceptionFromContext(array $context): ?Throwable
+    {
+        if (
+            !isset($context['exception']) ||
+            !$context['exception'] instanceof Throwable
+        ) {
+            return null;
+        }
+
+        return $context['exception'];
+    }
+}

--- a/src/Instrumentation/Laravel/tests/Fixtures/Jobs/DummyJob.php
+++ b/src/Instrumentation/Laravel/tests/Fixtures/Jobs/DummyJob.php
@@ -6,7 +6,7 @@ namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use OpenTelemetry\API\Trace\Span;
+use Psr\Log\LoggerInterface;
 
 class DummyJob implements ShouldQueue
 {
@@ -19,9 +19,8 @@ class DummyJob implements ShouldQueue
     }
 
     /** @psalm-suppress PossiblyUnusedMethod */
-    public function handle(): void
+    public function handle(LoggerInterface $logger): void
     {
-        $currentSpan = Span::getCurrent();
-        $currentSpan->setAttribute('task.name', $this->name);
+        $logger->info("Task: {$this->name}");
     }
 }

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -9,8 +9,6 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use OpenTelemetry\API\Trace\StatusCode;
-use OpenTelemetry\SDK\Trace\ImmutableSpan;
 use OpenTelemetry\SemConv\Attributes\ExceptionAttributes;
 use OpenTelemetry\SemConv\Attributes\UrlAttributes;
 
@@ -62,8 +60,8 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertCount(0, $this->storage);
         $response = $this->call('GET', '/hello');
         $this->assertEquals(200, $response->status());
-        $this->assertCount(2, $this->storage);
-        $span = $this->storage[1];
+        $this->assertCount(3, $this->storage);
+        $span = $this->storage[2];
         $this->assertSame('GET /hello', $span->getName());
         $this->assertSame('http://localhost/hello', $span->getAttributes()->get(UrlAttributes::URL_FULL));
         $this->assertCount(4, $span->getEvents());
@@ -72,12 +70,20 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertSame('cache hit', $span->getEvents()[2]->getName());
         $this->assertSame('cache forget', $span->getEvents()[3]->getName());
 
-        $span = $this->storage[0];
+        $span = $this->storage[1];
         $this->assertSame('sql SELECT', $span->getName());
         $this->assertSame('SELECT', $span->getAttributes()->get('db.operation.name'));
         $this->assertSame(':memory:', $span->getAttributes()->get('db.namespace'));
         $this->assertSame('select 1', $span->getAttributes()->get('db.query.text'));
         $this->assertSame('sqlite', $span->getAttributes()->get('db.system.name'));
+
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord */
+        $logRecord = $this->storage[0];
+        $this->assertSame('Log info', $logRecord->getBody());
+        $this->assertSame('info', $logRecord->getSeverityText());
+        $this->assertSame(9, $logRecord->getSeverityNumber());
+        $this->assertArrayHasKey('context', $logRecord->getAttributes()->toArray());
+        $this->assertSame(['test' => true], $logRecord->getAttributes()->get('context'));
     }
 
     public function test_low_cardinality_route_span_name(): void
@@ -102,25 +108,14 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertSame('GET', $span->getName());
     }
 
-    public function test_records_exception_in_span_events(): void
+    public function test_records_exception_in_logs(): void
     {
         $this->router()->get('/exception', fn () => throw new Exception('Test exception'));
         $this->call('GET', '/exception');
-
-        $this->assertNotEmpty($this->storage);
-
-        /** @var ImmutableSpan $span */
-        $span = $this->storage[0];
-
-        $this->assertCount(1, $span->getEvents());
-
-        $event = $span->getEvents()[0];
-        $this->assertSame('exception', $event->getName());
-
-        $this->assertSame(StatusCode::STATUS_ERROR, $span->getStatus()->getCode());
-        $this->assertEquals(Exception::class, $event->getAttributes()->get(ExceptionAttributes::EXCEPTION_TYPE));
-        $this->assertEquals('Test exception', $event->getAttributes()->get(ExceptionAttributes::EXCEPTION_MESSAGE));
-        $this->assertNotNull($event->getAttributes()->get(ExceptionAttributes::EXCEPTION_STACKTRACE));
+        $logRecord = $this->storage[0];
+        $this->assertEquals(Exception::class, $logRecord->getAttributes()->get(ExceptionAttributes::EXCEPTION_TYPE));
+        $this->assertEquals('Test exception', $logRecord->getAttributes()->get(ExceptionAttributes::EXCEPTION_MESSAGE));
+        $this->assertNotNull($logRecord->getAttributes()->get(ExceptionAttributes::EXCEPTION_STACKTRACE));
     }
 
     private function router(): Router

--- a/src/Instrumentation/Laravel/tests/Integration/Queue/QueueTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Queue/QueueTest.php
@@ -14,11 +14,10 @@ use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Redis\Connections\Connection;
 use Mockery\MockInterface;
-use OpenTelemetry\API\Trace\Span;
-use OpenTelemetry\SDK\Trace\ImmutableSpan;
 use OpenTelemetry\SemConv\TraceAttributes;
 use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Jobs\DummyJob;
 use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration\TestCase;
+use Psr\Log\LoggerInterface;
 
 /** @psalm-suppress UnusedClass */
 class QueueTest extends TestCase
@@ -36,18 +35,19 @@ class QueueTest extends TestCase
     public function test_it_handles_pushing_to_a_queue(): void
     {
         $this->queue->push(new DummyJob('A'));
-        $this->queue->push(function () {
-            $currentSpan = Span::getCurrent();
-            $currentSpan->setAttribute('task.name', 'Job from closure');
+        $this->queue->push(function (LoggerInterface $logger) {
+            $logger->info('Logged from closure');
         });
 
-        $this->assertCount(2, $this->storage);
-
-        $this->assertEquals('sync process', $this->storage[0]->getName());
-        $this->assertEquals('A', $this->storage[0]->getAttributes()->get('task.name'));
-
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord0 */
+        $logRecord0 = $this->storage[0];
+        $this->assertEquals('Task: A', $logRecord0->getBody());
         $this->assertEquals('sync process', $this->storage[1]->getName());
-        $this->assertEquals('Job from closure', $this->storage[1]->getAttributes()->get('task.name'));
+
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord2 */
+        $logRecord2 = $this->storage[2];
+        $this->assertEquals('Logged from closure', $logRecord2->getBody());
+        $this->assertEquals('sync process', $this->storage[3]->getName());
     }
 
     public function test_it_can_push_a_message_with_a_delay(): void
@@ -56,24 +56,19 @@ class QueueTest extends TestCase
         $this->queue->later(new DateInterval('PT10M'), new DummyJob('DateInterval'));
         $this->queue->later(new DateTimeImmutable('2024-04-15 22:29:00.123Z'), new DummyJob('DateTime'));
 
-        $this->assertCount(6, $this->storage);
-
-        $this->assertEquals('create sync', $this->storage[1]->getName());
-        $this->assertSame('int', $this->storage[0]->getAttributes()->get('task.name'));
+        $this->assertEquals('create sync', $this->storage[2]->getName());
         $this->assertIsInt(
-            $this->storage[1]->getAttributes()->get('messaging.message.delivery_timestamp'),
-        );
-
-        $this->assertEquals('create sync', $this->storage[3]->getName());
-        $this->assertSame('DateInterval', $this->storage[2]->getAttributes()->get('task.name'));
-        $this->assertIsInt(
-            $this->storage[3]->getAttributes()->get('messaging.message.delivery_timestamp'),
+            $this->storage[2]->getAttributes()->get('messaging.message.delivery_timestamp'),
         );
 
         $this->assertEquals('create sync', $this->storage[5]->getName());
-        $this->assertSame('DateTime', $this->storage[4]->getAttributes()->get('task.name'));
         $this->assertIsInt(
             $this->storage[5]->getAttributes()->get('messaging.message.delivery_timestamp'),
+        );
+
+        $this->assertEquals('create sync', $this->storage[8]->getName());
+        $this->assertIsInt(
+            $this->storage[8]->getAttributes()->get('messaging.message.delivery_timestamp'),
         );
     }
 
@@ -151,14 +146,14 @@ class QueueTest extends TestCase
         }
 
         /** @psalm-suppress PossiblyInvalidMethodCall */
-        $this->assertEquals(102, $this->storage->count());
+        $this->assertEquals(204, $this->storage->count());
 
-        /** @var ImmutableSpan $span50 */
-        $span50 = $this->storage[50];
-        $this->assertEquals('500', $span50->getAttributes()->get('task.name'));
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord100 */
+        $logRecord100 = $this->storage[100];
+        $this->assertEquals('Task: 500', $logRecord100->getBody());
 
-        /** @var ImmutableSpan $span100 */
-        $span100 = $this->storage[100];
-        $this->assertEquals('More work', $span100->getAttributes()->get('task.name'));
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord200 */
+        $logRecord200 = $this->storage[200];
+        $this->assertEquals('Task: More work', $logRecord200->getBody());
     }
 }


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-php-contrib#518

I'd argue this is a breaking change, as it removes the automatic capture of any logs from existing systems which rely on this functionality.

There is a potential solution in https://github.com/open-telemetry/opentelemetry-php-contrib/pull/501