### PR TITLE
fix(laravel): use `KIND_SERVER` for Artisan `Kernel::handle` span

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Console/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Console/Kernel.php
@@ -43,7 +43,7 @@ class Kernel implements LaravelHook
                 $builder = $this->instrumentation
                     ->tracer()
                     ->spanBuilder('Artisan handler')
-                    ->setSpanKind(SpanKind::KIND_PRODUCER)
+                    ->setSpanKind(SpanKind::KIND_SERVER)
                     ->setAttribute(TraceAttributes::CODE_FUNCTION_NAME, sprintf('%s::%s', $class, $function))
                     ->setAttribute(TraceAttributes::CODE_FILE_PATH, $filename)
                     ->setAttribute(TraceAttributes::CODE_LINE_NUMBER, $lineno);


### PR DESCRIPTION
## Summary

### Description
- `Illuminate\Contracts\Console\Kernel::handle()` is instrumented with `SpanKind::KIND_PRODUCER`, which is meant for fire-and-forget messages sent to a queue and does not describe a synchronous Artisan CLI invocation.                                                                                                              
- Changed to `SpanKind::KIND_SERVER`, matching the role this span plays as the entry point of the Artisan process — the same treatment already given to `Hooks/Illuminate/Contracts/Http/Kernel.php`'s `handle()` span for HTTP requests. 

### Why no test was added
The existing test suite cannot cover this bug in principle:

- `Kernel::instrument()` only registers `hookHandle()` when `shouldTraceCli()` returns `true`
- `shouldTraceCli()` evaluates to `false` during PHPUnit runs because PHPUnit itself runs under the CLI SAPI (`PHP_SAPI === 'cli'`) and `OTEL_PHP_TRACE_CLI_ENABLED` defaults to `false`. 
So, `Kernel::hookHandle()` is never registered during test execution, making it impossible to assert on the SpanKind from within the test suite.