### PR TITLE
Add `process.paging.faults` and `process.uptime` runtime metrics

### DIFF
--- a/src/Metrics/Runtime/README.md
+++ b/src/Metrics/Runtime/README.md
@@ -95,7 +95,7 @@ Registered only on platforms where `getrusage()` is available (Linux, macOS, Win
 |--------|------|------|-------------|
 | `process.cpu.time` | Counter | `s` | CPU time consumed. Reported for `user` and `system` modes via the `cpu.mode` attribute. |
 | `process.context_switches` | Counter | `{context_switch}` | Number of times the process has been context switched. Reported for `voluntary` and `involuntary` switches via the `process.context_switch.type` attribute. |
-| `process.paging.faults` | Counter | `{fault}` | Number of page faults the process has made. Reported for `minor` and `major` faults via the `system.paging.fault.ype` attribute. |
+| `process.paging.faults` | Counter | `{fault}` | Number of page faults the process has made. Reported for `minor` and `major` faults via the `system.paging.fault.type` attribute. |
 
 ## Configuration
 

--- a/src/Metrics/Runtime/README.md
+++ b/src/Metrics/Runtime/README.md
@@ -94,6 +94,7 @@ Registered only on platforms where `getrusage()` is available (Linux, macOS, Win
 |--------|------|------|-------------|
 | `process.cpu.time` | Counter | `s` | CPU time consumed. Reported for `user` and `system` modes via the `cpu.mode` attribute. |
 | `process.context_switches` | Counter | `{context_switch}` | Number of times the process has been context switched. Reported for `voluntary` and `involuntary` switches via the `process.context_switch.type` attribute. |
+| `process.paging.faults` | Counter | `{fault}` | Number of page faults the process has made. Reported for `minor` and `major` faults via the `system.paging.fault.ype` attribute. |
 
 ## Configuration
 

--- a/src/Metrics/Runtime/README.md
+++ b/src/Metrics/Runtime/README.md
@@ -68,6 +68,7 @@ RuntimeMetrics::register($meterProvider, new RuntimeMetricsConfig(disabled: ['op
 | `php.gc.collector_time` | Counter | `s` | Cumulative time spent in the GC collector. **PHP 8.3+** |
 | `php.gc.destructor_time` | Counter | `s` | Cumulative time spent running destructors during GC. **PHP 8.3+** |
 | `php.gc.free_time` | Counter | `s` | Cumulative time spent freeing memory during GC. **PHP 8.3+** |
+| `process.uptime` | Gauge | `s` | The time the process has been running. **PHP 8.3+** |
 
 ### OPcache (`opcache`)
 

--- a/src/Metrics/Runtime/README.md
+++ b/src/Metrics/Runtime/README.md
@@ -68,7 +68,7 @@ RuntimeMetrics::register($meterProvider, new RuntimeMetricsConfig(disabled: ['op
 | `php.gc.collector_time` | Counter | `s` | Cumulative time spent in the GC collector. **PHP 8.3+** |
 | `php.gc.destructor_time` | Counter | `s` | Cumulative time spent running destructors during GC. **PHP 8.3+** |
 | `php.gc.free_time` | Counter | `s` | Cumulative time spent freeing memory during GC. **PHP 8.3+** |
-| `process.uptime` | Gauge | `s` | The time the process has been running. **PHP 8.3+** |
+| `process.uptime` | Gauge | `s` | The time the process has been running. **PHP 8.3+** (CLI only) |
 
 ### OPcache (`opcache`)
 

--- a/src/Metrics/Runtime/src/CpuMetrics.php
+++ b/src/Metrics/Runtime/src/CpuMetrics.php
@@ -34,11 +34,17 @@ class CpuMetrics
             '{context_switch}',
             'Number of times the process has been context switched',
         );
+        $pagingFaults = $meter->createObservableCounter(
+            'process.paging.faults',
+            '{fault}',
+            'Number of page faults the process has made',
+        );
 
         $meter->batchObserve(
             static function (
                 ObserverInterface $cpuObserver,
                 ObserverInterface $contextSwitchesObserver,
+                ObserverInterface $pagingFaultsObserver,
             ): void {
                 /** @var array<string, int> $usage */
                 $usage = getrusage();
@@ -56,9 +62,16 @@ class CpuMetrics
                 if (isset($usage['ru_nivcsw'])) {
                     $contextSwitchesObserver->observe($usage['ru_nivcsw'], ['process.context_switch.type' => 'involuntary']);
                 }
+                if (isset($usage['ru_minflt'])) {
+                    $pagingFaultsObserver->observe($usage['ru_minflt'], ['system.paging.fault.type' => 'minor']);
+                }
+                if (isset($usage['ru_majflt'])) {
+                    $pagingFaultsObserver->observe($usage['ru_majflt'], ['system.paging.fault.type' => 'major']);
+                }
             },
             $cpuTime,
             $contextSwitches,
+            $pagingFaults,
         );
     }
 }

--- a/src/Metrics/Runtime/src/GarbageCollectionMetrics.php
+++ b/src/Metrics/Runtime/src/GarbageCollectionMetrics.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Contrib\Metrics\Runtime;
 
 use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Metrics\ObserverInterface;
+use const PHP_VERSION_ID;
 
 /**
  * @internal
@@ -36,6 +37,26 @@ class GarbageCollectionMetrics
             '{object}',
             'Current number of objects in the root buffer',
         );
+        $collectorTime = $meter->createObservableCounter(
+            'php.gc.collector_time',
+            's',
+            'Cumulative time spent in the garbage collector',
+        );
+        $destructorTime = $meter->createObservableCounter(
+            'php.gc.destructor_time',
+            's',
+            'Cumulative time spent running destructors during GC',
+        );
+        $freeTime = $meter->createObservableCounter(
+            'php.gc.free_time',
+            's',
+            'Cumulative time spent freeing memory during GC',
+        );
+        $processUptime = $meter->createObservableGauge(
+            'process.uptime',
+            's',
+            'The time the process has been running',
+        );
 
         $meter->batchObserve(
             static function (
@@ -43,65 +64,39 @@ class GarbageCollectionMetrics
                 ObserverInterface $collectedObs,
                 ObserverInterface $thresholdObs,
                 ObserverInterface $rootsObs,
+                ObserverInterface $collectorObs,
+                ObserverInterface $destructorObs,
+                ObserverInterface $freeObs,
+                ObserverInterface $uptimeObs,
             ): void {
                 $status = gc_status();
                 $runsObs->observe($status['runs']);
                 $collectedObs->observe($status['collected']);
                 $thresholdObs->observe($status['threshold']);
                 $rootsObs->observe($status['roots']);
+
+                if (PHP_VERSION_ID < 80300) { // Timing metrics available since PHP 8.3
+                    return;
+                }
+
+                /** @var array<string, int|float> $status */
+                // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
+                $collectorObs->observe($status['collector_time']);
+                // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
+                $destructorObs->observe($status['destructor_time']);
+                // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
+                $freeObs->observe($status['free_time']);
+                // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
+                $uptimeObs->observe($status['application_time']);
             },
             $runs,
             $collected,
             $threshold,
             $roots,
+            $collectorTime,
+            $destructorTime,
+            $freeTime,
+            $processUptime,
         );
-
-        // Timing metrics available since PHP 8.3
-        if (PHP_VERSION_ID >= 80300) {
-            $collectorTime = $meter->createObservableCounter(
-                'php.gc.collector_time',
-                's',
-                'Cumulative time spent in the garbage collector',
-            );
-            $destructorTime = $meter->createObservableCounter(
-                'php.gc.destructor_time',
-                's',
-                'Cumulative time spent running destructors during GC',
-            );
-            $freeTime = $meter->createObservableCounter(
-                'php.gc.free_time',
-                's',
-                'Cumulative time spent freeing memory during GC',
-            );
-            $processUptime = $meter->createObservableGauge(
-                'process.uptime',
-                's',
-                'The time the process has been running',
-            );
-
-            $meter->batchObserve(
-                static function (
-                    ObserverInterface $collectorObs,
-                    ObserverInterface $destructorObs,
-                    ObserverInterface $freeObs,
-                    ObserverInterface $uptimeObs,
-                ): void {
-                    /** @var array<string, int|float> $status */
-                    $status = gc_status();
-                    // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
-                    $collectorObs->observe($status['collector_time']);
-                    // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
-                    $destructorObs->observe($status['destructor_time']);
-                    // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
-                    $freeObs->observe($status['free_time']);
-                    // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
-                    $uptimeObs->observe($status['application_time']);
-                },
-                $collectorTime,
-                $destructorTime,
-                $freeTime,
-                $processUptime,
-            );
-        }
     }
 }

--- a/src/Metrics/Runtime/src/GarbageCollectionMetrics.php
+++ b/src/Metrics/Runtime/src/GarbageCollectionMetrics.php
@@ -73,12 +73,18 @@ class GarbageCollectionMetrics
                 's',
                 'Cumulative time spent freeing memory during GC',
             );
