### PR TITLE
feat(laravel): inject trace context into outbound `HTTP` client requests

### DIFF
--- a/src/Instrumentation/Laravel/README.md
+++ b/src/Instrumentation/Laravel/README.md
@@ -22,3 +22,21 @@ The extension can be disabled via [runtime configuration](https://opentelemetry.
 ```shell
 OTEL_PHP_DISABLED_INSTRUMENTATIONS=laravel
 ```
+
+### Outbound HTTP client trace propagation
+
+By default, outbound requests made via Laravel's HTTP client (`Illuminate\Http\Client`)
+do not have trace context (`traceparent`/`tracestate`) injected into their headers.
+This is opt-in for security reasons: the instrumentation cannot distinguish between
+requests to trusted internal services and external third-party endpoints. Injecting
+trace context and baggage into the latter could leak sensitive information.
+
+To enable trace context propagation on outbound HTTP client requests:
+
+```shell
+OTEL_PHP_INSTRUMENTATION_LARAVEL_HTTP_CLIENT_PROPAGATION_ENABLED=true
+```
+
+**Only enable this if all outbound HTTP client requests are sent to trusted internal services.**
+
+Defaults to `false`.

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Http/Client/PendingRequest.php
@@ -50,6 +50,7 @@ class PendingRequest implements LaravelHook
                     return $params;
                 }
 
+                /** @phan-suppress-next-line PhanAccessMethodInternal */
                 TraceContextPropagator::getInstance()->inject($request, RequestPropagationSetter::instance(), Context::getCurrent());
                 $params[0] = $request;
 

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Http/Client/PendingRequest.php
@@ -9,6 +9,7 @@ use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHook;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHookTrait;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\LaravelInstrumentation;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Propagators\RequestPropagationSetter;
 use function OpenTelemetry\Instrumentation\hook;
 use Psr\Http\Message\RequestInterface;
@@ -28,6 +29,10 @@ class PendingRequest implements LaravelHook
      * is actually sent (the `RequestSending` event ClientRequestWatcher listens on can't do this
      * itself, since it only receives an immutable copy that never reaches the real request).
      *
+     * Gated behind an opt-in flag: the target of an outbound HTTP client request may be a
+     * third-party service outside the application's control, which should not receive internal
+     * trace (and, in future, baggage) data unless the developer explicitly asks for it.
+     *
      * @psalm-suppress PossiblyUnusedReturnValue
      */
     protected function hookRunBeforeSendingCallbacks(): bool
@@ -36,6 +41,10 @@ class PendingRequest implements LaravelHook
             IlluminatePendingRequest::class,
             'runBeforeSendingCallbacks',
             pre: function (IlluminatePendingRequest $_pendingRequest, array $params) {
+                if (!LaravelInstrumentation::shouldPropagateHttpClientTraceContext()) {
+                    return $params;
+                }
+
                 $request = $params[0];
                 if (!$request instanceof RequestInterface) {
                     return $params;

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Http/Client/PendingRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Http\Client;
+
+use Illuminate\Http\Client\PendingRequest as IlluminatePendingRequest;
+use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHook;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHookTrait;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Propagators\RequestPropagationSetter;
+use function OpenTelemetry\Instrumentation\hook;
+use Psr\Http\Message\RequestInterface;
+
+class PendingRequest implements LaravelHook
+{
+    use LaravelHookTrait;
+
+    public function instrument(): void
+    {
+        $this->hookRunBeforeSendingCallbacks();
+    }
+
+    /**
+     * `runBeforeSendingCallbacks()` is where Laravel finalizes the PSR-7 request just before
+     * handing it to Guzzle, so injecting into its first argument here reaches the request that
+     * is actually sent (the `RequestSending` event ClientRequestWatcher listens on can't do this
+     * itself, since it only receives an immutable copy that never reaches the real request).
+     *
+     * @psalm-suppress PossiblyUnusedReturnValue
+     */
+    protected function hookRunBeforeSendingCallbacks(): bool
+    {
+        return hook(
+            IlluminatePendingRequest::class,
+            'runBeforeSendingCallbacks',
+            pre: function (IlluminatePendingRequest $_pendingRequest, array $params) {
+                $request = $params[0];
+                if (!$request instanceof RequestInterface) {
+                    return $params;
+                }
+
+                TraceContextPropagator::getInstance()->inject($request, RequestPropagationSetter::instance(), Context::getCurrent());
+                $params[0] = $request;
+
+                return $params;
+            },
+        );
+    }
+}

--- a/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
@@ -41,4 +41,15 @@ class LaravelInstrumentation
             && Configuration::getBoolean('OTEL_PHP_TRACE_CLI_ENABLED', false)
         );
     }
