### PR TITLE
Fix job tracing

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/Worker.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/Worker.php
@@ -156,7 +156,7 @@ class Worker implements LaravelHook
          */
         if ($this->inheritsTracingInterface($job, TracingIsolated::class)) {
 
-            $spanBuilder->setParent(null);
+            $spanBuilder->setParent(false);
 
             return Context::getCurrent();
         }
@@ -167,7 +167,7 @@ class Worker implements LaravelHook
         if ($this->inheritsTracingInterface($job, TracingLinked::class) && $parentContext instanceof ContextInterface) {
 
             $spanBuilder
-                ->setParent(null)
+                ->setParent(false)
                 ->addLink(Span::fromContext($parentContext)->getContext());
 
             return Context::getCurrent();


### PR DESCRIPTION
PR to fix job tracing to correctly set no parent.

---

From the docs:

```
    /**
     * Sets the parent `Context`.
     *
     * @param ContextInterface|false|null $context the parent context, null to use the
     *        current context, false to set no parent
     *
```