+            $processUptime = $meter->createObservableGauge(
+                'process.uptime',
+                's',
+                'The time the process has been running',
+            );
 
             $meter->batchObserve(
                 static function (
                     ObserverInterface $collectorObs,
                     ObserverInterface $destructorObs,
                     ObserverInterface $freeObs,
+                    ObserverInterface $uptimeObs,
                 ): void {
                     /** @var array<string, int|float> $status */
                     $status = gc_status();
@@ -88,10 +94,13 @@ class GarbageCollectionMetrics
                     $destructorObs->observe($status['destructor_time']);
                     // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
                     $freeObs->observe($status['free_time']);
+                    // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
+                    $uptimeObs->observe($status['application_time']);
                 },
                 $collectorTime,
                 $destructorTime,
                 $freeTime,
+                $processUptime,
             );
         }
     }

--- a/src/Metrics/Runtime/src/GarbageCollectionMetrics.php
+++ b/src/Metrics/Runtime/src/GarbageCollectionMetrics.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Contrib\Metrics\Runtime;
 
 use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Metrics\ObserverInterface;
+use const PHP_SAPI;
 use const PHP_VERSION_ID;
 
 /**
@@ -86,8 +87,11 @@ class GarbageCollectionMetrics
                 $destructorObs->observe($status['destructor_time']);
                 // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
                 $freeObs->observe($status['free_time']);
-                // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
-                $uptimeObs->observe($status['application_time']);
+
+                if (PHP_SAPI === 'cli') {
+                    // @phan-suppress-next-line PhanTypeInvalidDimOffset, PhanTypeMismatchArgument -- fields added in PHP 8.3
+                    $uptimeObs->observe($status['application_time']);
+                }
             },
             $runs,
             $collected,

--- a/src/Metrics/Runtime/tests/Unit/CpuMetricsTest.php
+++ b/src/Metrics/Runtime/tests/Unit/CpuMetricsTest.php
@@ -26,7 +26,7 @@ class CpuMetricsTest extends TestCase
 
         $meter = $this->createMock(MeterInterface::class);
 
-        $meter->expects($this->exactly(2))
+        $meter->expects($this->exactly(3))
             ->method('createObservableCounter')
             ->willReturn($this->createMock(ObservableCounterInterface::class));
 
@@ -71,7 +71,9 @@ class CpuMetricsTest extends TestCase
 
         $contextSwitchesObserver = $this->createMock(ObserverInterface::class);
 
-        $capturedCallback($cpuObserver, $contextSwitchesObserver);
+        $pagingFaultsObserver = $this->createMock(ObserverInterface::class);
+
+        $capturedCallback($cpuObserver, $contextSwitchesObserver, $pagingFaultsObserver);
     }
 
     public function test_context_switches_callback_observes_voluntary_and_involuntary_types(): void
@@ -108,6 +110,47 @@ class CpuMetricsTest extends TestCase
                 ),
             );
 
-        $capturedCallback($cpuObserver, $contextSwitchesObserver);
+        $pagingFaultsObserver = $this->createMock(ObserverInterface::class);
+
+        $capturedCallback($cpuObserver, $contextSwitchesObserver, $pagingFaultsObserver);
+    }
+
+    public function test_paging_faults_callback_observes_minor_and_major_types(): void
+    {
+        if (!CpuMetrics::isAvailable()) {
+            $this->markTestSkipped('getrusage() not available on this platform');
+        }
+
+        $capturedCallback = null;
+
+        $meter = $this->createMock(MeterInterface::class);
+        $meter->method('createObservableCounter')->willReturn($this->createMock(ObservableCounterInterface::class));
+        $meter->method('batchObserve')
+            ->willReturnCallback(function (callable $cb) use (&$capturedCallback): ObservableCallbackInterface {
+                $capturedCallback = $cb;
+
+                return $this->createMock(ObservableCallbackInterface::class);
+            });
+
+        CpuMetrics::register($meter);
+
+        assert($capturedCallback !== null);
+
+        $cpuObserver = $this->createMock(ObserverInterface::class);
+
+        $contextSwitchesObserver = $this->createMock(ObserverInterface::class);
+
+        $pagingFaultsObserver = $this->createMock(ObserverInterface::class);
+        $pagingFaultsObserver->expects($this->atMost(2))
+            ->method('observe')
+            ->with(
+                $this->isType('int'),
+                $this->logicalOr(
+                    $this->equalTo(['system.paging.fault.type' => 'minor']),
+                    $this->equalTo(['system.paging.fault.type' => 'major']),
+                ),
+            );
+
+        $capturedCallback($cpuObserver, $contextSwitchesObserver, $pagingFaultsObserver);
     }
 }

--- a/src/Metrics/Runtime/tests/Unit/GarbageCollectionMetricsTest.php
+++ b/src/Metrics/Runtime/tests/Unit/GarbageCollectionMetricsTest.php
@@ -10,6 +10,7 @@ use OpenTelemetry\API\Metrics\ObservableCounterInterface;
 use OpenTelemetry\API\Metrics\ObservableGaugeInterface;
 use OpenTelemetry\API\Metrics\ObserverInterface;
 use OpenTelemetry\Contrib\Metrics\Runtime\GarbageCollectionMetrics;
+use const PHP_VERSION_ID;
 use PHPUnit\Framework\TestCase;
 
 class GarbageCollectionMetricsTest extends TestCase
@@ -23,7 +24,7 @@ class GarbageCollectionMetricsTest extends TestCase
             ->method('createObservableCounter')
             ->willReturn($this->createMock(ObservableCounterInterface::class));
 
-        $meter->expects($this->exactly(2))
+        $meter->expects($this->exactly(PHP_VERSION_ID >= 80300 ? 3 : 2))
             ->method('createObservableGauge')
             ->willReturn($this->createMock(ObservableGaugeInterface::class));
 
@@ -110,6 +111,7 @@ class GarbageCollectionMetricsTest extends TestCase
 
         $callbacks[1](
             $collectorObs,
+            $this->createMock(ObserverInterface::class),
             $this->createMock(ObserverInterface::class),
             $this->createMock(ObserverInterface::class),
         );

--- a/src/Metrics/Runtime/tests/Unit/GarbageCollectionMetricsTest.php
+++ b/src/Metrics/Runtime/tests/Unit/GarbageCollectionMetricsTest.php
@@ -19,17 +19,15 @@ class GarbageCollectionMetricsTest extends TestCase
     {
         $meter = $this->createMock(MeterInterface::class);
 
-        $expectedCounters = PHP_VERSION_ID >= 80300 ? 5 : 2;
-        $meter->expects($this->exactly($expectedCounters))
+        $meter->expects($this->exactly(5))
             ->method('createObservableCounter')
             ->willReturn($this->createMock(ObservableCounterInterface::class));
 
-        $meter->expects($this->exactly(PHP_VERSION_ID >= 80300 ? 3 : 2))
+        $meter->expects($this->exactly(3))
             ->method('createObservableGauge')
             ->willReturn($this->createMock(ObservableGaugeInterface::class));
 
-        $expectedBatchObserve = PHP_VERSION_ID >= 80300 ? 2 : 1;
-        $meter->expects($this->exactly($expectedBatchObserve))
+        $meter->expects($this->exactly(1))
             ->method('batchObserve')
             ->willReturn($this->createMock(ObservableCallbackInterface::class));
 
@@ -64,26 +62,11 @@ class GarbageCollectionMetricsTest extends TestCase
             $this->createMock(ObserverInterface::class),
             $this->createMock(ObserverInterface::class),
             $this->createMock(ObserverInterface::class),
+            $this->createMock(ObserverInterface::class),
+            $this->createMock(ObserverInterface::class),
+            $this->createMock(ObserverInterface::class),
+            $this->createMock(ObserverInterface::class),
         );
-    }
-
-    public function test_gc_timing_metrics_registered_on_php83(): void
-    {
-        if (PHP_VERSION_ID < 80300) {
-            $this->markTestSkipped('GC timing metrics require PHP 8.3+');
-        }
-
-        $meter = $this->createMock(MeterInterface::class);
-        $meter->expects($this->exactly(5))
-            ->method('createObservableCounter')
-            ->willReturn($this->createMock(ObservableCounterInterface::class));
-        $meter->method('createObservableGauge')
-            ->willReturn($this->createMock(ObservableGaugeInterface::class));
-        $meter->expects($this->exactly(2))
-            ->method('batchObserve')
-            ->willReturn($this->createMock(ObservableCallbackInterface::class));
-
-        GarbageCollectionMetrics::register($meter);
     }
 
     public function test_gc_timing_callback_observes_float(): void
@@ -92,24 +75,29 @@ class GarbageCollectionMetricsTest extends TestCase
             $this->markTestSkipped('GC timing metrics require PHP 8.3+');
         }
 
-        $callbacks = [];
+        $callback = null;
         $meter = $this->createMock(MeterInterface::class);
         $meter->method('createObservableCounter')->willReturn($this->createMock(ObservableCounterInterface::class));
         $meter->method('createObservableGauge')->willReturn($this->createMock(ObservableGaugeInterface::class));
         $meter->method('batchObserve')
-            ->willReturnCallback(function (callable $cb) use (&$callbacks): ObservableCallbackInterface {
-                $callbacks[] = $cb;
+            ->willReturnCallback(function (callable $cb) use (&$callback): ObservableCallbackInterface {
+                $callback = $cb;
 
                 return $this->createMock(ObservableCallbackInterface::class);
             });
 
         GarbageCollectionMetrics::register($meter);
 
-        // $callbacks[1] is the PHP 8.3 timing batchObserve (collector_time, destructor_time, free_time)
         $collectorObs = $this->createMock(ObserverInterface::class);
         $collectorObs->expects($this->once())->method('observe')->with($this->isType('float'));
 
-        $callbacks[1](
+        $this->assertNotNull($callback);
+
+        $callback(
+            $this->createMock(ObserverInterface::class),
+            $this->createMock(ObserverInterface::class),
+            $this->createMock(ObserverInterface::class),
+            $this->createMock(ObserverInterface::class),
             $collectorObs,
             $this->createMock(ObserverInterface::class),
             $this->createMock(ObserverInterface::class),


### PR DESCRIPTION
Adds additional recommended process metrics:
- [`process.paging.faults`](https://opentelemetry.io/docs/specs/semconv/system/process-metrics/#metric-processpagingfaults)
- [`process.uptime`](https://opentelemetry.io/docs/specs/semconv/system/process-metrics/#metric-processuptime)

Follow-up to #645, cc @intuibase 