### PR TITLE
fix(laravel): end span on empty receive to prevent span leak in Worker

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/Worker.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/Worker.php
@@ -126,7 +126,9 @@ class Worker implements LaravelHook
 
                 // Discard empty receives.
                 if (!$job) {
+                    $span = Span::fromContext($scope->context());
                     $scope->detach();
+                    $span->end();
 
                     return;
                 }

--- a/src/Instrumentation/Laravel/tests/Integration/Queue/QueueTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Queue/QueueTest.php
@@ -159,14 +159,14 @@ class QueueTest extends TestCase
         }
 
         /** @psalm-suppress PossiblyInvalidMethodCall */
-        $this->assertEquals(204, $this->storage->count());
+        $this->assertEquals(1206, $this->storage->count());
 
-        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord100 */
-        $logRecord100 = $this->storage[100];
-        $this->assertEquals('Task: 500', $logRecord100->getBody());
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord600 */
+        $logRecord600 = $this->storage[600];
+        $this->assertEquals('Task: 500', $logRecord600->getBody());
 
-        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord200 */
-        $logRecord200 = $this->storage[200];
-        $this->assertEquals('Task: More work', $logRecord200->getBody());
+        /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord1200 */
+        $logRecord1200 = $this->storage[1200];
+        $this->assertEquals('Task: More work', $logRecord1200->getBody());
     }
 }


### PR DESCRIPTION
## Summary

### Content

- `hookWorkerGetNextJob` started a span in the pre-hook but never called `$span->end()` in the "empty receive" discard path — only `$scope->detach()` was called and this caused the span to remain open indefinitely, leaking memory on every empty queue poll.
- With this fix,  retrieving the span from the scope's context before detaching, then calling `$span->end()`.

### What I have done

**before**

```php
if (!$job) {
    $scope->detach();  // span was never ended → leak
    
    return;
}
```

**after**

```php
if (!$job) {
    $span = Span::fromContext($scope->context());
    $scope->detach();
    $span->end();
  
    return;
}

```

### Test Plans
- Empty receive spans are now exported. 
The test test_it_drops_empty_receives has been updated to reflect the correct storage count (204 → 1206) and the adjusted span indices.

### Test Results
<img width="682" height="338" alt="スクリーンショット 2026-06-19 10 15 11" src="https://github.com/user-attachments/assets/ca38168c-454e-4783-8e31-6c9ff5f6b42d" />
