### PR TITLE
fix(Laravel): fix incorrect URL path construction in `httpTarget()`

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
@@ -112,9 +112,9 @@ class Kernel implements LaravelHook
     private function httpTarget(Request $request): string
     {
         $query = $request->getQueryString();
-        $question = $request->getBaseUrl() . $request->getPathInfo() === '/' ? '/?' : '?';
+        $path = $request->getBaseUrl() . $request->getPathInfo();
 
-        return $query ? $request->path() . $question . $query : $request->path();
+        return $query ? $path . '?' . $query : $path;
     }
 
     private function httpHostName(Request $request): string

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -13,6 +13,7 @@ use OpenTelemetry\SemConv\Attributes\DbAttributes;
 use OpenTelemetry\SemConv\Attributes\ExceptionAttributes;
 use OpenTelemetry\SemConv\Attributes\ServerAttributes;
 use OpenTelemetry\SemConv\Attributes\UrlAttributes;
+use OpenTelemetry\SemConv\TraceAttributes;
 
 /** @psalm-suppress UnusedClass */
 class LaravelInstrumentationTest extends TestCase
@@ -120,6 +121,38 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertEquals(Exception::class, $logRecord->getAttributes()->get(ExceptionAttributes::EXCEPTION_TYPE));
         $this->assertEquals('Test exception', $logRecord->getAttributes()->get(ExceptionAttributes::EXCEPTION_MESSAGE));
         $this->assertNotNull($logRecord->getAttributes()->get(ExceptionAttributes::EXCEPTION_STACKTRACE));
+    }
+
+    public function test_url_path_root(): void
+    {
+        $this->router()->get('/', fn () => null);
+        $this->call('GET', '/');
+        $span = $this->storage[0];
+        $this->assertSame('/', $span->getAttributes()->get(TraceAttributes::URL_PATH));
+    }
+
+    public function test_url_path_non_root(): void
+    {
+        $this->router()->get('/hello', fn () => null);
+        $this->call('GET', '/hello');
+        $span = $this->storage[0];
+        $this->assertSame('/hello', $span->getAttributes()->get(TraceAttributes::URL_PATH));
+    }
+
+    public function test_url_path_root_with_query_string(): void
+    {
+        $this->router()->get('/', fn () => null);
+        $this->call('GET', '/?foo=bar');
+        $span = $this->storage[0];
+        $this->assertSame('/?foo=bar', $span->getAttributes()->get(TraceAttributes::URL_PATH));
+    }
+
+    public function test_url_path_with_query_string(): void
+    {
+        $this->router()->get('/hello', fn () => null);
+        $this->call('GET', '/hello?foo=bar');
+        $span = $this->storage[0];
+        $this->assertSame('/hello?foo=bar', $span->getAttributes()->get(TraceAttributes::URL_PATH));
     }
 
     private function router(): Router


### PR DESCRIPTION
## Summary

### Content
- Fixed a PHP operator precedence bug  in `httpTarget()` where `.` (concatenation) has higher precedence than `===` (strict equality). This caused incorrect path construction when appending query strings.
- Ensured correct leading slash handling by replacing `$request->path()` (which strips the leading slash in Laravel) with a robust combination of `$request->getBaseUrl() . $request->getPathInfo()`.
- Added integration tests covering both root and non-root paths, with and without query strings.
  
### Cause

The original code was evaluated incorrectly due to operator precedence:
```php
$question = $request->getBaseUrl() . $request->getPathInfo() === '/' ? '/?' : '?';
return $query ? $request->path() . $question . $query : $request->path();
```

This caused the following incorrect behaviors:
  - GET `/?foo=bar` → URL_PATH = `//?foo=bar` (double slash)
  - GET `/hello?foo=bar` → URL_PATH = `foo?foo=bar` (missing leading slash)

Fixed code:
```php
$path = $request->getBaseUrl() . $request->getPathInfo();

return $query ? $path . '?' . $query : $path;
```

### Test Results
<img width="886" height="262" alt="screen shot 2026-06-09 20 13 09" src="https://github.com/user-attachments/assets/5abdec0e-3ac4-4987-bbbf-aaecedcd59c3" />