+
+    /**
+     * Trace context (and, in future, baggage) is only injected into outbound HTTP client requests
+     * when explicitly opted into, since the target of those requests may be a third-party service
+     * outside the application's control that should not receive internal trace/baggage data.
+     */
+    public static function shouldPropagateHttpClientTraceContext(): bool
+    {
+        return class_exists(Configuration::class)
+            && Configuration::getBoolean('OTEL_PHP_INSTRUMENTATION_LARAVEL_HTTP_CLIENT_PROPAGATION_ENABLED', false);
+    }
 }

--- a/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
+++ b/src/Instrumentation/Laravel/src/LaravelInstrumentation.php
@@ -27,6 +27,7 @@ class LaravelInstrumentation
         Hooks\Illuminate\Contracts\Queue\Queue::hook($instrumentation);
         Hooks\Illuminate\Foundation\Application::hook($instrumentation);
         Hooks\Illuminate\Foundation\Console\ServeCommand::hook($instrumentation);
+        Hooks\Illuminate\Http\Client\PendingRequest::hook($instrumentation);
         Hooks\Illuminate\Queue\SyncQueue::hook($instrumentation);
         Hooks\Illuminate\Queue\Queue::hook($instrumentation);
         Hooks\Illuminate\Queue\Worker::hook($instrumentation);

--- a/src/Instrumentation/Laravel/src/Propagators/RequestPropagationSetter.php
+++ b/src/Instrumentation/Laravel/src/Propagators/RequestPropagationSetter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Propagators;
+
+use function assert;
+use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @internal
+ */
+class RequestPropagationSetter implements PropagationSetterInterface
+{
+    public static function instance(): self
+    {
+        static $instance;
+
+        return $instance ??= new self();
+    }
+
+    public function set(&$carrier, string $key, string $value): void
+    {
+        assert($carrier instanceof RequestInterface);
+
+        $carrier = $carrier->withHeader($key, $value);
+    }
+}

--- a/src/Instrumentation/Laravel/tests/Integration/Http/ClientTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Http/ClientTest.php
@@ -46,6 +46,32 @@ class ClientTest extends TestCase
         self::assertEquals(StatusCode::STATUS_UNSET, $span->getStatus()->getCode());
     }
 
+    public function test_it_injects_trace_context_into_outbound_requests(): void
+    {
+        Http::fake();
+
+        // A span must be active for there to be any trace context to propagate downstream,
+        // just as there would be one from the incoming request/command/job being traced.
+        $parent = $this->tracerProvider->getTracer('test')->spanBuilder('parent')->startSpan();
+        $scope = $parent->activate();
+
+        try {
+            Http::get('http://propagation.opentelemetry.io');
+        } finally {
+            $scope->detach();
+            $parent->end();
+        }
+
+        // Asserted separately from the header check below so a failure here points at the request
+        // never reaching PendingRequest::runBeforeSendingCallbacks(), rather than at the injected
+        // value being wrong.
+        Http::assertSentCount(1);
+
+        $traceparent = sprintf('00-%s-%s-01', $parent->getContext()->getTraceId(), $parent->getContext()->getSpanId());
+
+        Http::assertSent(static fn (Request $request): bool => $request->header('traceparent') === [$traceparent]);
+    }
+
     public function test_it_records_connection_failures(): void
     {
         Http::fake(fn (Request $request) => new RejectedPromise(new ConnectException('Failure', $request->toPsrRequest())));

--- a/src/Instrumentation/Laravel/tests/Integration/Http/ClientTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Http/ClientTest.php
@@ -46,12 +46,10 @@ class ClientTest extends TestCase
         self::assertEquals(StatusCode::STATUS_UNSET, $span->getStatus()->getCode());
     }
 
