### PR TITLE
feat(symfony): emit CONSUMER span when a received Messenger message is dispatched

### DIFF
--- a/src/Instrumentation/Symfony/src/MessengerInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/MessengerInstrumentation.php
@@ -14,6 +14,7 @@ use OpenTelemetry\SemConv\TraceAttributes;
 use OpenTelemetry\SemConv\Version;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 /**
@@ -60,13 +61,23 @@ final class MessengerInstrumentation
             ) use ($instrumentation): array {
                 /** @var object|Envelope $message */
                 $message = $params[0];
+
+                // A message dispatched by a worker after being pulled from a transport
+                // carries a ReceivedStamp. That is the consumer side of messaging, so it
+                // must be a CONSUMER span; a plain dispatch is the producer side. For an
+                // Envelope, report the wrapped message class rather than Envelope. See #1314.
+                $isReceiving = false;
                 $messageClass = \get_class($message);
+                if ($message instanceof Envelope) {
+                    $messageClass = \get_class($message->getMessage());
+                    $isReceiving = $message->last(ReceivedStamp::class) !== null;
+                }
 
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $instrumentation
                     ->tracer()
-                    ->spanBuilder(\sprintf('DISPATCH %s', $messageClass))
-                    ->setSpanKind(SpanKind::KIND_PRODUCER)
+                    ->spanBuilder(\sprintf('%s %s', $isReceiving ? 'CONSUME' : 'DISPATCH', $messageClass))
+                    ->setSpanKind($isReceiving ? SpanKind::KIND_CONSUMER : SpanKind::KIND_PRODUCER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, sprintf('%s::%s', $class, $function))
                     ->setAttribute(TraceAttributes::CODE_FILE_PATH, $filename)
                     ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno)

--- a/src/Instrumentation/Symfony/tests/Integration/MessengerInstrumentationTest.php
+++ b/src/Instrumentation/Symfony/tests/Integration/MessengerInstrumentationTest.php
@@ -9,6 +9,7 @@ use OpenTelemetry\Contrib\Instrumentation\Symfony\MessengerInstrumentation;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 use Symfony\Component\Messenger\Transport\InMemoryTransport as LegacyInMemoryTransport;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -70,6 +71,28 @@ final class MessengerInstrumentationTest extends AbstractTest
             $this->assertTrue($span->getAttributes()->has($key), sprintf('Attribute %s not found', $key));
             $this->assertEquals($value, $span->getAttributes()->get($key));
         }
+    }
+
+    public function test_dispatch_of_received_message_is_a_consumer_span()
+    {
+        $bus = $this->getMessenger();
+
+        // A worker re-dispatches a message pulled from a transport with a ReceivedStamp.
+        $envelope = (new Envelope(new SendEmailMessage('Hello Again')))->with(new ReceivedStamp('async'));
+        $bus->dispatch($envelope);
+
+        $this->assertCount(1, $this->storage);
+        $span = $this->storage[0];
+
+        $this->assertEquals(
+            'CONSUME OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration\SendEmailMessage',
+            $span->getName(),
+        );
+        $this->assertEquals(SpanKind::KIND_CONSUMER, $span->getKind());
+        $this->assertEquals(
+            'OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration\SendEmailMessage',
+            $span->getAttributes()->get(MessengerInstrumentation::ATTRIBUTE_MESSENGER_MESSAGE),
+        );
     }
 
     /**


### PR DESCRIPTION
## Problem

Fixes open-telemetry/opentelemetry-php#1314.

The Symfony Messenger instrumentation only emitted `KIND_PRODUCER` spans (`DISPATCH` / `SEND`). The **consumer** side of messaging was not represented at all — as noted in the issue, "the consumer is currently not instrumented" and spans were not marked `KIND_CONSUMER` per the [messaging span-kind conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#span-kind).

## Fix

When a Symfony worker pulls a message off a transport and re-dispatches it onto the bus, the `Envelope` carries a `ReceivedStamp`. The `MessageBusInterface::dispatch` pre-hook now:

- detects the `ReceivedStamp` and emits a `KIND_CONSUMER` span named `CONSUME <message>` (instead of the producer `DISPATCH` span); and
- for an `Envelope`, reports the **wrapped** message class as `symfony.messenger.message` and in the span name, rather than `Symfony\...\Envelope`.

Plain (producer-side) dispatches are unchanged — still `DISPATCH` / `KIND_PRODUCER`.

This is intentionally scoped to span kind + naming; trace-context propagation through transports remains out of scope (as the class docblock already notes).

## Tests

Added `test_dispatch_of_received_message_is_a_consumer_span`: dispatching an `Envelope` stamped with `ReceivedStamp` produces a `CONSUME …` / `KIND_CONSUMER` span with the unwrapped message class. Fails before this change, passes after. Existing producer tests remain green (22 tests).

> Note: `psalm`/`phpstan` report 2 pre-existing errors in `SymfonyInstrumentation.php` / `SymfonyInstrumentationTest.php` (a missing `TraceResponsePropagator` due to local Symfony version skew) that also occur on a clean checkout and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)