### PR TITLE
Update list of default redacted query parameters

### DIFF
--- a/src/Instrumentation/HttpConfig/src/UriSanitizer/DefaultSanitizer.php
+++ b/src/Instrumentation/HttpConfig/src/UriSanitizer/DefaultSanitizer.php
@@ -22,7 +22,7 @@ final class DefaultSanitizer implements UriSanitizer
     {
         $this->sanitizer = MultiSanitizer::composite([
             new RedactUsernamePasswordSanitizer(),
-            new RedactSensitiveQueryStringValuesSanitizer(['AWSAccessKeyId', 'Signature', 'sig', 'X-Goog-Signature']),
+            new RedactSensitiveQueryStringValuesSanitizer(['X-Amz-Signature', 'X-Amz-Credential', 'X-Amz-Security-Token', 'sig', 'X-Goog-Signature']),
         ]);
     }
 

--- a/src/Instrumentation/ReactPHP/src/ReactPHPInstrumentation.php
+++ b/src/Instrumentation/ReactPHP/src/ReactPHPInstrumentation.php
@@ -82,7 +82,7 @@ class ReactPHPInstrumentation
      *
      * @see https://opentelemetry.io/docs/specs/semconv/attributes-registry/url/#url-query
      */
-    private const URL_QUERY_REDACT_KEYS = ['AWSAccessKeyId', 'Signature', 'sig', 'X-Goog-Signature'];
+    private const URL_QUERY_REDACT_KEYS = ['X-Amz-Signature', 'X-Amz-Credential', 'X-Amz-Security-Token', 'sig', 'X-Goog-Signature'];
     /**
      * Value used to replace any sensitive content in the URL.
      *

--- a/src/Instrumentation/ReactPHP/tests/Integration/ReactPHPInstrumentationTest.php
+++ b/src/Instrumentation/ReactPHP/tests/Integration/ReactPHPInstrumentationTest.php
@@ -118,10 +118,10 @@ class ReactPHPInstrumentationTest extends TestCase
         $span = $this->storage->offsetGet(0);
         $this->assertSame('http://REDACTED@example.com/success', $span->getAttributes()->get(TraceAttributes::URL_FULL));
 
-        $this->browser->request('GET', 'http://username:password@example.com/success?Signature=private')->then();
+        $this->browser->request('GET', 'http://username:password@example.com/success?sig=private')->then();
 
         $span = $this->storage->offsetGet(1);
-        $this->assertSame('http://REDACTED:REDACTED@example.com/success?Signature=REDACTED', $span->getAttributes()->get(TraceAttributes::URL_FULL));
+        $this->assertSame('http://REDACTED:REDACTED@example.com/success?sig=REDACTED', $span->getAttributes()->get(TraceAttributes::URL_FULL));
     }
 
     public function test_fulfilled_promise_with_custom_redactions(): void
@@ -166,7 +166,8 @@ class ReactPHPInstrumentationTest extends TestCase
 
     public function test_rejected_promise_with_response_exception(): void
     {
-        $this->browser->request('GET', 'http://example.com/network_error')->then(null, function () {});
+        $this->browser->request('GET', 'http://example.com/network_error')->then(null, function () {
+        });
 
         $span = $this->storage->offsetGet(0);
         $this->assertSame(StatusCode::STATUS_ERROR, $span->getStatus()->getCode());
@@ -181,7 +182,8 @@ class ReactPHPInstrumentationTest extends TestCase
 
     public function test_rejected_promise_with_unknown_exception(): void
     {
-        $this->browser->request('GET', 'http://example.com/unknown_error')->then(null, function () {});
+        $this->browser->request('GET', 'http://example.com/unknown_error')->then(null, function () {
+        });
 
         $span = $this->storage->offsetGet(0);
         $this->assertSame(StatusCode::STATUS_ERROR, $span->getStatus()->getCode());


### PR DESCRIPTION
The list of query parameters that should be redacted in `url.query`/`url.full` was changed was changed in `1.42.0`.

https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/#url-query