### PR TITLE
fix: code-level cleanup surfaced during psalm/phan upgrade work

### DIFF
--- a/src/Aws/src/AwsSdkInstrumentation.php
+++ b/src/Aws/src/AwsSdkInstrumentation.php
@@ -9,12 +9,12 @@ use Aws\Middleware;
 use Aws\ResultInterface;
 use Closure;
 use GuzzleHttp\Promise;
-use OpenTelemetry\API\Instrumentation\InstrumentationInterface;
-use OpenTelemetry\API\Instrumentation\InstrumentationTrait;
+use OpenTelemetry\API\Trace\NoopTracerProvider;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
+use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
 use Psr\Http\Message\RequestInterface;
 use Stringable;
@@ -23,19 +23,30 @@ use Throwable;
 /**
  * @experimental
  */
-class AwsSdkInstrumentation implements InstrumentationInterface
+class AwsSdkInstrumentation
 {
-    use InstrumentationTrait;
-
     public const NAME = 'AWS SDK Instrumentation';
     public const VERSION = '0.0.1';
     public const SPAN_KIND = SpanKind::KIND_CLIENT;
 
+    private TextMapPropagatorInterface $propagator;
+    private TracerProviderInterface $tracerProvider;
     private array $clients = [];
 
     private array $instrumentedClients = [];
 
     private array $spanStorage = [];
+
+    /**
+     * Defaults match those previously supplied by the removed
+     * InstrumentationTrait constructor, so an instance is usable before
+     * setPropagator()/setTracerProvider() are called.
+     */
+    public function __construct()
+    {
+        $this->propagator = new NoopTextMapPropagator();
+        $this->tracerProvider = new NoopTracerProvider();
+    }
 
     public function getName(): string
     {

--- a/src/Aws/src/Lambda/AwsLambdaWrapper.php
+++ b/src/Aws/src/Lambda/AwsLambdaWrapper.php
@@ -64,6 +64,7 @@ class AwsLambdaWrapper
                 ?: self::DEFAULT_OTLP_EXPORTER_ENDPOINT,
             'application/x-protobuf'
         );
+        /** @phan-suppress-next-line PhanTypeMismatchArgument */
         $exporter = new OtlpExporter($transport);
 
         $spanProcessor = new SimpleSpanProcessor($exporter);

--- a/src/Instrumentation/PDO/ignore-by-php-version.neon.php
+++ b/src/Instrumentation/PDO/ignore-by-php-version.neon.php
@@ -4,17 +4,12 @@ declare(strict_types=1);
 
 $ignoreErrors = [];
 
+// PHPStan ships PHP 8.4 stubs regardless of the PHP version it runs on, so
+// Pdo\Sqlite and its methods always resolve. Only PDO::connect() is reported,
+// and only when the analysing PHP version predates it.
 if (version_compare(PHP_VERSION, '8.4', '<')) {
     $ignoreErrors = [
         '#Call to an undefined static method PDO::connect\(\)#',
-        '#PHPDoc tag @var for variable \$db contains unknown class PDO\\\\Sqlite#',
-        '#Call to method createFunction\(\) on an unknown class PDO\\\\Sqlite#',
-        '#Call to method exec\(\) on an unknown class PDO\\\\Sqlite#',
-        '#Call to method query\(\) on an unknown class PDO\\\\Sqlite#',
-    ];
-} elseif (version_compare(PHP_VERSION, '8.4', '>=')) {
-    $ignoreErrors = [
-        '#Call to an undefined method Pdo\\\\Sqlite::createFunction\(\)#',
     ];
 }
 

--- a/src/Instrumentation/PDO/tests/Integration/PDOInstrumentationTest.php
+++ b/src/Instrumentation/PDO/tests/Integration/PDOInstrumentationTest.php
@@ -102,11 +102,12 @@ class PDOInstrumentationTest extends TestCase
         $this->assertCount(0, $this->storage);
 
         /**
-         * Need to suppress because of different casing of the class name
+         * Fully qualified so the `use PDO;` import above does not resolve
+         * `Pdo\Sqlite` to `PDO\Sqlite` (class aliases are case-insensitive).
          *
          * @psalm-suppress UndefinedClass
          * @psalm-suppress InvalidClass
-         * @var Pdo\Sqlite $db
+         * @var \Pdo\Sqlite $db
          */
         $db = self::createDBWithNewSubclass();
         $this->assertCount(1, $this->storage);

--- a/src/ResourceDetectors/Container/tests/Unit/ContainerTest.php
+++ b/src/ResourceDetectors/Container/tests/Unit/ContainerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use OpenTelemetry\Contrib\Resource\Detector\Container\Container;
 use OpenTelemetry\SemConv\ResourceAttributes;
+use OpenTelemetry\SemConv\Version;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamFile;
 use PHPUnit\Framework\TestCase;
@@ -67,7 +68,7 @@ class ContainerTest extends TestCase
         $this->cgroup->setContent($data);
         $resource = $this->detector->getResource();
 
-        $this->assertSame(ResourceAttributes::SCHEMA_URL, $resource->getSchemaUrl());
+        $this->assertSame(Version::VERSION_1_38_0->url(), $resource->getSchemaUrl());
         $this->assertIsString($resource->getAttributes()->get(ResourceAttributes::CONTAINER_ID));
         $this->assertSame($expected, $resource->getAttributes()->get(ResourceAttributes::CONTAINER_ID));
     }


