### PR TITLE
fix(laravel): fix trailing space in span name for unknown SQL operations in `QueryWatcher`

### DIFF
--- a/src/Instrumentation/Laravel/src/Watchers/QueryWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/QueryWatcher.php
@@ -39,8 +39,10 @@ class QueryWatcher extends Watcher
             $operationName = null;
         }
 
+        $spanName = $operationName !== null ? 'sql ' . $operationName : 'sql';
+
         /** @psalm-suppress ArgumentTypeCoercion */
-        $span = $this->instrumentation->tracer()->spanBuilder('sql ' . $operationName)
+        $span = $this->instrumentation->tracer()->spanBuilder($spanName)
             ->setSpanKind(SpanKind::KIND_CLIENT)
             ->setStartTimestamp($this->calculateQueryStartTime($nowInNs, $query->time))
             ->startSpan();

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -155,6 +155,21 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertSame('/hello?foo=bar', $span->getAttributes()->get(TraceAttributes::URL_PATH));
     }
 
+    public function test_unknown_sql_operation_span_name(): void
+    {
+        $this->router()->get('/pragma', function () {
+            DB::statement('PRAGMA table_info(sqlite_master)');
+
+            return response('ok');
+        });
+
+        $this->call('GET', '/pragma');
+
+        $span = $this->storage[0];
+        $this->assertSame('sql', $span->getName());
+        $this->assertNull($span->getAttributes()->get(DbAttributes::DB_OPERATION_NAME));
+    }
+
     private function router(): Router
     {
         /** @psalm-suppress PossiblyNullReference */


### PR DESCRIPTION
## Summary

### Content

- When a SQL statement starts with an unrecognised operation (e.g. `PRAGMA`, `EXPLAIN`, `CREATE`), `$operationName` was set to `null`, causing the span name to be built as `'sql ' . null = 'sql '`(trailing space)
- Since PHP 8.1, this also emits a deprecation notice for implicit null-to-string coercion.
- Fixed by building the span name explicitly: `'sql <OPERATION>'` for known operations, `'sql'` for unknown ones.

### What I have done

- Built the span name explicitly to avoid null concatenation:

**Before**
  ```php
  $span = $this->instrumentation->tracer()->spanBuilder('sql ' . $operationName) // 'sql ' when null
  ```
  
**After**
  ```php  
  $spanName = $operationName !== null ? 'sql ' . $operationName : 'sql';
  $span = $this->instrumentation->tracer()->spanBuilder($spanName)
  ```
  
### Test Results
  
```bash
php@33736e758e63:/usr/src/myapp/src/Instrumentation/Laravel$ vendor/bin/phpunit --filter test_unknown_sql_operation_span_name tests/Integration/LaravelInstrumentationTest.php
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.34
Configuration: /usr/src/myapp/src/Instrumentation/Laravel/phpunit.xml.dist

.                                                                   1 / 1 (100%)

Time: 00:02.467, Memory: 24.00 MB

OK (1 test, 2 assertions)
php@33736e758e63:/usr/src/myapp/src/Instrumentation/Laravel$
```