### PR TITLE
[Laravel] Allow Laravel 13

### DIFF
--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -19,7 +19,7 @@
     "php": "^8.1",
     "ext-json": "*",
     "ext-opentelemetry": "*",
-    "laravel/framework": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+    "laravel/framework": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
     "open-telemetry/api": "^1.8",
     "open-telemetry/sem-conv": "^1.32"
   },


### PR DESCRIPTION
Allows Laravel 13 to be installed with open-telemetry/opentelemetry-auto-laravel