### PR TITLE
[Laravel] Add opt-in context flattening for faceted log search

### DIFF
--- a/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/LogWatcher.php
@@ -7,17 +7,27 @@ namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Log\LogManager;
+use Illuminate\Support\Arr;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Instrumentation\ConfigurationResolver;
 use OpenTelemetry\API\Logs\Severity;
+use Stringable;
 use Throwable;
 use TypeError;
 
 class LogWatcher extends Watcher
 {
+    public const OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN = 'OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN';
+
     private LogManager $logger;
+    private bool $flattenAttributes;
+
     public function __construct(
         private CachedInstrumentation $instrumentation,
     ) {
+        $resolver = new ConfigurationResolver();
+        $this->flattenAttributes = $resolver->has(self::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN)
+            && $resolver->getBoolean(self::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN);
     }
 
     /** @psalm-suppress UndefinedInterfaceMethod */
@@ -67,9 +77,29 @@ class LogWatcher extends Watcher
 
         $logBuilder->setBody($log->message)
             ->setSeverityText($log->level)
-            ->setSeverityNumber(Severity::fromPsr3($log->level))
-            ->setAttribute('context', $context)
-            ->emit();
+            ->setSeverityNumber(Severity::fromPsr3($log->level));
+
+        if ($this->flattenAttributes) {
+            foreach (Arr::dot($context) as $key => $value) {
+                $logBuilder->setAttribute((string) $key, $this->normalizeValue($value));
+            }
+        } else {
+            $logBuilder->setAttribute('context', $context);
+        }
+
+        $logBuilder->emit();
+    }
+
+    private function normalizeValue(mixed $value): string|bool|int|float|null
+    {
+        if ($value === null || is_scalar($value)) {
+            return $value;
+        }
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        return json_encode($value) ?: null;
     }
 
     private function getExceptionFromContext(array $context): ?Throwable

--- a/src/Instrumentation/Laravel/tests/Unit/Watchers/LogWatcherTest.php
+++ b/src/Instrumentation/Laravel/tests/Unit/Watchers/LogWatcherTest.php
@@ -144,7 +144,7 @@ class LogWatcherTest extends TestCase
         putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
         $watcher = $this->createWatcher();
 
