### PR TITLE
fix(Laravel): use correct param index for queue name in `hookLater()`

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Queue/Queue.php
@@ -94,7 +94,7 @@ class Queue implements LaravelHook
                     ->spanBuilder(vsprintf('%s %s', [
                         TraceAttributeValues::MESSAGING_OPERATION_TYPE_CREATE,
                         /** @phan-suppress-next-line PhanUndeclaredMethod */
-                        method_exists($queue, 'getQueue') ? $queue->getQueue($params[2] ?? null) : $queue->getConnectionName(),
+                        method_exists($queue, 'getQueue') ? $queue->getQueue($params[3] ?? null) : $queue->getConnectionName(),
                     ]))
                     ->setSpanKind(SpanKind::KIND_PRODUCER)
                     ->setAttributes($attributes)

--- a/src/Instrumentation/Laravel/tests/Integration/Queue/QueueTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Queue/QueueTest.php
@@ -72,6 +72,19 @@ class QueueTest extends TestCase
         );
     }
 
+    public function test_it_uses_correct_queue_name_when_later_is_called_with_explicit_queue(): void
+    {
+        /** @var SqsQueue|MockInterface $mockQueue */
+        $mockQueue = $this->createMock(SqsQueue::class);
+        /** @psalm-suppress UndefinedMethod */
+        $mockQueue->method('getQueue')->with('custom-queue')->willReturn('custom-queue');
+
+        /** @psalm-suppress PossiblyUndefinedMethod */
+        $mockQueue->later(15, new DummyJob('test'), '', 'custom-queue');
+
+        $this->assertEquals('create custom-queue', $this->storage[0]->getName());
+    }
+
     public function test_it_can_publish_in_bulk(): void
     {
         $jobs = [];


### PR DESCRIPTION
## Summary

### Content
`hookLater()` was passing the wrong argument to `getQueue()` when building the span name.

Laravel's method `later()` signature is:

  ```php
  later($delay, $job, $data = '', $queue = null)
   // $params[0] = delay
   // $params[1] = job
  // $params[2] = data  ← was incorrectly used as queue name
  // $params[3] = queue ← correct
  
  Compare with bulk() where $params[2] is correctly the queue:
  bulk($jobs, $data = '', $queue = null)
  // $params[0] = jobs
  // $params[1] = data
  // $params[2] = queue ← correct
  
`hookLater()` was copied from hookBulk() but the index was not updated, 
causing the job's data payload to be passed to `getQueue()` instead of the actual queue name.

  Fix: change $params[2] to $params[3] in `hookLater()`.
  ```
  
### Test Results
<img width="1034" height="455" alt="スクリーンショット 2026-06-18 18 56 54" src="https://github.com/user-attachments/assets/07f3ac4d-5d9e-4b4d-8600-3dce7a4d3c6d" />
