### PR TITLE
[Laravel] Add opt-in fastcgi_finish_request() hook in Kernel::terminate() to prevent blocking OTLP export from affecting PHP-FPM response time

### DIFF
--- a/src/Aws/composer.json
+++ b/src/Aws/composer.json
@@ -31,7 +31,7 @@
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "~9",
-        "psalm/plugin-phpunit": "^0.20.0",
+        "psalm/plugin-phpunit": "^0.19.2",
         "vimeo/psalm": "6.4.0"
     },
     "autoload": {

--- a/src/Aws/composer.json
+++ b/src/Aws/composer.json
@@ -32,7 +32,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "~9",
         "psalm/plugin-phpunit": "^0.20.0",
-        "vimeo/psalm": "6.16.1"
+        "vimeo/psalm": "6.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Context/Swoole/composer.json
+++ b/src/Context/Swoole/composer.json
@@ -28,7 +28,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Context/Swoole/composer.json
+++ b/src/Context/Swoole/composer.json
@@ -31,6 +31,6 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   }
 }

--- a/src/Exporter/Instana/composer.json
+++ b/src/Exporter/Instana/composer.json
@@ -27,7 +27,7 @@
         "phan/phan": "^5.0",
         "phpstan/phpstan": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",
-        "psalm/plugin-phpunit": "^0.20.0",
+        "psalm/plugin-phpunit": "^0.19.2",
         "open-telemetry/sdk": "^1.0",
         "phpunit/phpunit": "^9.5",
         "vimeo/psalm": "^4|^5|^6",

--- a/src/Instrumentation/AwsSdk/composer.json
+++ b/src/Instrumentation/AwsSdk/composer.json
@@ -23,7 +23,7 @@
     "phpstan/phpstan-mockery": "^1.1.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/AwsSdk/composer.json
+++ b/src/Instrumentation/AwsSdk/composer.json
@@ -26,7 +26,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/CakePHP/composer.json
+++ b/src/Instrumentation/CakePHP/composer.json
@@ -23,7 +23,7 @@
     "phpstan/phpstan-mockery": "^1.1.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5|^10.5",
     "vimeo/psalm": "6.4.0",

--- a/src/Instrumentation/CakePHP/composer.json
+++ b/src/Instrumentation/CakePHP/composer.json
@@ -26,7 +26,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5|^10.5",
-    "vimeo/psalm": "6.16.1",
+    "vimeo/psalm": "6.4.0",
     "symfony/http-client": "^6 || ^7"
   },
   "suggest": {

--- a/src/Instrumentation/CodeIgniter/composer.json
+++ b/src/Instrumentation/CodeIgniter/composer.json
@@ -28,7 +28,7 @@
       "phpstan/phpstan-phpunit": "^1.0",
       "psalm/plugin-phpunit": "^0.20.0",
       "phpunit/phpunit": "^9.5",
-      "vimeo/psalm": "6.16.1"
+      "vimeo/psalm": "6.4.0"
     },
     "autoload": {
       "psr-4": {

--- a/src/Instrumentation/CodeIgniter/composer.json
+++ b/src/Instrumentation/CodeIgniter/composer.json
@@ -26,7 +26,7 @@
       "php-http/mock-client": "*",
       "phpstan/phpstan": "^1.1",
       "phpstan/phpstan-phpunit": "^1.0",
-      "psalm/plugin-phpunit": "^0.20.0",
+      "psalm/plugin-phpunit": "^0.19.2",
       "phpunit/phpunit": "^9.5",
       "vimeo/psalm": "6.4.0"
     },

--- a/src/Instrumentation/Curl/composer.json
+++ b/src/Instrumentation/Curl/composer.json
@@ -28,7 +28,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/Curl/composer.json
+++ b/src/Instrumentation/Curl/composer.json
@@ -31,7 +31,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Doctrine/composer.json
+++ b/src/Instrumentation/Doctrine/composer.json
@@ -31,7 +31,7 @@
         "psalm/plugin-phpunit": "^0.20.0",
         "open-telemetry/sdk": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "vimeo/psalm": "6.16.1"
+        "vimeo/psalm": "6.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Instrumentation/Doctrine/composer.json
+++ b/src/Instrumentation/Doctrine/composer.json
@@ -28,7 +28,7 @@
         "php-http/mock-client": "*",
         "phpstan/phpstan": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",
-        "psalm/plugin-phpunit": "^0.20.0",
+        "psalm/plugin-phpunit": "^0.19.2",
         "open-telemetry/sdk": "^1.0",
         "phpunit/phpunit": "^9.5",
         "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/ExtAmqp/composer.json
+++ b/src/Instrumentation/ExtAmqp/composer.json
@@ -25,7 +25,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/ExtAmqp/composer.json
+++ b/src/Instrumentation/ExtAmqp/composer.json
@@ -22,7 +22,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/ExtRdKafka/composer.json
+++ b/src/Instrumentation/ExtRdKafka/composer.json
@@ -23,7 +23,7 @@
     "mockery/mockery": "^1.5",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/ExtRdKafka/composer.json
+++ b/src/Instrumentation/ExtRdKafka/composer.json
@@ -26,7 +26,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Guzzle/composer.json
+++ b/src/Instrumentation/Guzzle/composer.json
@@ -23,7 +23,7 @@
     "phpstan/phpstan-mockery": "^1.1.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/Guzzle/composer.json
+++ b/src/Instrumentation/Guzzle/composer.json
@@ -26,7 +26,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/HttpAsyncClient/composer.json
+++ b/src/Instrumentation/HttpAsyncClient/composer.json
@@ -32,7 +32,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/HttpAsyncClient/composer.json
+++ b/src/Instrumentation/HttpAsyncClient/composer.json
@@ -35,7 +35,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "config": {
     "allow-plugins": {

--- a/src/Instrumentation/HttpConfig/composer.json
+++ b/src/Instrumentation/HttpConfig/composer.json
@@ -19,7 +19,7 @@
     "phan/phan": "^5.4",
     "phpstan/phpstan": "^2.1",
     "phpstan/phpstan-phpunit": "^2.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.3",
     "open-telemetry/sdk": "^1.6",
     "open-telemetry/sdk-configuration": "^0.8",
     "phpunit/phpunit": "^10.5",

--- a/src/Instrumentation/IO/composer.json
+++ b/src/Instrumentation/IO/composer.json
@@ -20,7 +20,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/IO/composer.json
+++ b/src/Instrumentation/IO/composer.json
@@ -23,7 +23,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Laravel/README.md
+++ b/src/Instrumentation/Laravel/README.md
@@ -22,3 +22,38 @@ The extension can be disabled via [runtime configuration](https://opentelemetry.
 ```shell
 OTEL_PHP_DISABLED_INSTRUMENTATIONS=laravel
 ```
+
+### PHP-FPM: Non-blocking telemetry export
+
+By default, the OTel SDK exports spans during the PHP process shutdown phase using a synchronous,
+blocking HTTP POST. Under PHP-FPM, when the collector is slow or unreachable, the FPM worker is
+held for the full exporter timeout, causing worker pool exhaustion and upstream proxy timeouts.
+
+Enable this opt-in feature to call `fastcgi_finish_request()` during `Kernel::terminate()`. This
+closes the FastCGI connection to nginx before the blocking export begins. The client and upstream
+proxy see the request as complete immediately; the FPM worker finishes the export in the
+background using the existing SDK shutdown handler.
+
+```shell
+OTEL_PHP_INSTRUMENTATION_LARAVEL_FPM_FINISH_REQUEST_ENABLED=true
+```
+
+**Configure exporter timeouts first (required):**
+
+Bound the background worker time even during collector outages:
+
+```shell
+OTEL_EXPORTER_OTLP_TIMEOUT=500
+OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=500
+OTEL_BSP_EXPORT_TIMEOUT=1000
+```
+
+**Tradeoffs:**
+
+- Eliminates user-facing latency spikes and upstream proxy timeouts caused by blocking OTLP export.
+- FPM worker pool can still be exhausted during prolonged outages; bound this with the timeouts above.
+- `fastcgi_finish_request()` is a PHP-FPM built-in. Outside FPM (CLI, tests), it does not exist
+  and is silently skipped.
+- **Do not enable in long-running Laravel workers (Octane/Swoole/RoadRunner).** The feature detects
+  Octane via the `LARAVEL_OCTANE` environment variable and the application container, and logs a
+  warning if misused rather than silently misbehaving.

--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -38,7 +38,7 @@
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "spatie/laravel-ignition": "*",
     "vimeo/psalm": "6.4.0"
   },

--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -40,7 +40,7 @@
     "phpunit/phpunit": "^9.5",
     "psalm/plugin-phpunit": "^0.20.0",
     "spatie/laravel-ignition": "*",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
@@ -18,6 +18,7 @@ use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHookTrait;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\PostHookTrait;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Propagators\HeadersPropagator;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Propagators\ResponsePropagationSetter;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Support\FpmFinishRequest;
 use function OpenTelemetry\Instrumentation\hook;
 use OpenTelemetry\SemConv\TraceAttributes;
 use Symfony\Component\HttpFoundation\Response;
@@ -31,6 +32,7 @@ class Kernel implements LaravelHook
     public function instrument(): void
     {
         $this->hookHandle();
+        $this->hookTerminate();
     }
 
     /** @psalm-suppress PossiblyUnusedReturnValue  */
@@ -128,5 +130,22 @@ class Kernel implements LaravelHook
         }
 
         return '';
+    }
+
+    /**
+     * Always registered regardless of the feature flag.
+     * handle() evaluates the env toggle on first call (then caches it);
+     * subsequent terminate() calls are a single cached property read.
+     * @psalm-suppress UnusedReturnValue
+     */
+    private function hookTerminate(): bool
+    {
+        return hook(
+            KernelContract::class,
+            'terminate',
+            post: static function (): void {
+                FpmFinishRequest::handle();
+            }
+        );
     }
 }