-        $stringable = new class () implements Stringable {
+        $stringable = new class() implements Stringable {
             public function __toString(): string
             {
                 return 'stringable-value';

--- a/src/Instrumentation/Laravel/tests/Unit/Watchers/LogWatcherTest.php
+++ b/src/Instrumentation/Laravel/tests/Unit/Watchers/LogWatcherTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Unit\Watchers;
+
+use ArrayObject;
+use Exception;
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Log\LogManager;
+use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Instrumentation\Configurator;
+use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\LogWatcher;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeFactory;
+use OpenTelemetry\SDK\Logs\Exporter\InMemoryExporter;
+use OpenTelemetry\SDK\Logs\LoggerProvider;
+use OpenTelemetry\SDK\Logs\Processor\SimpleLogRecordProcessor;
+use OpenTelemetry\SemConv\Attributes\ExceptionAttributes;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use stdClass;
+use Stringable;
+
+class LogWatcherTest extends TestCase
+{
+    private ScopeInterface $scope;
+    private ArrayObject $storage;
+
+    protected function setUp(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN);
+
+        $this->storage = new ArrayObject();
+        $loggerProvider = new LoggerProvider(
+            new SimpleLogRecordProcessor(
+                new InMemoryExporter($this->storage),
+            ),
+            new InstrumentationScopeFactory(Attributes::factory()),
+        );
+
+        $this->scope = Configurator::create()
+            ->withLoggerProvider($loggerProvider)
+            ->activate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->scope->detach();
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN);
+    }
+
+    private function createWatcher(): LogWatcher
+    {
+        $watcher = new LogWatcher(new CachedInstrumentation('io.opentelemetry.contrib.php.laravel'));
+
+        // Inject a mock LogManager that passes all log levels through.
+        // getLogger() is forwarded via __call on the real class, so addMethods() is required.
+        $mockLogManager = $this->getMockBuilder(LogManager::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getLogger'])
+            ->getMock();
+        $mockLogManager->method('getLogger')->willReturn(new stdClass());
+
+        $prop = new ReflectionProperty(LogWatcher::class, 'logger');
+        $prop->setAccessible(true);
+        $prop->setValue($watcher, $mockLogManager);
+
+        return $watcher;
+    }
+
+    private function emit(LogWatcher $watcher, string $message, array $context = [], string $level = 'info'): void
+    {
+        $watcher->recordLog(new MessageLogged($level, $message, $context));
+    }
+
+    public function test_default_stores_context_as_structured_array(): void
+    {
+        $watcher = $this->createWatcher();
+        $this->emit($watcher, 'hello', ['user_id' => 42, 'action' => 'login']);
+
+        $record = $this->storage[0];
+        $this->assertSame('hello', $record->getBody());
+        $this->assertSame(['user_id' => 42, 'action' => 'login'], $record->getAttributes()->get('context'));
+    }
+
+    public function test_default_preserves_nested_arrays_in_context(): void
+    {
+        $watcher = $this->createWatcher();
+        $this->emit($watcher, 'request', ['http' => ['method' => 'GET', 'path' => '/users'], 'user_id' => '123']);
+
+        $record = $this->storage[0];
+        $this->assertSame(
+            ['http' => ['method' => 'GET', 'path' => '/users'], 'user_id' => '123'],
+            $record->getAttributes()->get('context'),
+        );
+    }
+
+    public function test_flatten_spreads_context_as_individual_attributes(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
+        $watcher = $this->createWatcher();
+        $this->emit($watcher, 'login', ['user_id' => '123', 'action' => 'login']);
+
+        $record = $this->storage[0];
+        $attrs = $record->getAttributes()->toArray();
+        $this->assertArrayNotHasKey('context', $attrs);
+        $this->assertSame('123', $attrs['user_id']);
+        $this->assertSame('login', $attrs['action']);
+    }
+
+    public function test_flatten_uses_dot_notation_for_nested_arrays(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
+        $watcher = $this->createWatcher();
+        $this->emit($watcher, 'request', ['http' => ['method' => 'GET', 'path' => '/users', 'status' => 200]]);
+
+        $record = $this->storage[0];
+        $attrs = $record->getAttributes()->toArray();
+        $this->assertArrayNotHasKey('context', $attrs);
+        $this->assertSame('GET', $attrs['http.method']);
+        $this->assertSame('/users', $attrs['http.path']);
+        $this->assertSame(200, $attrs['http.status']);
+    }
+
+    public function test_exception_is_extracted_and_sets_exception_attributes(): void
+    {
+        $exception = new Exception('something broke');
+        $watcher = $this->createWatcher();
+        $this->emit($watcher, 'error logged', ['exception' => $exception], 'error');
+
+        $record = $this->storage[0];
+        $this->assertSame(Exception::class, $record->getAttributes()->get(ExceptionAttributes::EXCEPTION_TYPE));
+        $this->assertSame('something broke', $record->getAttributes()->get(ExceptionAttributes::EXCEPTION_MESSAGE));
+        $this->assertNotNull($record->getAttributes()->get(ExceptionAttributes::EXCEPTION_STACKTRACE));
+        // exception key must not appear in context
+        $context = $record->getAttributes()->get('context');
+        $this->assertArrayNotHasKey('exception', (array) $context);
+    }
+
+    public function test_flatten_stringable_values_cast_to_string(): void
+    {
+        putenv(LogWatcher::OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN . '=true');
+        $watcher = $this->createWatcher();
+
+        $stringable = new class () implements Stringable {
+            public function __toString(): string
+            {
+                return 'stringable-value';
+            }
+        };
+
+        $this->emit($watcher, 'msg', ['key' => $stringable]);
+
+        $record = $this->storage[0];
+        $this->assertSame('stringable-value', $record->getAttributes()->get('key'));
+    }
+
+    public function test_null_context_values_are_filtered_out(): void
+    {
+        $watcher = $this->createWatcher();
+        $this->emit($watcher, 'msg', ['present' => 'yes', 'absent' => null]);
+
+        $record = $this->storage[0];
+        $context = $record->getAttributes()->get('context');
+        $this->assertArrayHasKey('present', $context);
+        $this->assertArrayNotHasKey('absent', $context);
+    }
+
+    public function test_flatten_disabled_by_default(): void
+    {
+        // No env var set; watcher must not flatten
+        $watcher = $this->createWatcher();
+        $this->emit($watcher, 'msg', ['a' => ['b' => 'c']]);
+
+        $record = $this->storage[0];
+        // 'a.b' must not exist; nested array must be under 'context'
+        $this->assertNull($record->getAttributes()->get('a.b'));
+        $this->assertIsArray($record->getAttributes()->get('context'));
+    }
+}


### PR DESCRIPTION
## Description

This PR restores the context-flattening feature from #491 (which was reverted in #559 due to a conflict with #511), now correctly layered on top of the structured-array default that #511 introduced.

### Background

PR #491 identified a real observability problem: the Laravel `LogWatcher` was JSON-encoding the entire log context into a single `context` string attribute, making it impossible to filter by specific values in backends like SigNoz, Jaeger, or Grafana. For example, given context `{"http": {"method": "GET", "path": "/users"}, "user_id": "123"}`, there was no way to query `http.method = "GET"` as a facet.

PR #491 solved this with an opt-in `OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN` flag that spreads context fields as individual OTLP attributes using dot notation for nested keys:

```
http.method = GET
http.path   = /users
user_id     = 123
```

### What went wrong with #491

When #491 was merged, it conflicted with #511, which had already changed the default `context` handling from a JSON-encoded string to a structured array (`->setAttribute('context', $context)`). The #491 code regressed that improvement by reverting the non-flatten path back to `json_encode()`.

PR #559 reverted #491 entirely to restore the #511 behaviour, but that also lost the flattening feature.

### What this PR does

This PR re-introduces the flattening feature cleanly on top of #511:

- **Default behaviour (unchanged from #511):** context is stored as a structured array attribute, e.g. `->setAttribute('context', ['http' => ['method' => 'GET'], 'user_id' => '123'])`.
- **Opt-in flatten mode** (`OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN=true`): context fields are spread as individual top-level OTLP attributes using `Illuminate\Support\Arr::dot()`, enabling faceted search in observability backends.

The non-flatten default path is identical to what #511 shipped. The flatten path is additive and off by default.

### Changes

- `src/Watchers/LogWatcher.php`: adds `OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN` constant, reads it via `ConfigurationResolver` in the constructor, and branches on it in `recordLog()`. A `normalizeValue()` helper ensures OTLP-compatible scalar types (casting `Stringable` objects to string, JSON-encoding anything else).
- `tests/Unit/Watchers/LogWatcherTest.php`: 8 unit tests covering default structured-array mode, flatten mode, nested dot-notation expansion, exception extraction, `Stringable` normalisation, and null filtering.

### Backward compatibility

- Default behaviour is unchanged from #511.
- `OTEL_PHP_LARAVEL_LOG_ATTRIBUTES_FLATTEN` is off by default; existing deployments are unaffected.