### PR TITLE
fix(symfony): end sub-request spans in handle post-hook to prevent scope leak

### DIFF
--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -93,18 +93,33 @@ final class SymfonyInstrumentation
                 ?Response $response,
                 ?\Throwable $exception
             ): void {
+                $type = $params[1] ?? HttpKernelInterface::MAIN_REQUEST;
                 $scope = Context::storage()->scope();
-                if (null === $scope || null === $exception) {
+
+                if (null === $scope) {
+                    return;
+                }
+
+                // Main request with no exception: terminate() hook handles ending the span
+                if ($type === HttpKernelInterface::MAIN_REQUEST && null === $exception) {
                     return;
                 }
 
                 $span = Span::fromContext($scope->context());
                 $scope->detach();
-                $span->recordException($exception, [
-                    TraceAttributes::EXCEPTION_ESCAPED => true,
-                ]);
-                if (null !== $response && $response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
-                    $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
+
+                if (null !== $exception) {
+                    $span->recordException($exception, [
+                        TraceAttributes::EXCEPTION_ESCAPED => true,
+                    ]);
+                    if (null !== $response && $response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
+                        $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
+                    }
+                }
+
+                // Sub-requests never receive a terminate() call, so the span must be ended here
+                if ($type === HttpKernelInterface::SUB_REQUEST) {
+                    $span->end();
                 }
             }
         );
@@ -163,8 +178,12 @@ final class SymfonyInstrumentation
 
                 $span->setAttribute(TraceAttributes::HTTP_RESPONSE_BODY_SIZE, $contentLength);
 
-                $prop = Globals::responsePropagator();
-                $prop->inject($response, ResponsePropagationSetter::instance(), $scope->context());
+                try {
+                    $prop = Globals::responsePropagator();
+                    $prop->inject($response, ResponsePropagationSetter::instance(), $scope->context());
+                } catch (\Throwable) {
+                    // ensure span->end() is always called even if response propagation fails
+                }
 
                 $span->end();
             }

--- a/src/Instrumentation/Symfony/tests/Integration/SymfonyInstrumentationTest.php
+++ b/src/Instrumentation/Symfony/tests/Integration/SymfonyInstrumentationTest.php
@@ -143,8 +143,9 @@ class SymfonyInstrumentationTest extends AbstractTest
         $request = new Request();
         $request->attributes->set('_controller', 'ErrorController');
 
-        $response = $kernel->handle($request, HttpKernelInterface::SUB_REQUEST);
-        $kernel->terminate($request, $response);
+        // Note: terminate() is not called — sub-requests never receive a terminate() call
+        // in Symfony. The span is ended and exported directly from the handle post-hook.
+        $kernel->handle($request, HttpKernelInterface::SUB_REQUEST);
 
         $this->assertCount(1, $this->storage);
 
@@ -199,6 +200,81 @@ class SymfonyInstrumentationTest extends AbstractTest
         $request->attributes->set('_controller', null);
         $kernel->handle($request, \Symfony\Component\HttpKernel\HttpKernelInterface::SUB_REQUEST);
         $this->assertSame('GET sub-request', $this->storage[0]->getName());
