### PR TITLE
curl instrumentation: Add support for standard capture headers config option names

### DIFF
--- a/src/Instrumentation/Curl/README.md
+++ b/src/Instrumentation/Curl/README.md
@@ -53,7 +53,7 @@ OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=host,accept
 #### php.ini configuration
 
 ```ini
-OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS=content-type,server
+OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS=content-type,server
 ; or
 otel.instrumentation.http.response_headers[]=content-type
 otel.instrumentation.http.response_headers[]=server
@@ -63,7 +63,7 @@ otel.instrumentation.http.response_headers[]=server
 Similarly, to capture headers sent in a request to the server, use the following configuration:
 
 ```ini
-OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=host,accept
+OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS=host,accept
 ; or
 otel.instrumentation.http.request_headers[]=host
 otel.instrumentation.http.request_headers[]=accept

--- a/src/Instrumentation/Curl/README.md
+++ b/src/Instrumentation/Curl/README.md
@@ -40,6 +40,12 @@ To enable response header capture from the server, specify the required headers 
 #### Environment variables configuration
 
 ```bash
+OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS=content-type,server
+OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS=host,accept
+```
+The legacy options are still supported but are not recommended because they might be deprecated in a future release 
+
+```bash
 OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS=content-type,server
 OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=host,accept
 ```

--- a/src/Instrumentation/Curl/src/CurlInstrumentation.php
+++ b/src/Instrumentation/Curl/src/CurlInstrumentation.php
@@ -26,6 +26,11 @@ class CurlInstrumentation
 
     public const NAME = 'curl';
 
