### PR TITLE
fix(laravel): fix missing https scheme in `test_request_response`

### DIFF
--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -40,7 +40,7 @@ class LaravelInstrumentationTest extends TestCase
         $span = $this->storage[0];
         $this->assertSame('GET /', $span->getName());
 
-        $response = Http::get('opentelemetry.io');
+        $response = Http::get('https://opentelemetry.io');
         $this->assertEquals(200, $response->status());
         $span = $this->storage[1];
         $this->assertSame('GET', $span->getName());


### PR DESCRIPTION
## Summary

### Content
When I run the unit test for asserting my PR #622, following test was failed.
So, I make this PR.

### What I have done
  - `test_request_response` was failing with `GuzzleHttp\Exception\RequestException: The scheme "" is not allowed`
  - `Http::get('opentelemetry.io')` was passed without a scheme, causing Guzzle to reject the URL. So, fixed by adding `https://` to the URL

### Test results

**before** (error codes were so long, thus I copied those.)
```php
php@dce248dbca56:/usr/src/myapp/src/Instrumentation/Laravel$ vendor/bin/phpunit --testdox --colors=always ./tests/Integration/LaravelInstrumentationTest.php
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.34
Configuration: /usr/src/myapp/src/Instrumentation/Laravel/phpunit.xml.dist

Laravel Instrumentation (OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration\LaravelInstrumentation)
 ✘ Request response  1153 ms
   ┐
   ├ GuzzleHttp\Exception\RequestException: The scheme "" is not allowed by the protocols request option.
   │
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:613
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php:118
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/Handler/CurlHandler.php:66
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/Handler/Proxy.php:28
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/Handler/Proxy.php:48
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php:1256
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php:1222
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php:1208
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php:35
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/Middleware.php:38
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php:71
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/Middleware.php:63
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/HandlerStack.php:75
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/Client.php:808
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/Client.php:199
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/guzzlehttp/guzzle/src/Client.php:229
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php:1053
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php:894
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/laravel/framework/src/Illuminate/Support/helpers.php:261
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php:938
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/laravel/framework/src/Illuminate/Http/Client/PendingRequest.php:771
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/laravel/framework/src/Illuminate/Http/Client/Factory.php:461
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:355
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php:43
   ╵ /usr/src/myapp/src/Instrumentation/Laravel/vendor/orchestra/testbench-core/src/PHPUnit/TestCase.php:70
   ┴
```

**after**
<img width="1225" height="365" alt="スクリーンショット 2026-06-18 21 58 20" src="https://github.com/user-attachments/assets/6b068c20-39ee-4e04-802f-250ca6071d51" />
