### PR TITLE
added: peer service attribute to Guzzle

### DIFF
--- a/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php
+++ b/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php
@@ -54,6 +54,7 @@ class GuzzleInstrumentation
                     ->spanBuilder(sprintf('%s', $request->getMethod()))
                     ->setParent($parentContext)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
+                    ->setAttribute(TraceAttributes::PEER_SERVICE, $request->getUri()->getHost())
                     ->setAttribute(TraceAttributes::URL_FULL, (string) $request->getUri())
                     ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
                     ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $request->getProtocolVersion())


### PR DESCRIPTION
The HttpClientInstrumentation sets the PEER_SERVICE attribute whilst GuzzleInstrumentation.php does not.

Grafana’s Traces Drilldown view uses the PEER_SERVICE attribute to make the spans more readable.

This PR aligns behaviour between the two instrumentations.