+    private const CAPTURE_REQUEST_HEADERS_LEGACY_CFG_OPT_NAME = 'OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS';
+    private const CAPTURE_REQUEST_HEADERS_CFG_OPT_NAME = 'OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS';
+    private const CAPTURE_RESPONSE_HEADERS_LEGACY_CFG_OPT_NAME = 'OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS';
+    private const CAPTURE_RESPONSE_HEADERS_CFG_OPT_NAME = 'OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS';
+
     public static function register(): void
     {
         // @var WeakMap<CurlHandle, CurlHandleMetadata>
@@ -493,16 +498,20 @@ class CurlInstrumentation
 
     private static function isRequestHeadersCapturingEnabled(): bool
     {
-        if (class_exists('OpenTelemetry\SDK\Common\Configuration\Configuration') && count(Configuration::getList('OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS', [])) > 0) {
-            return true;
-        }
-
-        return get_cfg_var('otel.instrumentation.http.request_headers') !== false;
+        return !empty(self::getRequestHeadersToCapture());
     }
 
     private static function getRequestHeadersToCapture(): array
     {
-        if (class_exists('OpenTelemetry\SDK\Common\Configuration\Configuration') && count($values = Configuration::getList('OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS', [])) > 0) {
+        if (
+            class_exists('OpenTelemetry\SDK\Common\Configuration\Configuration')
+            &&
+            (
+                (count($values = Configuration::getList(self::CAPTURE_REQUEST_HEADERS_LEGACY_CFG_OPT_NAME, [])) > 0)
+                ||
+                (count($values = Configuration::getList(self::CAPTURE_REQUEST_HEADERS_CFG_OPT_NAME, [])) > 0)
+            )
+        ) {
             return $values;
         }
 
@@ -511,16 +520,20 @@ class CurlInstrumentation
 
     private static function isResponseHeadersCapturingEnabled(): bool
     {
-        if (class_exists('OpenTelemetry\SDK\Common\Configuration\Configuration') && count(Configuration::getList('OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS', [])) > 0) {
-            return true;
-        }
-
-        return get_cfg_var('otel.instrumentation.http.response_headers') !== false;
+        return !empty(self::getResponseHeadersToCapture());
     }
 
     private static function getResponseHeadersToCapture(): array
     {
-        if (class_exists('OpenTelemetry\SDK\Common\Configuration\Configuration') && count($values = Configuration::getList('OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS', [])) > 0) {
+        if (
+            class_exists('OpenTelemetry\SDK\Common\Configuration\Configuration')
+            &&
+            (
+                (count($values = Configuration::getList(self::CAPTURE_RESPONSE_HEADERS_LEGACY_CFG_OPT_NAME, [])) > 0)
+                ||
+                (count($values = Configuration::getList(self::CAPTURE_RESPONSE_HEADERS_CFG_OPT_NAME, [])) > 0)
+            )
+        ) {
             return $values;
         }
 

--- a/src/Instrumentation/Curl/tests/Integration/CurlInstrumentationTest.php
+++ b/src/Instrumentation/Curl/tests/Integration/CurlInstrumentationTest.php
@@ -165,12 +165,21 @@ class CurlInstrumentationTest extends TestCase
         $this->assertEquals(80, $span->getAttributes()->get(TraceAttributes::SERVER_PORT));
     }
 
-    public function test_curl_exec_calls_user_defined_headerfunc(): void
+    public function capture_headers_config_options_names_data_provider(): iterable
+    {
+        yield ['OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS', 'OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS'];
+        yield ['OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS', 'OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS'];
+    }
+
+    /**
+     * @dataProvider capture_headers_config_options_names_data_provider
+     */
+    public function test_curl_exec_calls_user_defined_headerfunc(string $captureRequestHeadersCfgName, string $captureResponseHeadersCfgName): void
     {
         // test if response header capturing is not breaking user header func invocation
 
-        putenv('OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS=server');
-        putenv('OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=host');
+        putenv($captureResponseHeadersCfgName . '=server');
+        putenv($captureRequestHeadersCfgName . '=host');
 
         $ch = curl_init('http://example.com/');
         $this->assertInstanceOf(CurlHandle::class, $ch);
@@ -199,10 +208,13 @@ class CurlInstrumentationTest extends TestCase
         $this->assertEquals(80, $span->getAttributes()->get(TraceAttributes::SERVER_PORT));
     }
 
-    public function test_curl_exec_headers_capturing(): void
+    /**
+     * @dataProvider capture_headers_config_options_names_data_provider
+     */
+    public function test_curl_exec_headers_capturing(string $captureRequestHeadersCfgName, string $captureResponseHeadersCfgName): void
     {
-        putenv('OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS=content-type');
-        putenv('OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=host');
+        putenv($captureResponseHeadersCfgName . '=content-type');
+        putenv($captureRequestHeadersCfgName . '=host');
 
         $ch = curl_init('http://example.com/');
         $this->assertInstanceOf(CurlHandle::class, $ch);
@@ -219,9 +231,12 @@ class CurlInstrumentationTest extends TestCase
         $this->assertEquals('example.com', $span->getAttributes()->get('http.request.header.host'));
     }
 
-    public function test_curl_exec_sets_traceparent(): void
+    /**
+     * @dataProvider capture_headers_config_options_names_data_provider
+     */
+    public function test_curl_exec_sets_traceparent(string $captureRequestHeadersCfgName, /** @noinspection PhpUnusedParameterInspection */ string $captureResponseHeadersCfgName): void
     {
-        putenv('OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=traceparent');
+        putenv($captureRequestHeadersCfgName . '=traceparent');
 
         $ch = curl_init('http://example.com/');
         $this->assertInstanceOf(CurlHandle::class, $ch);

--- a/src/Instrumentation/Curl/tests/Integration/CurlMultiInstrumentationTest.php
+++ b/src/Instrumentation/Curl/tests/Integration/CurlMultiInstrumentationTest.php
@@ -130,10 +130,13 @@ class CurlMultiInstrumentationTest extends TestCase
         $this->assertEquals('other://scheme.com/', actual: $span->getAttributes()->get(TraceAttributes::URL_FULL));
     }
 
-    public function test_curl_multi_exec_calls_user_defined_headerfunc(): void
+    /**
+     * @dataProvider CurlInstrumentationTest::capture_headers_config_options_names_data_provider
+     */
+    public function test_curl_multi_exec_calls_user_defined_headerfunc(string $captureRequestHeadersCfgName, string $captureResponseHeadersCfgName): void
     {
-        putenv('OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS=content-type');
-        putenv('OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=host');
+        putenv($captureResponseHeadersCfgName . '=content-type');
+        putenv($captureRequestHeadersCfgName . '=host');
 
         $mh = curl_multi_init();
         $ch1 = curl_init('http://example.com/');
@@ -182,10 +185,13 @@ class CurlMultiInstrumentationTest extends TestCase
         }
     }
 
-    public function test_curl_multi_exec_headers_capturing(): void
+    /**
+     * @dataProvider CurlInstrumentationTest::capture_headers_config_options_names_data_provider
+     */
+    public function test_curl_multi_exec_headers_capturing(string $captureRequestHeadersCfgName, string $captureResponseHeadersCfgName): void
     {
-        putenv('OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS=content-type');
-        putenv('OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=host');
+        putenv($captureResponseHeadersCfgName . '=content-type');
+        putenv($captureRequestHeadersCfgName . '=host');
 
         $mh = curl_multi_init();
         $ch1 = curl_init('http://example.com/');
@@ -222,9 +228,12 @@ class CurlMultiInstrumentationTest extends TestCase
         }
     }
 
-    public function test_curl_multi_exec_sets_traceparent(): void
+    /**
+     * @dataProvider CurlInstrumentationTest::capture_headers_config_options_names_data_provider
+     */
+    public function test_curl_multi_exec_sets_traceparent(string $captureRequestHeadersCfgName, /** @noinspection PhpUnusedParameterInspection */ string $captureResponseHeadersCfgName): void
     {
-        putenv('OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=traceparent');
+        putenv($captureRequestHeadersCfgName . '=traceparent');
 
         $mh = curl_multi_init();
         $ch1 = curl_init('http://example.com/');

--- a/src/Instrumentation/Curl/tests/Integration/CurlMultiInstrumentationTest.php
+++ b/src/Instrumentation/Curl/tests/Integration/CurlMultiInstrumentationTest.php
@@ -131,7 +131,7 @@ class CurlMultiInstrumentationTest extends TestCase
     }
 
     /**
-     * @dataProvider CurlInstrumentationTest::capture_headers_config_options_names_data_provider
+     * @dataProvider \OpenTelemetry\Tests\Instrumentation\Curl\Integration\CurlInstrumentationTest::capture_headers_config_options_names_data_provider
      */
     public function test_curl_multi_exec_calls_user_defined_headerfunc(string $captureRequestHeadersCfgName, string $captureResponseHeadersCfgName): void
     {
@@ -186,7 +186,7 @@ class CurlMultiInstrumentationTest extends TestCase
     }
 
     /**
-     * @dataProvider CurlInstrumentationTest::capture_headers_config_options_names_data_provider
+     * @dataProvider \OpenTelemetry\Tests\Instrumentation\Curl\Integration\CurlInstrumentationTest::capture_headers_config_options_names_data_provider
      */
     public function test_curl_multi_exec_headers_capturing(string $captureRequestHeadersCfgName, string $captureResponseHeadersCfgName): void
     {
@@ -229,7 +229,7 @@ class CurlMultiInstrumentationTest extends TestCase
     }
 
     /**
-     * @dataProvider CurlInstrumentationTest::capture_headers_config_options_names_data_provider
+     * @dataProvider \OpenTelemetry\Tests\Instrumentation\Curl\Integration\CurlInstrumentationTest::capture_headers_config_options_names_data_provider
      */
     public function test_curl_multi_exec_sets_traceparent(string $captureRequestHeadersCfgName, /** @noinspection PhpUnusedParameterInspection */ string $captureResponseHeadersCfgName): void
     {


### PR DESCRIPTION
The new configuration option names for capturing headers for the client side are:

- `OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS`
- `OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS`

in addition to the existing legacy option names:

- `OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS`
- `OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS`

### Open items:

1. Should we deprecate the existing legacy option names?
2. What should be behavior if both the new and the legacy options are set? (At the moment if the legacy option is set it takes precedence over the new option.)