### PR TITLE
detector-container. Update schema url to use Version::VERSION_1_38_0

### DIFF
--- a/src/ResourceDetectors/Container/composer.json
+++ b/src/ResourceDetectors/Container/composer.json
@@ -10,7 +10,8 @@
   "prefer-stable": true,
   "require": {
     "php": "^8.1",
-    "open-telemetry/sdk": "^1.0"
+    "open-telemetry/sdk": "^1.0",
+    "open-telemetry/sem-conv": "^1.38"
   },
   "autoload": {
     "psr-4": {

--- a/src/ResourceDetectors/Container/src/Container.php
+++ b/src/ResourceDetectors/Container/src/Container.php
@@ -8,6 +8,7 @@ use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Resource\ResourceDetectorInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use OpenTelemetry\SemConv\ResourceAttributes;
+use OpenTelemetry\SemConv\Version;
 
 /**
  * @see https://github.com/open-telemetry/opentelemetry-specification/blob/v1.18.0/specification/resource/semantic_conventions/container.md
@@ -35,7 +36,7 @@ final class Container implements ResourceDetectorInterface
             $attributes[ResourceAttributes::CONTAINER_ID] = $id;
         }
 
-        return ResourceInfo::create(Attributes::create($attributes), ResourceAttributes::SCHEMA_URL);
+        return ResourceInfo::create(Attributes::create($attributes), Version::VERSION_1_38_0->url());
     }
 
     private function getContainerId(): ?string


### PR DESCRIPTION
Updated the schema URLs to the current 1.38.0 in detector-container