### PR TITLE
fix(laravel): don't let Kernel::handle hook throw on hostile method override

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
@@ -41,10 +41,11 @@ class Kernel implements LaravelHook
             'handle',
             pre: function (KernelContract $kernel, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
                 $request = ($params[0] instanceof Request) ? $params[0] : null;
+                $method = $request ? $this->httpMethod($request) : 'unknown';
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $this->instrumentation
                     ->tracer()
-                    ->spanBuilder(sprintf('%s', $request?->method() ?? 'unknown'))
+                    ->spanBuilder($method)
                     ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, sprintf('%s::%s', $class, $function))
                     ->setAttribute(TraceAttributes::CODE_FILE_PATH, $filename)
@@ -56,7 +57,7 @@ class Kernel implements LaravelHook
                     $span = $builder
                         ->setParent($parent)
                         ->setAttribute(TraceAttributes::URL_FULL, $request->fullUrl())
-                        ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->method())
+                        ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $method)
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->header('Content-Length'))
                         ->setAttribute(TraceAttributes::URL_SCHEME, $request->getScheme())
                         ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $request->getProtocolVersion())
@@ -87,7 +88,7 @@ class Kernel implements LaravelHook
                 $route = $request?->route();
 
                 if ($request && $route instanceof Route) {
-                    $span->updateName("{$request->method()} /" . ltrim($route->uri, '/'));
+                    $span->updateName($this->httpMethod($request) . ' /' . ltrim($route->uri, '/'));
                     $span->setAttribute(TraceAttributes::HTTP_ROUTE, $route->uri);
                 }
 
@@ -117,14 +118,39 @@ class Kernel implements LaravelHook
         return $query ? $path . '?' . $query : $path;
     }
 
+    /**
+     * $request->method()/getMethod() throws SuspiciousOperationException for a
+     * malformed method override (e.g. a hostile `_method` or
+     * `X-HTTP-METHOD-OVERRIDE` value). Instrumentation must not raise on
+     * hostile input, since this hook runs before the framework's own
+     * exception handling is engaged.
+     */
+    private function httpMethod(Request $request): string
+    {
+        try {
+            return $request->method();
+        } catch (Throwable) {
+            return 'unknown';
+        }
+    }
+
+    /**
+     * getHost() throws SuspiciousOperationException for a Host header that
+     * fails validation (e.g. invalid characters, or a mismatch against
+     * trusted host patterns). See httpMethod() for why this must not throw.
+     */
     private function httpHostName(Request $request): string
     {
-        if (method_exists($request, 'host')) {
-            return $request->host();
-        }
+        try {
+            if (method_exists($request, 'host')) {
+                return $request->host();
+            }
 
-        if (method_exists($request, 'getHost')) {
-            return $request->getHost();
+            if (method_exists($request, 'getHost')) {
+                return $request->getHost();
+            }
+        } catch (Throwable) {
+            return '';
         }
 
         return '';

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
@@ -118,13 +118,7 @@ class Kernel implements LaravelHook
         return $query ? $path . '?' . $query : $path;
     }
 
-    /**
-     * $request->method()/getMethod() throws SuspiciousOperationException for a
-     * malformed method override (e.g. a hostile `_method` or
-     * `X-HTTP-METHOD-OVERRIDE` value). Instrumentation must not raise on
-     * hostile input, since this hook runs before the framework's own
-     * exception handling is engaged.
-     */
+    // getMethod() throws on a malformed override; this hook runs pre-boot, before Laravel's own exception handling.
     private function httpMethod(Request $request): string
     {
         try {
@@ -134,11 +128,7 @@ class Kernel implements LaravelHook
         }
     }
 
-    /**
-     * getHost() throws SuspiciousOperationException for a Host header that
-     * fails validation (e.g. invalid characters, or a mismatch against
-     * trusted host patterns). See httpMethod() for why this must not throw.
-     */
+    // getHost() has the same pre-boot throw risk for an invalid Host header; see httpMethod() above.
     private function httpHostName(Request $request): string
     {
         try {

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
@@ -56,7 +56,7 @@ class Kernel implements LaravelHook
                     $parent = Globals::propagator()->extract($request, HeadersPropagator::instance());
                     $span = $builder
                         ->setParent($parent)
-                        ->setAttribute(TraceAttributes::URL_FULL, $request->fullUrl())
+                        ->setAttribute(TraceAttributes::URL_FULL, $this->httpFullUrl($request))
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $method)
                         ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->header('Content-Length'))
                         ->setAttribute(TraceAttributes::URL_SCHEME, $request->getScheme())
@@ -127,18 +127,27 @@ class Kernel implements LaravelHook
         }
     }
 