--- a/src/Instrumentation/Laravel/src/Support/FpmFinishRequest.php
+++ b/src/Instrumentation/Laravel/src/Support/FpmFinishRequest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Support;
+
+use const FILTER_NULL_ON_FAILURE;
+use const FILTER_VALIDATE_BOOLEAN;
+use function filter_var;
+use function function_exists;
+use function getenv;
+use function is_scalar;
+use function method_exists;
+use OpenTelemetry\API\Behavior\LogsMessagesTrait;
+use function sprintf;
+use Throwable;
+
+/**
+ * Closes the FastCGI connection during Laravel Kernel::terminate() so the
+ * FPM worker can flush telemetry in the background without blocking the
+ * client or upstream proxy.
+ *
+ * Enable for PHP-FPM workloads only. Do not use with long-running runtimes
+ * such as Laravel Octane (Swoole/RoadRunner).
+ */
+final class FpmFinishRequest
+{
+    use LogsMessagesTrait;
+
+    public const ENV_ENABLED = 'OTEL_PHP_INSTRUMENTATION_LARAVEL_FPM_FINISH_REQUEST_ENABLED';
+    public const ENV_LARAVEL_OCTANE = 'LARAVEL_OCTANE';
+    public const WARNING_PREFIX = '[otel.laravel.fpm]';
+
+    private static ?bool $enabled = null;
+    /** @var array<string, true> */
+    private static array $loggedWarnings = [];
+    /** @var (callable(): void)|null */
+    private static $finishRequestCallback = null;
+
+    /** @psalm-suppress UnusedConstructor */
+    private function __construct()
+    {
+    }
+
+    public static function isEnabled(): bool
+    {
+        $enabled = self::$enabled;
+        if ($enabled !== null) {
+            return $enabled;
+        }
+
+        $raw = self::readEnv(self::ENV_ENABLED);
+        $enabled = filter_var($raw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false;
+        self::$enabled = $enabled;
+
+        return $enabled;
+    }
+
+    /** @internal For testing only. */
+    public static function resetCache(): void
+    {
+        self::$enabled = null;
+        self::$loggedWarnings = [];
+        self::$finishRequestCallback = null;
+    }
+
+    /**
+     * Override the finish-request implementation. Pass null to restore the
+     * default (fastcgi_finish_request() when available).
+     *
+     * @internal For testing only.
+     * @param (callable(): void)|null $callback
+     */
+    public static function setFinishRequestCallback(?callable $callback): void
+    {
+        self::$finishRequestCallback = $callback;
+    }
+
+    public static function handle(): void
+    {
+        if (!self::isEnabled()) {
+            return;
+        }
+
+        $warning = self::longRunningRuntimeWarning();
+        if ($warning !== null) {
+            // Deduplicate runtime-guard warnings only. Callback errors from
+            // finishRequest() are intentionally not deduplicated because a
+            // throwing callback indicates an active configuration defect.
+            if (!isset(self::$loggedWarnings[$warning])) {
+                self::logWarning($warning);
+                self::$loggedWarnings[$warning] = true;
+            }
+
+            return;
+        }
+
+        self::finishRequest();
+    }
+
+    private static function finishRequest(): void
+    {
+        if (self::$finishRequestCallback !== null) {
+            try {
+                (self::$finishRequestCallback)();
+            } catch (Throwable $throwable) {
+                self::logWarning(sprintf(
+                    '%s finish-request callback threw: %s',
+                    self::WARNING_PREFIX,
+                    $throwable->getMessage(),
+                ));
+            }
+
+            return;
+        }
+
+        if (function_exists('fastcgi_finish_request')) {
+            // The false-return path cannot be exercised in unit tests because
+            // fastcgi_finish_request() is a C built-in and cannot be mocked.
+            // The callback path (setFinishRequestCallback) is used for testing instead.
+            // @codeCoverageIgnoreStart
+            if (fastcgi_finish_request() === false) {
+                self::logWarning(sprintf(
+                    '%s fastcgi_finish_request() returned false; response may not have been flushed',
+                    self::WARNING_PREFIX,
+                ));
+            }
+            // @codeCoverageIgnoreEnd
+        }
+    }
+
+    /**
+     * Env signals are re-evaluated on each call. Container lookup remains a
+     * lightweight fallback when no env signal is present.
+     *
+     * Warning dedup uses rendered message text as key; this includes the raw
+     * env signal for invalid values and is therefore bounded by distinct values
+     * seen over the process lifetime.
+     *
+     * @return string|null Warning message if running in a long-lived process, null if safe to proceed.
+     */
+    private static function longRunningRuntimeWarning(): ?string
+    {
+        $signal = self::readEnv(self::ENV_LARAVEL_OCTANE);
+        if ($signal !== null) {
+            $isEnabled = filter_var($signal, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            if ($isEnabled === true) {
+                return self::longRunningRuntimeMessage();
+            }
+
+            if ($isEnabled === null) {
+                return sprintf(
+                    '%s unrecognized %s value "%s"; expected boolean-like value, treating as long-running runtime (fail-closed)',
+                    self::WARNING_PREFIX,
+                    self::ENV_LARAVEL_OCTANE,
+                    $signal,
+                );
+            }
+        }
+
+        if (self::isLongRunningContainerRuntime()) {
+            return self::longRunningRuntimeMessage();
+        }
+
+        return null;
+    }
+
+    private static function longRunningRuntimeMessage(): string
+    {
+        return sprintf(
+            '%s skipping fastcgi_finish_request() in long-running Laravel runtime',
+            self::WARNING_PREFIX,
+        );
+    }
+
+    private static function isLongRunningContainerRuntime(): bool
+    {
+        if (!function_exists('app')) {
+            return false;
+        }
+
+        // Container fallback is integration-oriented; unit tests primarily cover env-based guards.
+        try {
+            $app = app();
+            if (!method_exists($app, 'bound')) {
+                return false;
+            }
+
+            if ($app->bound('octane') || $app->bound('octane.client') || $app->bound('octane.worker')) {
+                return true;
+            }
+
+            return false;
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private static function readEnv(string $key): ?string
+    {
+        $server = $_SERVER[$key] ?? null;
+        if ($server !== null && $server !== '') {
+            // Web-server SAPIs may occasionally provide non-string scalar values.
+            if (is_scalar($server)) {
+                return (string) $server;
+            }
+
+            return null;
+        }
+
+        $env = getenv($key);
+
+        return ($env === false || $env === '') ? null : $env;
+    }
+}

--- a/src/Instrumentation/Laravel/tests/Unit/Support/FpmFinishRequestTest.php
+++ b/src/Instrumentation/Laravel/tests/Unit/Support/FpmFinishRequestTest.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Unit\Support;
+
+use OpenTelemetry\API\Behavior\Internal\Logging;
+use OpenTelemetry\API\Behavior\Internal\LogWriter\LogWriterInterface;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Support\FpmFinishRequest;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class FpmFinishRequestTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->setEnabled(false);
+        $this->setOctaneSignal(null);
+        FpmFinishRequest::resetCache();
+        Logging::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setEnabled(false);
+        $this->setOctaneSignal(null);
+        FpmFinishRequest::resetCache();
+        Logging::reset();
+    }
+
+    /**
+     * @dataProvider disabledEnvProvider
+     */
+    public function test_is_not_enabled_by_default(?string $raw): void
+    {
+        if ($raw === null) {
+            putenv(FpmFinishRequest::ENV_ENABLED);
+            unset($_SERVER[FpmFinishRequest::ENV_ENABLED]);
+        } else {
+            putenv(FpmFinishRequest::ENV_ENABLED . '=' . $raw);
+            $_SERVER[FpmFinishRequest::ENV_ENABLED] = $raw;
+        }
+        FpmFinishRequest::resetCache();
+
+        $this->assertFalse(FpmFinishRequest::isEnabled());
+    }
+
+    /**
+     * @dataProvider enabledEnvProvider
+     */
+    public function test_is_enabled_when_env_is_truthy(string $raw): void
+    {
+        putenv(FpmFinishRequest::ENV_ENABLED . '=' . $raw);
+        $_SERVER[FpmFinishRequest::ENV_ENABLED] = $raw;
+        FpmFinishRequest::resetCache();
+
+        $this->assertTrue(FpmFinishRequest::isEnabled());
+    }
+
+    public function test_is_enabled_when_server_signal_is_scalar(): void
+    {
+        putenv(FpmFinishRequest::ENV_ENABLED);
+        $_SERVER[FpmFinishRequest::ENV_ENABLED] = 1;
+        FpmFinishRequest::resetCache();
+
+        $this->assertTrue(FpmFinishRequest::isEnabled());
+    }
+
+    public function test_is_enabled_result_is_cached(): void
+    {
+        $this->setEnabled(true);
+        $this->assertTrue(FpmFinishRequest::isEnabled());
+
+        try {
+            // Change env without resetting cache; cached value should be retained.
+            putenv(FpmFinishRequest::ENV_ENABLED . '=false');
+            $_SERVER[FpmFinishRequest::ENV_ENABLED] = 'false';
+
+            $this->assertTrue(FpmFinishRequest::isEnabled());
+        } finally {
+            putenv(FpmFinishRequest::ENV_ENABLED);
+            unset($_SERVER[FpmFinishRequest::ENV_ENABLED]);
+        }
+    }
+
+    public function test_finish_request_is_called_when_enabled(): void
+    {
+        $this->setEnabled(true);
+
+        $called = false;
+        FpmFinishRequest::setFinishRequestCallback(static function () use (&$called): void {
+            $called = true;
+        });
+
+        FpmFinishRequest::handle();
+
+        $this->assertTrue($called, 'fastcgi_finish_request() should have been called when enabled');
+    }
+
+    public function test_finish_request_is_not_called_when_disabled(): void
+    {
+        $this->setEnabled(false);
+
+        $called = false;
+        FpmFinishRequest::setFinishRequestCallback(static function () use (&$called): void {
+            $called = true;
+        });
+
+        FpmFinishRequest::handle();
+
+        $this->assertFalse($called, 'fastcgi_finish_request() must not be called when disabled');
+    }
+
+    public function test_finish_request_is_not_called_when_octane_env_signal_is_set(): void
+    {
+        $this->setEnabled(true);
+        $this->setOctaneSignal('1');
+
+        $called = false;
+        FpmFinishRequest::setFinishRequestCallback(static function () use (&$called): void {
+            $called = true;
+        });
+
+        FpmFinishRequest::handle();
+
+        $this->assertFalse($called, 'fastcgi_finish_request() must not be called in long-running runtime');
+    }
+
+    public function test_explicit_octane_false_allows_finish_request(): void
+    {
+        $this->setEnabled(true);
+        $this->setOctaneSignal('false');
+
+        $called = false;
+        FpmFinishRequest::setFinishRequestCallback(static function () use (&$called): void {
+            $called = true;
+        });
+
+        FpmFinishRequest::handle();
+
+        $this->assertTrue($called, 'Explicit LARAVEL_OCTANE=false should allow fastcgi_finish_request()');
+    }
+
+    public function test_explicit_octane_zero_allows_finish_request(): void
+    {
+        $this->setEnabled(true);
+        $this->setOctaneSignal('0');
+
+        $called = false;
+        FpmFinishRequest::setFinishRequestCallback(static function () use (&$called): void {
+            $called = true;
+        });
+
+        FpmFinishRequest::handle();
+
+        $this->assertTrue($called, 'LARAVEL_OCTANE=0 should allow fastcgi_finish_request()');
+    }
+
+    public function test_warning_is_logged_when_octane_guard_fires(): void
+    {
+        $this->setEnabled(true);
+        $this->setOctaneSignal('1');
+
+        $called = false;
+        FpmFinishRequest::setFinishRequestCallback(static function () use (&$called): void {
+            $called = true;
+        });
+
+        $logs = $this->collectWarnings(static fn () => FpmFinishRequest::handle());
+
+        $this->assertWarningEntriesContain(
+            $logs,
+            FpmFinishRequest::WARNING_PREFIX . ' skipping fastcgi_finish_request() in long-running Laravel runtime'
+        );
+
+        $this->assertFalse($called, 'finishRequest() must not be called when Octane guard fires');
+    }
+
+    public function test_octane_warning_is_logged_only_once(): void
+    {
+        $this->setEnabled(true);
+        $this->setOctaneSignal('1');
+
+        FpmFinishRequest::setFinishRequestCallback(static function (): void {
+        });
+
+        $logs = $this->collectWarnings(static function (): void {
+            FpmFinishRequest::handle();
+            FpmFinishRequest::handle();
+        });
+
+        $warningCount = count(array_filter(
+            $logs,
+            static fn (array $entry): bool => str_contains($entry['message'], 'skipping fastcgi_finish_request()')
+        ));
+
+        $this->assertSame(1, $warningCount, 'Warning must be emitted exactly once per distinct message');
+    }
+
+    public function test_distinct_long_running_warnings_are_both_logged(): void
+    {
+        $this->setEnabled(true);
+
+        FpmFinishRequest::setFinishRequestCallback(static function (): void {
+        });
+
+        $logs = $this->collectWarnings(function (): void {
+            // Intentionally switch signals without cache reset to prove
+            // distinct warning messages are deduplicated independently.
+            $this->setOctaneSignal('roadrunner');
+            FpmFinishRequest::handle();
+
+            $this->setOctaneSignal('1');
+            FpmFinishRequest::handle();
+        });
+
+        $this->assertWarningEntriesContain($logs, 'unrecognized LARAVEL_OCTANE value "roadrunner"');
+        $this->assertWarningEntriesContain($logs, 'skipping fastcgi_finish_request() in long-running Laravel runtime');
+    }
+
+    public function test_warning_is_logged_when_octane_signal_is_invalid(): void
+    {
+        $this->setEnabled(true);
+        $this->setOctaneSignal('roadrunner');
+
+        $called = false;
+        FpmFinishRequest::setFinishRequestCallback(static function () use (&$called): void {
+            $called = true;
+        });
+
+        $logs = $this->collectWarnings(static fn () => FpmFinishRequest::handle());
+
+        $this->assertWarningEntriesContain(
+            $logs,
+            FpmFinishRequest::WARNING_PREFIX . ' unrecognized LARAVEL_OCTANE value "roadrunner"; expected boolean-like value, treating as long-running runtime (fail-closed)'
+        );
+        $this->assertFalse($called, 'finishRequest() must not fire when LARAVEL_OCTANE is unrecognized');
+    }
+
+    public function test_handle_delegates_every_call(): void
+    {
+        $this->setEnabled(true);
+
+        $callCount = 0;
+        FpmFinishRequest::setFinishRequestCallback(static function () use (&$callCount): void {
+            $callCount++;
+        });
+
+        FpmFinishRequest::handle();
+        FpmFinishRequest::handle();
+
+        $this->assertSame(2, $callCount, 'handle() should delegate every call; idempotency is the caller\'s responsibility');
+    }
+
+    public function test_warning_is_logged_when_finish_request_callback_throws(): void
+    {
+        $this->setEnabled(true);
+
+        FpmFinishRequest::setFinishRequestCallback(static function (): void {
+            throw new RuntimeException('callback exploded');
+        });
+
+        $logs = $this->collectWarnings(static fn () => FpmFinishRequest::handle());
+
+        $this->assertWarningEntriesContain(
+            $logs,
+            FpmFinishRequest::WARNING_PREFIX . ' finish-request callback threw: callback exploded'
+        );
+    }
+
+    public function test_reset_cache_clears_warning_dedup_state(): void
+    {
+        $this->setEnabled(true);
+        $this->setOctaneSignal('1');
+
+        FpmFinishRequest::setFinishRequestCallback(static function (): void {
+        });
+
+        $this->collectWarnings(static fn () => FpmFinishRequest::handle());
+        FpmFinishRequest::resetCache();
+
+        // Re-arm state explicitly after resetCache() cleared all internals.
+        $this->setEnabled(true);
+        FpmFinishRequest::setFinishRequestCallback(static function (): void {
+        });
+
+        $logs = $this->collectWarnings(static fn () => FpmFinishRequest::handle());
+        $this->assertWarningEntriesContain($logs, 'skipping fastcgi_finish_request()');
+    }
+
+    /** @return array<string, array{0: ?string}> */
+    public static function disabledEnvProvider(): array
+    {
+        return [
+            'unset' => [null],
+            'empty' => [''],
+            'zero' => ['0'],
+            'false' => ['false'],
+            'no' => ['no'],
+            'off' => ['off'],
+            'invalid' => ['not-a-bool'],
+        ];
+    }
+
+    /** @return array<string, array{0: string}> */
+    public static function enabledEnvProvider(): array
+    {
+        return [
+            'true' => ['true'],
+            'one' => ['1'],
+            'yes' => ['yes'],
+            'on' => ['on'],
+        ];
+    }
+
+    private function setEnabled(bool $enabled): void
+    {
+        if ($enabled) {
+            putenv(FpmFinishRequest::ENV_ENABLED . '=true');
+            $_SERVER[FpmFinishRequest::ENV_ENABLED] = 'true';
+        } else {
+            putenv(FpmFinishRequest::ENV_ENABLED);
+            unset($_SERVER[FpmFinishRequest::ENV_ENABLED]);
+        }
+    }
+
+    private function setOctaneSignal(?string $value): void
+    {
+        if ($value === null) {
+            putenv(FpmFinishRequest::ENV_LARAVEL_OCTANE);
+            unset($_SERVER[FpmFinishRequest::ENV_LARAVEL_OCTANE]);
+
+            return;
+        }
+
+        putenv(FpmFinishRequest::ENV_LARAVEL_OCTANE . '=' . $value);
+        $_SERVER[FpmFinishRequest::ENV_LARAVEL_OCTANE] = $value;
+    }
+
+    /** @return list<array{level: string, message: string}> */
+    private function collectWarnings(callable $callback): array
+    {
+        $logs = (object) ['entries' => []];
+        Logging::setLogWriter(new class($logs) implements LogWriterInterface {
+            public function __construct(private readonly object $logs)
+            {
+            }
+
+            public function write($level, string $message, array $context): void
+            {
+                $this->logs->entries[] = ['level' => (string) $level, 'message' => $message];
+            }
+        });
+
+        try {
+            $callback();
+        } finally {
+            Logging::reset();
+        }
+
+        /** @var list<array{level: string, message: string}> $entries */
+        $entries = $logs->entries;
+
+        return $entries;
+    }
+
+    /** @param list<array{level: string, message: string}> $logs */
+    private function assertWarningEntriesContain(array $logs, string $expectedSubstring): void
+    {
+        $found = false;
+        foreach ($logs as $entry) {
+            if (str_contains($entry['message'], $expectedSubstring)) {
+                $found = true;
+
+                break;
+            }
+        }
+
+        $encoded = json_encode($logs);
+        $this->assertTrue(
+            $found,
+            sprintf(
+                'Expected a warning containing "%s", got: %s',
+                $expectedSubstring,
+                $encoded !== false ? $encoded : '(json_encode failed)'
+            )
+        );
+    }
+}

--- a/src/Instrumentation/MongoDB/composer.json
+++ b/src/Instrumentation/MongoDB/composer.json
@@ -22,7 +22,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/MongoDB/composer.json
+++ b/src/Instrumentation/MongoDB/composer.json
@@ -19,7 +19,7 @@
     "phan/phan": "^5.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/MySqli/composer.json
+++ b/src/Instrumentation/MySqli/composer.json
@@ -33,7 +33,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/MySqli/composer.json
+++ b/src/Instrumentation/MySqli/composer.json
@@ -36,7 +36,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/OpenAIPHP/composer.json
+++ b/src/Instrumentation/OpenAIPHP/composer.json
@@ -26,7 +26,7 @@
     "nyholm/psr7": "^1",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/OpenAIPHP/composer.json
+++ b/src/Instrumentation/OpenAIPHP/composer.json
@@ -22,7 +22,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "nyholm/psr7": "^1",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",

--- a/src/Instrumentation/PDO/composer.json
+++ b/src/Instrumentation/PDO/composer.json
@@ -29,7 +29,7 @@
     "open-telemetry/sdk": "^1.0",
     "open-telemetry/test-utils": "^0.2.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/PDO/composer.json
+++ b/src/Instrumentation/PDO/composer.json
@@ -25,7 +25,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "open-telemetry/test-utils": "^0.2.0",
     "phpunit/phpunit": "^9.5",

--- a/src/Instrumentation/PostgreSql/composer.json
+++ b/src/Instrumentation/PostgreSql/composer.json
@@ -33,7 +33,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/PostgreSql/composer.json
+++ b/src/Instrumentation/PostgreSql/composer.json
@@ -36,7 +36,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Psr14/composer.json
+++ b/src/Instrumentation/Psr14/composer.json
@@ -36,7 +36,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/Psr14/composer.json
+++ b/src/Instrumentation/Psr14/composer.json
@@ -39,7 +39,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "config": {
     "allow-plugins": {

--- a/src/Instrumentation/Psr15/composer.json
+++ b/src/Instrumentation/Psr15/composer.json
@@ -30,7 +30,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/Psr15/composer.json
+++ b/src/Instrumentation/Psr15/composer.json
@@ -33,6 +33,6 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   }
 }

--- a/src/Instrumentation/Psr16/composer.json
+++ b/src/Instrumentation/Psr16/composer.json
@@ -25,7 +25,7 @@
     "psalm/plugin-phpunit": "^0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Psr18/composer.json
+++ b/src/Instrumentation/Psr18/composer.json
@@ -30,7 +30,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/Psr18/composer.json
+++ b/src/Instrumentation/Psr18/composer.json
@@ -33,6 +33,6 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   }
 }

