### PR TITLE
fix(guzzle): end span when Client::transfer() throws synchronously

### DIFF
--- a/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php
+++ b/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php
@@ -87,7 +87,7 @@ class GuzzleInstrumentation
 
                 return [$request];
             },
-            post: static function (Client $client, array $params, PromiseInterface $promise, ?Throwable $exception): void {
+            post: static function (Client $client, array $params, ?PromiseInterface $promise, ?Throwable $exception): void {
                 $scope = Context::storage()->scope();
                 $scope?->detach();
 
@@ -100,6 +100,14 @@ class GuzzleInstrumentation
                     $span->recordException($exception);
                     $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
                     $span->end();
+                }
+
+                if ($promise === null) {
+                    if (!$exception) {
+                        $span->end();
+                    }
+
+                    return;
                 }
 
                 $p = $promise->then(

--- a/src/Instrumentation/Guzzle/tests/Integration/GuzzleInstrumentationTest.php
+++ b/src/Instrumentation/Guzzle/tests/Integration/GuzzleInstrumentationTest.php
@@ -252,6 +252,28 @@ class GuzzleInstrumentationTest extends TestCase
         }
     }
 
+    /**
+     * @link https://github.com/open-telemetry/opentelemetry-php/issues/1988
+     */
+    public function test_post_hook_when_transfer_throws_synchronously(): void
+    {
+        $this->assertCount(0, $this->storage);
+
+        // A numerically-indexed "headers" option makes Client::applyOptions()
+        // throw InvalidArgumentException before transfer() returns a promise.
+        try {
+            $this->client->get('/foo', ['headers' => ['invalid']]);
+            $this->fail('Expected InvalidArgumentException was not thrown');
+        } catch (\InvalidArgumentException $e) {
+            // expected
+        }
+
+        $this->assertCount(1, $this->storage);
+        $span = $this->storage->offsetGet(0);
+        assert($span instanceof ImmutableSpan);
+        $this->assertSame(StatusCode::STATUS_ERROR, $span->getStatus()->getCode());
+    }
+
     public static function exceptionProvider(): array
     {
         return [

--- a/src/Instrumentation/Guzzle/tests/Integration/GuzzleInstrumentationTest.php
+++ b/src/Instrumentation/Guzzle/tests/Integration/GuzzleInstrumentationTest.php
@@ -260,9 +260,14 @@ class GuzzleInstrumentationTest extends TestCase
         $this->assertCount(0, $this->storage);
 
         // A numerically-indexed "headers" option makes Client::applyOptions()
-        // throw InvalidArgumentException before transfer() returns a promise.
+        // throw InvalidArgumentException synchronously inside transfer(), before
+        // a promise is returned. send()/sendAsync() must be used here: the get()
+        // magic method routes through requestAsync(), which unsets the headers
+        // option before transfer() is called, so applyOptions() never sees it.
+        $request = new Request('GET', 'https://example.com/foo');
+
         try {
-            $this->client->get('/foo', ['headers' => ['invalid']]);
+            $this->client->send($request, ['headers' => ['invalid']]);
             $this->fail('Expected InvalidArgumentException was not thrown');
         } catch (\InvalidArgumentException $e) {
             // expected


### PR DESCRIPTION
## Description

`GuzzleHttp\Client::transfer()` can throw **synchronously** before returning a
promise — e.g. when invalid request options are supplied, since `applyOptions()`
runs *outside* `transfer()`'s try/catch. In that case the extension invokes the
`transfer` post hook with a `null` return value.

The post hook typed the promise as non-nullable (`PromiseInterface $promise`), so
the runtime signature check failed: the hook was skipped, the span leaked (never
ended/detached), and an `E_CORE_WARNING` was emitted:

GuzzleHttp\Client::transfer(): OpenTelemetry: post hook invalid signature,
class=GuzzleHttp\Client function=transfer



This surfaces as a fatal error in error trackers such as Sentry.

## Fix

- Make the post hook's promise parameter nullable (`?PromiseInterface $promise`).
- When the promise is `null` (synchronous throw), end the span — unless it was
  already ended via the exception branch — and return instead of dereferencing
  null.

## Test

Adds a regression test that triggers a synchronous throw via a numerically-indexed
`headers` option and asserts the span is still ended with an error status.

## Related

Same class of "post hook invalid signature / span leak on throw" issue previously
fixed for other instrumentations:
- auto-curl: #335 (issue open-telemetry/opentelemetry-php#1531)
- Symfony Messenger: #267