-    private function httpHostName(Request $request): string
+    private function httpFullUrl(Request $request): string
     {
         try {
-            if (method_exists($request, 'host')) {
-                return $request->host();
-            }
-
-            if (method_exists($request, 'getHost')) {
-                return $request->getHost();
-            }
+            return $request->fullUrl();
         } catch (Throwable) {
             return '';
+        }
+    }
+
+    private function httpHostName(Request $request): string
+    {
+        if (method_exists($request, 'host')) {
+            try {
+                return $request->host();
+            } catch (Throwable) {
+                return '';
+            }
+        }
+
+        if (method_exists($request, 'getHost')) {
+            return $request->getHost();
         }
 
         return '';

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
@@ -118,7 +118,6 @@ class Kernel implements LaravelHook
         return $query ? $path . '?' . $query : $path;
     }
 
-    // getMethod() throws on a malformed override; this hook runs pre-boot, before Laravel's own exception handling.
     private function httpMethod(Request $request): string
     {
         try {
@@ -128,7 +127,6 @@ class Kernel implements LaravelHook
         }
     }
 
-    // getHost() has the same pre-boot throw risk for an invalid Host header; see httpMethod() above.
     private function httpHostName(Request $request): string
     {
         try {

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -159,10 +159,7 @@ class LaravelInstrumentationTest extends TestCase
     {
         $this->router()->post('/', fn () => response('ok'));
 
-        // `_method`/`X-HTTP-METHOD-OVERRIDE` values that aren't plain letters
-        // make Symfony's Request::getMethod() throw a SuspiciousOperationException.
-        // The Kernel::handle pre-hook must not let that propagate, since it runs
-        // before Laravel's own exception handling is engaged.
+        // Triggers Symfony's SuspiciousOperationException in getMethod(); see Kernel::httpMethod().
         $response = $this->call('POST', '/', server: ['HTTP_X_HTTP_METHOD_OVERRIDE' => '__construct']);
 
         $this->assertSame(200, $response->status());

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration;
 
 use Exception;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
@@ -166,6 +168,23 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertCount(1, $this->storage);
         $span = $this->storage[0];
         $this->assertSame('POST /', $span->getName());
+    }
+
+    public function test_malformed_host_header_does_not_break_instrumentation(): void
+    {
+        $this->router()->get('/', fn () => response('ok'));
+
+        // `Request::create()`'s URI parsing always overwrites HTTP_HOST, so the
+        // header has to be forced onto the request after construction.
+        $request = Request::create('/');
+        $request->headers->set('HOST', 'evil host!.example.com');
+
+        $response = $this->app->make(HttpKernel::class)->handle($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertCount(1, $this->storage);
+        $span = $this->storage[0];
+        $this->assertSame('', $span->getAttributes()->get(ServerAttributes::SERVER_ADDRESS));
     }
 
     public function test_unknown_sql_operation_span_name(): void

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -155,6 +155,22 @@ class LaravelInstrumentationTest extends TestCase
         $this->assertSame('/hello?foo=bar', $span->getAttributes()->get(TraceAttributes::URL_PATH));
     }
 
+    public function test_malformed_method_override_header_does_not_break_instrumentation(): void
+    {
+        $this->router()->post('/', fn () => response('ok'));
+
+        // `_method`/`X-HTTP-METHOD-OVERRIDE` values that aren't plain letters
+        // make Symfony's Request::getMethod() throw a SuspiciousOperationException.
+        // The Kernel::handle pre-hook must not let that propagate, since it runs
+        // before Laravel's own exception handling is engaged.
+        $response = $this->call('POST', '/', server: ['HTTP_X_HTTP_METHOD_OVERRIDE' => '__construct']);
+
+        $this->assertSame(200, $response->status());
+        $this->assertCount(1, $this->storage);
+        $span = $this->storage[0];
+        $this->assertSame('POST /', $span->getName());
+    }
+
     public function test_unknown_sql_operation_span_name(): void
     {
         $this->router()->get('/pragma', function () {

--- a/src/Instrumentation/Laravel/tests/Unit/Hooks/Illuminate/Contracts/Http/KernelTest.php
+++ b/src/Instrumentation/Laravel/tests/Unit/Hooks/Illuminate/Contracts/Http/KernelTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Unit\Hooks\Illuminate\Contracts\Http;
+
+use Illuminate\Http\Request;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Contracts\Http\Kernel;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
+
+class KernelTest extends TestCase
+{
+    public function test_http_method_swallows_suspicious_operation_exception(): void
+    {
+        $request = new class() extends Request {
+            public function method(): string
+            {
+                throw new SuspiciousOperationException('Invalid method override.');
+            }
+        };
+
+        $this->assertSame('unknown', $this->invokeGuard('httpMethod', $request));
+    }
+
+    public function test_http_full_url_swallows_suspicious_operation_exception(): void
+    {
+        $request = new class() extends Request {
+            public function fullUrl(): string
+            {
+                throw new SuspiciousOperationException('Invalid Host.');
+            }
+        };
+
+        $this->assertSame('', $this->invokeGuard('httpFullUrl', $request));
+    }
+
+    public function test_http_host_name_swallows_suspicious_operation_exception(): void
+    {
+        $request = new class() extends Request {
+            public function host(): string
+            {
+                throw new SuspiciousOperationException('Invalid Host.');
+            }
+        };
+
+        $this->assertSame('', $this->invokeGuard('httpHostName', $request));
+    }
+
+    private function invokeGuard(string $method, Request $request): string
+    {
+        $kernel = (new ReflectionClass(Kernel::class))->newInstanceWithoutConstructor();
+
+        $reflectionMethod = new ReflectionMethod(Kernel::class, $method);
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod->invoke($kernel, $request);
+    }
+}


### PR DESCRIPTION
## Which problem is this PR solving?

`Illuminate\Http\Request::method()`/`getMethod()` throws a `SuspiciousOperationException` when the request carries a malformed HTTP method override — e.g. `_method=__construct` or a `X-HTTP-METHOD-OVERRIDE: __construct` header, which is a fairly common vulnerability-scanner probe. `getHost()` has the same failure mode for a `Host` header that fails validation, and it's reached both directly (`host()`/`getHost()`) and indirectly via `fullUrl()` (used for the `URL_FULL` attribute).

The `Kernel::handle` `pre` hook calls all of these unguarded while building the span. Because this is a `pre` hook, it runs *before* the intercepted `Kernel::handle()` method body executes — i.e. before Laravel's own `try { ... } catch (Throwable $e)` around request handling is even reached. An uncaught throw here isn't caught by the application at all; the extension reports it as a raw PHP warning outside the normal response lifecycle (`OpenTelemetry: pre hook threw exception, ... message=Invalid HTTP method override.`), and the span for the request is silently dropped.

In a real deployment this surfaced as a `FatalError: Cannot modify header information - headers already sent` — the warning text got written to the response body before any headers were sent, so a later attempt to set a header (e.g. by the framework's own exception rendering) fatals.

## Short description of the changes

- Extract `$request->method()` access into a new `httpMethod()` helper that catches `Throwable` and falls back to `'unknown'`, used in both the `pre` and `post` hooks (also removes a redundant second call to `method()` that existed in the `pre` hook).
- Add a `httpFullUrl()` helper guarding `$request->fullUrl()` the same way, since it independently calls `getHost()` and runs *before* `httpHostName()` in the attribute chain — so a hostile `Host` header could still crash the hook even with `httpHostName()` guarded.
- Guard the one reachable `getHost()` call site inside `httpHostName()`. The `getHost()` fallback branch there is dead code (`Illuminate\Http\Request` always defines `host()`) and was already uncovered on `main`, so it's intentionally left unwrapped/untouched rather than dragging pre-existing untested lines into this diff.
- Add regression tests: a malformed `X-HTTP-METHOD-OVERRIDE` header case and a malformed `Host` header case (the latter constructs the request manually, since `MakesHttpRequests::call()`'s `Request::create()` always overwrites `HTTP_HOST` from the parsed URI). Plus focused unit tests invoking `httpMethod()`/`httpFullUrl()`/`httpHostName()` directly via reflection so each guard's catch branch is exercised independent of call order.

Reverting the `Kernel.php` guards locally reproduces the exact warning and the dropped span for both the method-override and Host-header cases, confirming this is the same failure mode in both spots.