--- a/src/Instrumentation/Psr3/composer.json
+++ b/src/Instrumentation/Psr3/composer.json
@@ -42,7 +42,7 @@
     "phan/phan": "^5.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/Psr3/composer.json
+++ b/src/Instrumentation/Psr3/composer.json
@@ -45,7 +45,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "config": {
     "allow-plugins": {

--- a/src/Instrumentation/Psr6/composer.json
+++ b/src/Instrumentation/Psr6/composer.json
@@ -25,7 +25,7 @@
     "psalm/plugin-phpunit": "^0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/ReactPHP/composer.json
+++ b/src/Instrumentation/ReactPHP/composer.json
@@ -25,7 +25,7 @@
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "react/async": "^4.3.0",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/ReactPHP/composer.json
+++ b/src/Instrumentation/ReactPHP/composer.json
@@ -21,7 +21,7 @@
     "phan/phan": "^5.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "react/async": "^4.3.0",

--- a/src/Instrumentation/Session/composer.json
+++ b/src/Instrumentation/Session/composer.json
@@ -24,7 +24,7 @@
         "php-http/mock-client": "*",
         "phpstan/phpstan": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",
-        "psalm/plugin-phpunit": "^0.20.0",
+        "psalm/plugin-phpunit": "^0.19.2",
         "open-telemetry/sdk": "^1.0",
         "phpunit/phpunit": "^9.5",
         "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/Session/composer.json
+++ b/src/Instrumentation/Session/composer.json
@@ -27,6 +27,6 @@
         "psalm/plugin-phpunit": "^0.20.0",
         "open-telemetry/sdk": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "vimeo/psalm": "6.16.1"
+        "vimeo/psalm": "6.4.0"
     }
 }

