### PR TITLE
fix: upgrade Psalm to 7.0+ to resolve plugin compatibility issue

### DIFF
--- a/src/Aws/composer.json
+++ b/src/Aws/composer.json
@@ -28,8 +28,8 @@
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "~9",
-        "psalm/plugin-phpunit": "^0.19.2",
-        "vimeo/psalm": "6.4.0"
+        "psalm/plugin-phpunit": "^0.20.0",
+        "vimeo/psalm": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -48,14 +48,14 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.1",
         "phpunit/phpunit": "^9.5",
-        "psalm/plugin-phpunit": "^0.19.2",
+        "psalm/plugin-phpunit": "^0.20.0",
         "symfony/config": "^4.4|^5.0|^6.0",
         "symfony/http-client": "^5.3",
         "symfony/http-kernel": "^4.4|^5.3|^6.0",
         "symfony/options-resolver": "^4.4|^5.3|^6.0",
         "symfony/proxy-manager-bridge": "^4.4|^5.3|^6.0",
         "symfony/yaml": "^4.4|^5.3|^6.0",
-        "vimeo/psalm": "6.4.0"
+        "vimeo/psalm": "^7.0"
     },
     "suggest": {
         "symfony/config": "Needed to use otel-sdk-bundle",


### PR DESCRIPTION
This PR should turn CI green.

The dev-tools dependency recently updated to require psalm/plugin-phpunit ^0.20, which requires psalm/psalm-plugin-api ^0.1. This conflicts with Psalm 6.x versions. Upgrading Psalm to 7.0+ resolves the dependency conflict.