### PR TITLE
fix(cakephp): set `STATUS_ERROR` only for `5xx` responses per `OTel HTTP` semconv

### DIFF
--- a/src/Instrumentation/CakePHP/src/Hooks/Cake/Controller/Controller.php
+++ b/src/Instrumentation/CakePHP/src/Hooks/Cake/Controller/Controller.php
@@ -39,7 +39,7 @@ class Controller implements CakeHook
                     $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
                 }
                 $response = $app->getResponse();
-                if ($response->getStatusCode() >= 400) {
+                if ($response->getStatusCode() >= 500) {
                     $span->setStatus(StatusCode::STATUS_ERROR);
                 }
                 $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode());

--- a/src/Instrumentation/CakePHP/src/Hooks/Cake/Http/Server.php
+++ b/src/Instrumentation/CakePHP/src/Hooks/Cake/Http/Server.php
@@ -53,7 +53,7 @@ class Server implements CakeHook
                     $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
                 }
                 if ($response) {
-                    if ($response->getStatusCode() >= 400) {
+                    if ($response->getStatusCode() >= 500) {
                         $span->setStatus(StatusCode::STATUS_ERROR);
                     }
 

--- a/src/Instrumentation/CakePHP/tests/Integration/App/src/Controller/ArticleController.php
+++ b/src/Instrumentation/CakePHP/tests/Integration/App/src/Controller/ArticleController.php
@@ -45,6 +45,11 @@ class ArticleController extends Controller
         return $this->response->withStatus(400);
     }
 
+    public function serverErrorResponse(): ResponseInterface
+    {
+        return $this->response->withStatus(500);
+    }
+
     public function add(): ResponseInterface
     {
         return $this->response;

--- a/src/Instrumentation/CakePHP/tests/Integration/CakePHPInstrumentationTest.php
+++ b/src/Instrumentation/CakePHP/tests/Integration/CakePHPInstrumentationTest.php
@@ -105,27 +105,41 @@ class CakePHPInstrumentationTest extends TestCase
         $this->assertSame('/{controller}/{action}/*', $attributes['http.route']);
     }
 
-    public function test_response_code_gte_400(): void
+    public function test_response_code_4xx_does_not_set_error_status(): void
     {
         $this->assertCount(0, $this->storage);
 
         $this->get('/article/clientErrorResponse');
 
         $this->assertCount(2, $this->storage);
-        /** @var ImmutableSpan $span */
-        $span = $this->storage[0];
-        $this->assertSame(StatusCode::STATUS_ERROR, $span->getStatus()->getCode());
-        $events = $span->getEvents();
-        $this->assertCount(0, $events);
-        $attributes = $span->getAttributes()->toArray();
-        $this->assertSame(400, $attributes['http.response.status_code']);
+        /** @var ImmutableSpan $controllerSpan */
+        $controllerSpan = $this->storage[0];
+        $this->assertSame(StatusCode::STATUS_UNSET, $controllerSpan->getStatus()->getCode());
+        $this->assertCount(0, $controllerSpan->getEvents());
+        $this->assertSame(400, $controllerSpan->getAttributes()->toArray()['http.response.status_code']);
 
-        /** @var ImmutableSpan $span */
+        /** @var ImmutableSpan $serverSpan */
         $serverSpan = $this->storage[1];
-        $this->assertSame(StatusCode::STATUS_ERROR, $span->getStatus()->getCode());
-        $events = $span->getEvents();
-        $this->assertCount(0, $events);
-        $attributes = $span->getAttributes()->toArray();
-        $this->assertSame(400, $attributes['http.response.status_code']);
+        $this->assertSame(StatusCode::STATUS_UNSET, $serverSpan->getStatus()->getCode());
+        $this->assertCount(0, $serverSpan->getEvents());
+        $this->assertSame(400, $serverSpan->getAttributes()->toArray()['http.response.status_code']);
+    }
+
+    public function test_response_code_5xx_sets_error_status(): void
+    {
+        $this->assertCount(0, $this->storage);
+
+        $this->get('/article/serverErrorResponse');
+
+        $this->assertCount(2, $this->storage);
+        /** @var ImmutableSpan $controllerSpan */
+        $controllerSpan = $this->storage[0];
+        $this->assertSame(StatusCode::STATUS_ERROR, $controllerSpan->getStatus()->getCode());
+        $this->assertSame(500, $controllerSpan->getAttributes()->toArray()['http.response.status_code']);
+
+        /** @var ImmutableSpan $serverSpan */
+        $serverSpan = $this->storage[1];
+        $this->assertSame(StatusCode::STATUS_ERROR, $serverSpan->getStatus()->getCode());
+        $this->assertSame(500, $serverSpan->getAttributes()->toArray()['http.response.status_code']);
     }
 }


### PR DESCRIPTION
## Summary

### Content
 - `Controller.php` and `Server.php` were setting `STATUS_ERROR` for all responses with status code `>= 400`, including 4xx client errors .
-  Per the [OTel HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status), server spans MUST only set `STATUS_ERROR` for 5xx responses; `4xx` responses are client errors and not be marked as server errors .
 - Fixed the threshold from `>= 400` to `>= 500` in both hooks .

### What I have changed
- src
   - `src/Hooks/Cake/Controller/Controller.php`: `>= 400` → `>= 500`
   - `src/Hooks/Cake/Http/Server.php`: `>= 400` → `>= 500`

- tests
    - `tests/Integration/CakePHPInstrumentationTest.php`:
        - Renamed `test_response_code_gte_400` → `test_response_code_4xx_does_not_set_error_status` and updated assertion to `STATUS_UNSET`
        - Fixed copy-paste bug where `$serverSpan` was assigned but `$span` was used in assertions (server span was never actually tested)
    - Added `test_response_code_5xx_sets_error_status` to verify 5xx correctly sets `STATUS_ERROR`
    - `tests/Integration/App/src/Controller/ArticleController.php`: 
        - added `serverErrorResponse()` fixture returning 500

### Test Results
<img width="1219" height="220" alt="screen shot 2026-06-19 23 44 24" src="https://github.com/user-attachments/assets/5731f695-534a-4dfa-892b-003d0c8a27bb" />