--- a/src/Instrumentation/Slim/composer.json
+++ b/src/Instrumentation/Slim/composer.json
@@ -32,7 +32,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.8",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Slim/composer.json
+++ b/src/Instrumentation/Slim/composer.json
@@ -29,7 +29,7 @@
     "phpstan/phpstan-mockery": "^1.1.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.8",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"

--- a/src/Instrumentation/Symfony/composer.json
+++ b/src/Instrumentation/Symfony/composer.json
@@ -26,7 +26,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.8",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0",

--- a/src/Instrumentation/Symfony/composer.json
+++ b/src/Instrumentation/Symfony/composer.json
@@ -29,7 +29,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.8",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1",
+    "vimeo/psalm": "6.4.0",
     "symfony/http-client": "^5.4||^6.0",
     "symfony/messenger": "^5.4||^6.0"
   },

--- a/src/Instrumentation/Wordpress/composer.json
+++ b/src/Instrumentation/Wordpress/composer.json
@@ -25,7 +25,7 @@
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.20.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Wordpress/composer.json
+++ b/src/Instrumentation/Wordpress/composer.json
@@ -23,7 +23,7 @@
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"
   },

--- a/src/Instrumentation/Yii/composer.json
+++ b/src/Instrumentation/Yii/composer.json
@@ -26,7 +26,7 @@
       "phpstan/phpstan-phpunit": "^1.0",
       "psalm/plugin-phpunit": "^0.20.0",
       "phpunit/phpunit": "^9.5",