+    }
+
+    public function test_main_request_span_is_exported_when_subrequest_occurs(): void
+    {
+        $kernel = $this->getHttpKernel(new EventDispatcher());
+        $mainRequest = new Request();
+        $mainRequest->attributes->set('_route', 'main_route');
+        $subRequest = new Request();
+        $subRequest->attributes->set('_controller', 'ErrorController');
+
+        // Simulate what Symfony does internally for error responses:
+        // handle(MAIN_REQUEST) is called, which internally calls handle(SUB_REQUEST)
+        // to render the error page, before terminate() is called.
+        $kernel->handle($mainRequest, HttpKernelInterface::MAIN_REQUEST);
+        $kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+        $response = new Response('Not Found', 404);
+        $kernel->terminate($mainRequest, $response);
+
+        // Both spans must be exported: sub-request span (ended in handle post-hook)
+        // and main request span (ended in terminate post-hook).
+        $this->assertCount(2, $this->storage);
+
+        $spans = iterator_to_array($this->storage);
+        $mainSpan = null;
+        $subSpan = null;
+        foreach ($spans as $span) {
+            if ($span->getKind() === SpanKind::KIND_SERVER) {
+                $mainSpan = $span;
+            } else {
+                $subSpan = $span;
+            }
+        }
+
+        $this->assertNotNull($mainSpan, 'Main request span (KIND_SERVER) must be exported');
+        $this->assertNotNull($subSpan, 'Sub-request span (KIND_INTERNAL) must be exported');
+
+        // Sub-request span must be a child of the main request span
+        $this->assertSame(
+            $mainSpan->getContext()->getSpanId(),
+            $subSpan->getParentSpanId(),
+            'Sub-request span must be a child of the main request span'
+        );
+
+        // Main request span must be the root (no parent)
+        $this->assertSame('0000000000000000', $mainSpan->getParentSpanId());
+    }
+
+    public function test_subrequest_scope_does_not_leak_into_next_request(): void
+    {
+        $kernel = $this->getHttpKernel(new EventDispatcher());
+
+        // First request: main + sub (simulating error response rendering)
+        $mainRequest = new Request();
+        $mainRequest->attributes->set('_route', 'first_route');
+        $subRequest = new Request();
+        $subRequest->attributes->set('_controller', 'ErrorController');
+
+        $kernel->handle($mainRequest, HttpKernelInterface::MAIN_REQUEST);
+        $kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+        $kernel->terminate($mainRequest, new Response('', 404));
+
+        $this->assertCount(2, $this->storage);
+        $this->storage->exchangeArray([]);
+
+        // Second request: must be independent with no leftover scope from the first
+        $secondRequest = new Request();
+        $secondRequest->attributes->set('_route', 'second_route');
+        $response = $kernel->handle($secondRequest, HttpKernelInterface::MAIN_REQUEST);
+        $kernel->terminate($secondRequest, $response);
+
+        $this->assertCount(1, $this->storage);
+        $span = $this->storage[0];
+        $this->assertSame(SpanKind::KIND_SERVER, $span->getKind());
+        // Must be a root span with no parent from the previous request
+        $this->assertSame('0000000000000000', $span->getParentSpanId());
     }
 
     private function getHttpKernel(EventDispatcherInterface $eventDispatcher, $controller = null, ?RequestStack $requestStack = null, array $arguments = []): HttpKernel


### PR DESCRIPTION
## Problem

When Symfony renders an error response, `HttpKernel::handle()` is called **twice**: once for the `MAIN_REQUEST` and once internally as a `SUB_REQUEST` to render the error page via `ExceptionController`. The `handle` post-hook returns early for **both** calls because `$exception` is `null` for a successfully-rendered error page, leaving two scopes on the OTEL context stack:

```
[top]    scope 1 → sub-request span  (KIND_INTERNAL, child of scope 2)
[bottom] scope 2 → main request span (KIND_SERVER, root, no parent)
```

When `terminate()` fires it pops only the topmost scope (scope 1, the sub-request span) and ends it. Scope 2 — the root `KIND_SERVER` span — is never popped, never ended, and **never exported**.

In practice: child spans (e.g. Doctrine queries) appear in the trace backend with `rootServiceName: <root span not yet received>` because the parent never arrives.

This is distinct from the exception case addressed in #317. The bug occurs on **normal** request handling whenever Symfony produces a non-2xx response (404, 403, 500, etc.).

Fixes https://github.com/open-telemetry/opentelemetry-php/issues/1905

## Solution

Detect `SUB_REQUEST` in the `handle` post-hook and end those spans immediately, since sub-requests never receive a `terminate()` call:

```php
$type = $params[1] ?? HttpKernelInterface::MAIN_REQUEST;

// Main request with no exception: terminate() hook handles ending the span
if ($type === HttpKernelInterface::MAIN_REQUEST && null === $exception) {
    return;
}

$span = Span::fromContext($scope->context());
$scope->detach();

if (null !== $exception) { ... }

// Sub-requests don't get a terminate() call — end the span here
if ($type === HttpKernelInterface::SUB_REQUEST) {
    $span->end();
}
```

By the time `terminate()` fires, only scope 2 (the main request span) remains on the stack and is properly ended and exported.

Also wraps `$prop->inject()` in a try-catch in the `terminate` hook to ensure `$span->end()` is always reached if response propagation fails.

## Tests

- Updated `test_http_kernel_handle_subrequest` to remove the erroneous `terminate()` call — standalone sub-requests don't receive `terminate()` in real Symfony, and the span is now correctly exported from the handle post-hook directly.
- Added `test_main_request_span_is_exported_when_subrequest_occurs`: verifies that after a MAIN_REQUEST + SUB_REQUEST sequence followed by `terminate()`, **both** spans are exported, the sub-request span is a child of the main span, and the main span is a root span.
- Added `test_subrequest_scope_does_not_leak_into_next_request`: verifies that a subsequent request after a MAIN_REQUEST + SUB_REQUEST cycle starts with a clean context and produces an independent root span.

All 12 tests pass.