### PR TITLE
fix: exception recording for Symfony sub-requests in instrumentation

### DIFF
--- a/src/Instrumentation/Symfony/composer.json
+++ b/src/Instrumentation/Symfony/composer.json
@@ -22,11 +22,10 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",
-    "phan/phan": "^5.0",
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
-    "psalm/plugin-phpunit": "^0.20.0",
+    "psalm/plugin-phpunit": "^0.19.0",
     "open-telemetry/sdk": "^1.8",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "6.16.1",
@@ -48,7 +47,8 @@
   },
   "config": {
     "allow-plugins": {
-      "php-http/discovery": false
+      "php-http/discovery": false,
+      "tbachert/spi": true
     }
   }
 }

--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -94,15 +94,33 @@ final class SymfonyInstrumentation
                 ?\Throwable $exception
             ): void {
                 $scope = Context::storage()->scope();
-                if (null === $scope || null === $exception) {
+                if (null === $scope) {
+                    return;
+                }
+
+                $type = $params[1] ?? HttpKernelInterface::MAIN_REQUEST;
+                $isSubRequest = $type === HttpKernelInterface::SUB_REQUEST;
+
+                if (!$isSubRequest && null === $exception) {
                     return;
                 }
 
                 $span = Span::fromContext($scope->context());
                 $scope->detach();
-                $span->recordException($exception);
-                if (null !== $response && $response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
+
+                if (null !== $exception) {
+                    $span->recordException($exception, [
+                        TraceAttributes::EXCEPTION_ESCAPED => true,
+                    ]);
+
                     $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
+                }
+
+                if ($isSubRequest) {
+                    if (null !== $response) {
+                        $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode());
+                    }
+                    $span->end();
                 }
             }
         );
@@ -119,8 +137,11 @@ final class SymfonyInstrumentation
                 if (null === $scope) {
                     return;
                 }
-                $scope->detach();
                 $span = Span::fromContext($scope->context());
+                if (!$span->isRecording()) {
+                    return;
+                }
+                $scope->detach();
 
                 $request = ($params[0] instanceof Request) ? $params[0] : null;
                 $response = ($params[1] instanceof Response) ? $params[1] : null;

--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -109,9 +109,7 @@ final class SymfonyInstrumentation
                 $scope->detach();
 
                 if (null !== $exception) {
-                    $span->recordException($exception, [
-                        TraceAttributes::EXCEPTION_ESCAPED => true,
-                    ]);
+                    $span->recordException($exception);
 
                     $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
                 }
@@ -119,6 +117,10 @@ final class SymfonyInstrumentation
                 if ($isSubRequest) {
                     if (null !== $response) {
                         $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode());
+
+                        if ($response->getStatusCode() >= Response::HTTP_INTERNAL_SERVER_ERROR) {
+                            $span->setStatus(StatusCode::STATUS_ERROR);
+                        }
                     }
                     $span->end();
                 }
@@ -205,7 +207,9 @@ final class SymfonyInstrumentation
                 $throwable = $params[0];
 
                 Span::getCurrent()
-                    ->recordException($throwable);
+                    ->recordException($throwable)
+                    ->setStatus(StatusCode::STATUS_ERROR, $throwable->getMessage())
+                ;
 
                 return $params;
             },

--- a/src/Instrumentation/Symfony/tests/Integration/SymfonyInstrumentationTest.php
+++ b/src/Instrumentation/Symfony/tests/Integration/SymfonyInstrumentationTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration;
 
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\SemConv\Attributes\ExceptionAttributes;
 use OpenTelemetry\SemConv\TraceAttributes;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -16,9 +17,11 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 class SymfonyInstrumentationTest extends AbstractTest
 {
@@ -199,6 +202,57 @@ class SymfonyInstrumentationTest extends AbstractTest
         $request->attributes->set('_controller', null);
         $kernel->handle($request, \Symfony\Component\HttpKernel\HttpKernelInterface::SUB_REQUEST);
         $this->assertSame('GET sub-request', $this->storage[0]->getName());
+    }
+
+    public function test_exception_in_main_request_is_recorded_when_error_handled_via_subrequest(): void
+    {
+        $exception = new \RuntimeException('Something went wrong');
+        $dispatcher = new EventDispatcher();
+
+        $controllerResolver = $this->createMock(ControllerResolverInterface::class);
+        $controllerResolver
+            ->method('getController')
+            ->willReturnOnConsecutiveCalls(
+                static function () use ($exception): void {
+                    throw $exception;
+                },
+                static fn () => new Response('Error Page', 500),
+            );
+
+        $argumentResolver = $this->createMock(ArgumentResolverInterface::class);
+        $argumentResolver->method('getArguments')->willReturn([]);
+
+        $kernel = new HttpKernel($dispatcher, $controllerResolver, null, $argumentResolver);
+
+        $dispatcher->addListener(
+            KernelEvents::EXCEPTION,
+            static function (ExceptionEvent $event) use ($kernel): void {
+                $subRequest = Request::create('/error');
+                $subRequest->attributes->set('_controller', 'error_controller');
+                $event->setResponse($kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false));
+            }
+        );
+
+        $mainRequest = new Request();
+        $response = $kernel->handle($mainRequest);
+        $kernel->terminate($mainRequest, $response);
+
+        // Sub-request span ended first (in handle post hook), main request span ended in terminate
+        $this->assertCount(2, $this->storage);
+
+        $subRequestSpan = $this->storage[0];
+        $this->assertSame(SpanKind::KIND_INTERNAL, $subRequestSpan->getKind());
+        $this->assertSame('GET error_controller', $subRequestSpan->getName());
+
+        $mainRequestSpan = $this->storage[1];
+        $this->assertSame(SpanKind::KIND_SERVER, $mainRequestSpan->getKind());
+        $this->assertSame(StatusCode::STATUS_ERROR, $mainRequestSpan->getStatus()->getCode());
+
+        $events = $mainRequestSpan->getEvents();
+        $this->assertCount(1, $events, 'Main request span must have the exception event');
+        $this->assertSame('exception', $events[0]->getName());
+        $this->assertSame(\RuntimeException::class, $events[0]->getAttributes()->get(ExceptionAttributes::EXCEPTION_TYPE));
+        $this->assertSame('Something went wrong', $events[0]->getAttributes()->get(ExceptionAttributes::EXCEPTION_MESSAGE));
     }
 
     private function getHttpKernel(EventDispatcherInterface $eventDispatcher, $controller = null, ?RequestStack $requestStack = null, array $arguments = []): HttpKernel


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-php/issues/1844

Based on https://github.com/open-telemetry/opentelemetry-php-contrib/pull/494 but then with a test.

I wasn't able to install the dependencies locally so I made some changes there. Also the version in the previous PR wasn't really working for me either as the tests kept failing.

I added a test with claude as I'm not really familiar with the internals of Symfony. I'm adding this version to our own codebase to verify it in production for a couple of days. So I'll report on the success of that soon.