-      "vimeo/psalm": "6.16.1"
+      "vimeo/psalm": "6.4.0"
     },
     "repositories": [
       {

--- a/src/Instrumentation/Yii/composer.json
+++ b/src/Instrumentation/Yii/composer.json
@@ -24,7 +24,7 @@
       "php-http/mock-client": "*",
       "phpstan/phpstan": "^1.1",
       "phpstan/phpstan-phpunit": "^1.0",
-      "psalm/plugin-phpunit": "^0.20.0",
+      "psalm/plugin-phpunit": "^0.19.2",
       "phpunit/phpunit": "^9.5",
       "vimeo/psalm": "6.4.0"
     },

--- a/src/Logs/Monolog/composer.json
+++ b/src/Logs/Monolog/composer.json
@@ -29,7 +29,7 @@
     "phpbench/phpbench": "^1.2",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"
   },

--- a/src/Logs/Monolog/composer.json
+++ b/src/Logs/Monolog/composer.json
@@ -31,7 +31,7 @@
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.20.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "config": {
     "allow-plugins": {

--- a/src/Propagation/CloudTrace/composer.json
+++ b/src/Propagation/CloudTrace/composer.json
@@ -30,7 +30,7 @@
     "phan/phan": "^5.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "^4|^5|^6"

--- a/src/Propagation/Instana/composer.json
+++ b/src/Propagation/Instana/composer.json
@@ -26,7 +26,7 @@
     "phan/phan": "^5.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "^4|^5|^6",

--- a/src/Propagation/ServerTiming/composer.json
+++ b/src/Propagation/ServerTiming/composer.json
@@ -25,7 +25,7 @@
     "phan/phan": "^5.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.8",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "^4|^5|^6",

--- a/src/Propagation/TraceResponse/composer.json
+++ b/src/Propagation/TraceResponse/composer.json
@@ -28,7 +28,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.8",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1",
+    "vimeo/psalm": "6.4.0",
     "symfony/http-client": "^5.4|^6.0",
     "guzzlehttp/promises": "^2",
     "php-http/message-factory": "^1.0",

--- a/src/Propagation/TraceResponse/composer.json
+++ b/src/Propagation/TraceResponse/composer.json
@@ -25,7 +25,7 @@
     "phan/phan": "^5.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.8",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0",

--- a/src/ResourceDetectors/Azure/composer.json
+++ b/src/ResourceDetectors/Azure/composer.json
@@ -30,7 +30,7 @@
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "~9",
-        "psalm/plugin-phpunit": "^0.20.0",
+        "psalm/plugin-phpunit": "^0.19.2",
         "vimeo/psalm": "6.4.0"
     },
     "autoload": {

--- a/src/ResourceDetectors/Azure/composer.json
+++ b/src/ResourceDetectors/Azure/composer.json
@@ -31,7 +31,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "~9",
         "psalm/plugin-phpunit": "^0.20.0",
-        "vimeo/psalm": "6.16.1"
+        "vimeo/psalm": "6.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ResourceDetectors/Container/composer.json
+++ b/src/ResourceDetectors/Container/composer.json
@@ -29,7 +29,7 @@
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.20.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1",
+    "vimeo/psalm": "6.4.0",
     "symfony/http-client": "^5.4|^6.0",
     "guzzlehttp/promises": "^1.5|^2",
     "php-http/message-factory": "^1.0",

--- a/src/ResourceDetectors/Container/composer.json
+++ b/src/ResourceDetectors/Container/composer.json
@@ -27,7 +27,7 @@
     "phan/phan": "^5.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0",
     "symfony/http-client": "^5.4|^6.0",

--- a/src/ResourceDetectors/DigitalOcean/composer.json
+++ b/src/ResourceDetectors/DigitalOcean/composer.json
@@ -26,7 +26,7 @@
         "phpstan/phpstan": "^1.10.13",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "^10 || ^11",
-        "psalm/plugin-phpunit": "^0.20.0",
+        "psalm/plugin-phpunit": "^0.19.2",
         "vimeo/psalm": "6.4.0",
         "zalas/phpunit-globals": "^4.0"
     },

--- a/src/ResourceDetectors/DigitalOcean/composer.json
+++ b/src/ResourceDetectors/DigitalOcean/composer.json
@@ -27,7 +27,7 @@
         "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "^10 || ^11",
         "psalm/plugin-phpunit": "^0.20.0",
-        "vimeo/psalm": "6.16.1",
+        "vimeo/psalm": "6.4.0",
         "zalas/phpunit-globals": "^4.0"
     },
     "autoload": {

--- a/src/Sampler/RuleBased/composer.json
+++ b/src/Sampler/RuleBased/composer.json
@@ -18,7 +18,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "psalm/plugin-phpunit": "^0.20.0",
         "phpunit/phpunit": "^10 || ^11",
-        "vimeo/psalm": "6.16.1"
+        "vimeo/psalm": "^4|^5|6.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Sampler/RuleBased/composer.json
+++ b/src/Sampler/RuleBased/composer.json
@@ -16,7 +16,7 @@
         "phan/phan": "^5.0",
         "phpstan/phpstan": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",
-        "psalm/plugin-phpunit": "^0.20.0",
+        "psalm/plugin-phpunit": "^0.19.2",
         "phpunit/phpunit": "^10 || ^11",
         "vimeo/psalm": "^4|^5|6.4.0"
     },