-    public function test_it_injects_trace_context_into_outbound_requests(): void
+    public function test_it_does_not_inject_trace_context_by_default(): void
     {
         Http::fake();
 
-        // A span must be active for there to be any trace context to propagate downstream,
-        // just as there would be one from the incoming request/command/job being traced.
         $parent = $this->tracerProvider->getTracer('test')->spanBuilder('parent')->startSpan();
         $scope = $parent->activate();
 
@@ -62,14 +60,41 @@ class ClientTest extends TestCase
             $parent->end();
         }
 
-        // Asserted separately from the header check below so a failure here points at the request
-        // never reaching PendingRequest::runBeforeSendingCallbacks(), rather than at the injected
-        // value being wrong.
-        Http::assertSentCount(1);
+        // The target of an outbound HTTP client request may be a third-party service outside the
+        // application's control, so propagation must stay off unless explicitly opted into.
+        Http::assertSent(static fn (Request $request): bool => !$request->hasHeader('traceparent'));
+    }
 
-        $traceparent = sprintf('00-%s-%s-01', $parent->getContext()->getTraceId(), $parent->getContext()->getSpanId());
+    public function test_it_injects_trace_context_into_outbound_requests_when_opted_in(): void
+    {
+        putenv('OTEL_PHP_INSTRUMENTATION_LARAVEL_HTTP_CLIENT_PROPAGATION_ENABLED=true');
 
-        Http::assertSent(static fn (Request $request): bool => $request->header('traceparent') === [$traceparent]);
+        try {
+            Http::fake();
+
+            // A span must be active for there to be any trace context to propagate downstream,
+            // just as there would be one from the incoming request/command/job being traced.
+            $parent = $this->tracerProvider->getTracer('test')->spanBuilder('parent')->startSpan();
+            $scope = $parent->activate();
+
+            try {
+                Http::get('http://propagation.opentelemetry.io');
+            } finally {
+                $scope->detach();
+                $parent->end();
+            }
+
+            // Asserted separately from the header check below so a failure here points at the request
+            // never reaching PendingRequest::runBeforeSendingCallbacks(), rather than at the injected
+            // value being wrong.
+            Http::assertSentCount(1);
+
+            $traceparent = sprintf('00-%s-%s-01', $parent->getContext()->getTraceId(), $parent->getContext()->getSpanId());
+
+            Http::assertSent(static fn (Request $request): bool => $request->header('traceparent') === [$traceparent]);
+        } finally {
+            putenv('OTEL_PHP_INSTRUMENTATION_LARAVEL_HTTP_CLIENT_PROPAGATION_ENABLED');
+        }
     }
 
     public function test_it_records_connection_failures(): void


### PR DESCRIPTION
## Summary

### Motivation

`ClientRequestWatcher` records spans for outbound `Illuminate\Http\Client` requests, but never injected　`traceparent`/`tracestate` headers into them. 
Since the watcher only listens on the `RequestSending` event, which carries an immutable PSR-7 request that never reaches the request Guzzle actually sends, distributed　tracing was completely broken for any downstream service called via Laravel's HTTP client — there was no way to link the receiving service's trace back to the calling trace.

### What I have done

- Added `RequestPropagationSetter` (`src/Propagators/RequestPropagationSetter.php`), a `PropagationSetterInterface`implementation for PSR-7 `RequestInterface`, following the same pattern as the existing `ResponsePropagationSetter` and the other `PropagationSetterInterface` implementations across this monorepo.                                                                                   
 - Added a hook on `Illuminate\Http\Client\PendingRequest::runBeforeSendingCallbacks()` (`src/Hooks/Illuminate/Http/Client/PendingRequest.php`), the point where Laravel finalizes the PSR-7 request just                                                  
    before handing it to Guzzle. Injects the active span's trace context into the request headers there, since that's                                                  
    the last point the actual outgoing request can still be mutated.                                                                                                   
- Registered the new hook in `LaravelInstrumentation.php`.                                                                                                           
- Added `test_it_injects_trace_context_into_outbound_requests` to `ClientTest.php`, asserting the injected                                                           
    `traceparent` header matches an active parent span's trace/span id.

### Test Results

```bash                                                                                                                                                          
vendor/bin/phpunit tests/Integration/Http/ClientTest.php
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.34
Configuration: /usr/src/myapp/src/Instrumentation/Laravel/phpunit.xml.dist

...                                                                 3 / 3 (100%)

Time: 00:01.066, Memory: 24.00 MB
OK (3 tests, 17 assertions)
```