### PR TITLE
fix(postgresql): remove hardcoded version from composer.json

### DIFF
--- a/src/Instrumentation/PostgreSql/composer.json
+++ b/src/Instrumentation/PostgreSql/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "open-telemetry/opentelemetry-auto-postgresql",
-  "version": "dev-main",
   "description": "OpenTelemetry auto-instrumentation for postgresql",
   "keywords": [
     "opentelemetry",


### PR DESCRIPTION
The version field was set to "dev-main" which prevents proper release tagging. Version should be derived from git tags, not hardcoded.