--- a/src/Sampler/Xray/composer.json
+++ b/src/Sampler/Xray/composer.json
@@ -18,7 +18,7 @@
         "phan/phan": "^5.0",
         "phpstan/phpstan": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",
-        "psalm/plugin-phpunit": "^0.20.0",
+        "psalm/plugin-phpunit": "^0.19.2",
         "phpunit/phpunit": "^10 || ^11",
         "vimeo/psalm": "^4|^5|6.4.0"
     },

--- a/src/Sampler/Xray/composer.json
+++ b/src/Sampler/Xray/composer.json
@@ -20,7 +20,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "psalm/plugin-phpunit": "^0.20.0",
         "phpunit/phpunit": "^10 || ^11",
-        "vimeo/psalm": "6.16.1"
+        "vimeo/psalm": "^4|^5|6.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Shims/OpenTracing/composer.json
+++ b/src/Shims/OpenTracing/composer.json
@@ -27,7 +27,7 @@
     "phan/phan": "^5.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0"
   },

--- a/src/Shims/OpenTracing/composer.json
+++ b/src/Shims/OpenTracing/composer.json
@@ -29,7 +29,7 @@
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.20.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1"
+    "vimeo/psalm": "6.4.0"
   },
   "config": {
     "allow-plugins": {

--- a/src/SqlCommenter/composer.json
+++ b/src/SqlCommenter/composer.json
@@ -23,7 +23,7 @@
     "phan/phan": "^5.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.4.0",

--- a/src/SqlCommenter/composer.json
+++ b/src/SqlCommenter/composer.json
@@ -26,7 +26,7 @@
     "psalm/plugin-phpunit": "^0.20.0",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.16.1",
+    "vimeo/psalm": "6.4.0",
     "symfony/http-client": "^5.4|^6.0",
     "guzzlehttp/promises": "^2",
     "php-http/message-factory": "^1.0",

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -55,7 +55,7 @@
         "symfony/options-resolver": "^4.4|^5.3|^6.0",
         "symfony/proxy-manager-bridge": "^4.4|^5.3|^6.0",
         "symfony/yaml": "^4.4|^5.3|^6.0",
-        "vimeo/psalm": "6.16.1"
+        "vimeo/psalm": "6.4.0"
     },
     "suggest": {
         "symfony/config": "Needed to use otel-sdk-bundle",

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -48,7 +48,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.1",
         "phpunit/phpunit": "^9.5",
-        "psalm/plugin-phpunit": "^0.20.0",
+        "psalm/plugin-phpunit": "^0.19.2",
         "symfony/config": "^4.4|^5.0|^6.0",
         "symfony/http-client": "^5.3",
         "symfony/http-kernel": "^4.4|^5.3|^6.0",

--- a/src/Utils/Test/composer.json
+++ b/src/Utils/Test/composer.json
@@ -20,7 +20,7 @@
         "phan/phan": "^5.0",
         "phpstan/phpstan": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",
-        "psalm/plugin-phpunit": "^0.20.0",
+        "psalm/plugin-phpunit": "^0.19.2",
         "open-telemetry/api": "^1.0",
         "open-telemetry/sdk": "^1.0",
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
## Problem

Under PHP-FPM, the OTel SDK exports spans during the PHP process shutdown phase via a synchronous, blocking HTTP POST. This export runs *after* `Kernel::handle()` returns but *before* the FastCGI connection to the upstream web server (nginx, Apache) is closed. The sequence today is:

```text
nginx -> FPM worker -> handle() -> terminate() -> [PHP shutdown] -> OTLP export -> FastCGI close
                                                                                    |
                                                                                   upstream proxy waits until here
```

When the collector is slow or unreachable, the FPM worker is held for the full exporter timeout
(default: 10s). This causes two observable failures:

- **Upstream proxy timeouts** — the proxy is waiting for the FastCGI connection to close; if its own timeout (e.g. 2 s) fires first, the client receives a gateway error even though the application handled the request successfully.
- **FPM worker pool exhaustion** — all workers block on the export during a collector outage, causing incoming requests to queue or be rejected.

## Solution

PHP-FPM provides `fastcgi_finish_request()`, which flushes the response buffer and closes the FastCGI socket to the upstream server immediately, allowing the worker to continue executing PHP in the background. The upstream proxy and client see the request as complete; the OTel export runs without holding the connection open.

The correct place to call this in a Laravel application is the **post-hook of `Kernel::terminate()`**, after the response has been sent and all terminating middleware have run, but before PHP shutdown handlers (including `TracerProvider::shutdown()`) fire.

This PR adds that hook as an **opt-in feature**, disabled by default.

## Changes

### `src/Hooks/Illuminate/Contracts/Http/Kernel.php`

Adds `hookTerminate()`, registered unconditionally from `instrument()` alongside the existing `hookHandle()`. The hook's post-callback delegates entirely to `FpmFinishRequest::handle()`, which evaluates the feature flag and runtime guards on every call. The hook registration itself is cheap (a single cached property read per request when the feature is disabled).

### `src/Support/FpmFinishRequest.php` *(new)*

The guard and dispatch class. Responsibilities:

- **Feature flag** — reads `OTEL_PHP_INSTRUMENTATION_LARAVEL_FPM_FINISH_REQUEST_ENABLED` once and caches it for the process lifetime.
- **Long-running runtime guard** — detects Laravel Octane (Swoole / RoadRunner) via:
  1. `LARAVEL_OCTANE` environment variable (boolean-validated; unrecognised values are treated as `true`, fail-closed, with a warning).
  2. Laravel container bindings (`octane`, `octane.client`, `octane.worker`) as a fallback for environments that set neither env variable. Fires a deduplicated warning and skips `fastcgi_finish_request()` in both cases. **Do not enable this feature in Octane / long-running worker deployments.**
- **No-op outside FPM** — `fastcgi_finish_request()` is a PHP-FPM C built-in and is not defined in CLI or test environments. The code checks `function_exists()` before calling it.
- **Testability** — `setFinishRequestCallback()` injects a callable that replaces the `fastcgi_finish_request()` call, allowing full unit-test coverage without requiring FPM. The override path wraps the callback in a `try/catch(Throwable)` and logs a warning on failure.
- **Warning deduplication** — long-running runtime warnings are keyed on message text and emitted at most once per distinct message per process lifetime, preventing log flooding during sustained outages.

### `tests/Unit/Support/FpmFinishRequestTest.php` *(new)*

Full PHPUnit coverage via the callback injection path:

| Test                                                              | What it verifies                                                                    |
| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| `test_is_not_enabled_by_default` (data-driven)                    | `false`, `0`, `off`, `no`, unset, empty, and invalid values all disable the feature |
| `test_is_enabled_when_env_is_truthy` (data-driven)                | `true`, `1`, `yes`, `on` all enable the feature                                     |
| `test_is_enabled_when_server_signal_is_scalar`                    | Non-string `$_SERVER` values (e.g. integer `1`) are coerced correctly               |
| `test_is_enabled_result_is_cached`                                | Re-reading env after first call does not change the cached result                   |
| `test_finish_request_is_called_when_enabled`                      | Callback fires when the feature is enabled                                          |
| `test_finish_request_is_not_called_when_disabled`                 | Callback is never invoked when the feature is disabled                              |
| `test_finish_request_is_not_called_when_octane_env_signal_is_set` | `LARAVEL_OCTANE=1` suppresses the call                                              |
| `test_explicit_octane_false_allows_finish_request`                | `LARAVEL_OCTANE=false` does not suppress the call                                   |
| `test_explicit_octane_zero_allows_finish_request`                 | `LARAVEL_OCTANE=0` does not suppress the call                                       |
| `test_warning_is_logged_when_octane_guard_fires`                  | A warning is emitted via `LogsMessagesTrait` when Octane is detected                |
| `test_octane_warning_is_logged_only_once`                         | The Octane warning is deduplicated across multiple `handle()` calls                 |
| `test_distinct_long_running_warnings_are_both_logged`             | Distinct warning messages are deduplicated independently                            |
| `test_warning_is_logged_when_octane_signal_is_invalid`            | Unrecognised `LARAVEL_OCTANE` values emit a specific warning and fail-closed        |
| `test_handle_delegates_every_call`                                | `handle()` does not itself deduplicate; the callback fires on every call            |
| `test_warning_is_logged_when_finish_request_callback_throws`      | A throwing callback logs a warning and does not propagate                           |
| `test_reset_cache_clears_warning_dedup_state`                     | `resetCache()` clears all cached state including the warning dedup map              |

The `fastcgi_finish_request() === false` error path is behind `@codeCoverageIgnoreStart` because
the C built-in cannot be mocked in unit tests; the callback path covers all reachable branches.

### `README.md`

Documents the feature, the required companion timeout configuration, and the Octane constraint.

## Configuration

Enable for PHP-FPM workloads only:

```shell
OTEL_PHP_INSTRUMENTATION_LARAVEL_FPM_FINISH_REQUEST_ENABLED=true
```

**Also configure exporter timeouts** to bound background worker hold time during collector
outages:

```shell
OTEL_EXPORTER_OTLP_TIMEOUT=500
OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=500
OTEL_BSP_EXPORT_TIMEOUT=1000
```

Without these, FPM workers are still held for the SDK's default 10 s timeout during a full
outage. With them, background hold time is bounded to ≈ 600 ms per request.

## Notes

- The feature is **opt-in and off by default**. Existing users are entirely unaffected until they set the environment variable.
- Outside FPM (CLI, test runners, Octane), the feature is a no-op or emits a single warning. There are no side effects on non-FPM runtimes.