### PR DESCRIPTION
## Summary

Small set of correctness fixes surfaced while investigating CI failures from the psalm/phan upgrade work (PR #579, now superseded by the revert in #600). These are clean code-level changes with no suppressions beyond one narrow phan annotation.

Each of the three projects touched here is **currently failing on `main`**, and these are the fixes for those failures.

### `Aws` — phan, all PHP versions

`main` reports:

```
src/AwsSdkInstrumentation.php:26 PhanDeprecatedInterface Using a deprecated interface \OpenTelemetry\API\Instrumentation\InstrumentationInterface
src/AwsSdkInstrumentation.php:26 PhanDeprecatedTrait Using a deprecated trait \OpenTelemetry\API\Instrumentation\InstrumentationTrait
```

`AwsSdkInstrumentation` already implemented every interface method itself, so the interface and trait are dropped. The two properties the trait contributed (`$propagator`, `$tracerProvider`) are now declared explicitly, and a constructor installs the same `NoopTextMapPropagator` / `NoopTracerProvider` defaults that the trait's constructor used to set, so an instance stays usable before `setPropagator()` / `setTracerProvider()` are called.

Also adds `@phan-suppress-next-line PhanTypeMismatchArgument` for the `TransportInterface` generic type narrowing on `OtlpExporter` construction in `AwsLambdaWrapper`.

### `Instrumentation/PDO` — phpstan, PHP 8.2 / 8.3 / 8.4

`main` reports the same error on every version:

```
Class Pdo\Sqlite referenced with incorrect case: PDO\Sqlite.
```

The cause is the `use PDO;` import in `PDOInstrumentationTest`: class aliases are case-insensitive, so the relative `@var Pdo\Sqlite` resolves through it to `PDO\Sqlite`. Fully qualifying it as `@var \Pdo\Sqlite` fixes it.

With that resolved, the `Pdo\Sqlite` ignore patterns are all obsolete — PHPStan ships PHP 8.4 stubs whatever version it runs on, so the class and its methods always resolve and the patterns went unmatched (which is itself an error under `reportUnmatchedIgnoredErrors`). Only `PDO::connect()` still needs ignoring below 8.4.

### `ResourceDetectors/Container` — phpunit, all PHP versions

`ContainerTest::test_valid_v1` asserts `ResourceAttributes::SCHEMA_URL` while the detector emits `Version::VERSION_1_38_0->url()`, so it fails on `main`.

An earlier revision of this PR resolved the mismatch by changing the detector. As @ChrisLightfootWild [pointed out in review](https://github.com/open-telemetry/opentelemetry-php-contrib/pull/613#discussion_r3399618164), that silently downgrades the detector's semantic conventions claim from 1.38.0 to 1.32.0 via the deprecated `ResourceAttributes` class. The detector is now left alone and the test is corrected instead, in its own commit. The package already requires `open-telemetry/sem-conv: ^1.38`.

## Test plan

Full `make all-checks` (style, composer validate, phan, psalm, phpstan, phpunit) run locally in the project's Docker images:

| Project | PHP | Result |
| --- | --- | --- |
| `Aws` | 8.1, 8.4 | pass (81 tests) |
| `ResourceDetectors/Container` | 8.1, 8.4 | pass (9 tests) |
| `Instrumentation/PDO` | 8.2, 8.4 | pass (23 tests) |

On 8.4 the `Pdo\Sqlite` subclass test runs for real rather than skipping.

The remaining red jobs in this PR's matrix (`Symfony`, `Yii`, `Psr3`, `Monolog`, `Sampler/RuleBased`, `Laravel`, `ReactPHP`, `HttpConfig`, `CodeIgniter`, `ExtRdKafka`) are pre-existing failures on `main` and are untouched here.