### PR TITLE
Do not add an extra % when escaping in SQLCommenter

### DIFF
--- a/src/SqlCommenter/src/Utils.php
+++ b/src/SqlCommenter/src/Utils.php
@@ -15,22 +15,10 @@ class Utils
         return '/*' . implode(
             ',',
             array_map(
-                static fn (string $value, string $key) => Utils::customUrlEncode($key) . "='" . Utils::customUrlEncode($value) . "'",
+                static fn (string $value, string $key) => urlencode($key) . "='" . urlencode($value) . "'",
                 $comments,
                 array_keys($comments)
             ),
         ) . '*/';
-    }
-
-    private static function customUrlEncode(string $input): string
-    {
-        $encodedString = urlencode($input);
-
-        // Since SQL uses '%' as a keyword, '%' is a by-product of url quoting
-        // e.g. foo,bar --> foo%2Cbar
-        // thus in our quoting, we need to escape it too to finally give
-        //      foo,bar --> foo%%2Cbar
-
-        return str_replace('%', '%%', $encodedString);
     }
 }

--- a/src/SqlCommenter/tests/Unit/UtilsTest.php
+++ b/src/SqlCommenter/tests/Unit/UtilsTest.php
@@ -21,16 +21,16 @@ class UtilsTest extends TestCase
 
     public function testFormatCommentsWithSpecialCharKeys(): void
     {
-        $this->assertEquals("/*key1='value1%%40',key2='value2'*/", Utils::formatComments(['key1' => 'value1@', 'key2' => 'value2']));
+        $this->assertEquals("/*key1='value1%40',key2='value2'*/", Utils::formatComments(['key1' => 'value1@', 'key2' => 'value2']));
     }
 
     public function testFormatCommentsWithPlaceholder(): void
     {
-        $this->assertEquals("/*key1='value1%%3F',key2='value2'*/", Utils::formatComments(['key1' => 'value1?', 'key2' => 'value2']));
+        $this->assertEquals("/*key1='value1%3F',key2='value2'*/", Utils::formatComments(['key1' => 'value1?', 'key2' => 'value2']));
     }
 
     public function testFormatCommentsWithNamedPlaceholder(): void
     {
-        $this->assertEquals("/*key1='%%3Anamed',key2='value2'*/", Utils::formatComments(['key1' => ':named', 'key2' => 'value2']));
+        $this->assertEquals("/*key1='%3Anamed',key2='value2'*/", Utils::formatComments(['key1' => ':named', 'key2' => 'value2']));
     }
 }


### PR DESCRIPTION
The formatter for SQLCommenter comments was calling `urlencode` to perform percent-escaping, and then adding an _extra_ % to each escaped value with that idea that you need a second % to escape the percent symbols themselves for SQL.

But this isn't necessary, because it's inside a SQL comment (not a literal in a SQL query), and % has no special meaning there.

This was noted in the old Google SQLCommenter repo: https://github.com/google/sqlcommenter/issues/168

... which specifically called out the PHP implementation as out-of-spec.

And the spec also makes it clear that the extra % character is not required: https://google.github.io/sqlcommenter/spec/#key-value-format

I've removed the Util method that was doing the extra % escaping, and switched `formatComments` to just call `urlencode` directly.