### PR TITLE
Workflow: gitsplit

### DIFF
--- a/.github/workflows/instrumentation-httpconfig.yml
+++ b/.github/workflows/instrumentation-httpconfig.yml
@@ -1,0 +1,36 @@
+name: "[CI] HttpConfig"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/Instrumentation/HttpConfig/**'
+
+  pull_request:
+    paths:
+      - 'src/Instrumentation/HttpConfig/**'
+
+  # To call from https://github.com/opentelemetry-php/contrib-config-http repo/forks.
+  workflow_call:
+    inputs:
+      package-root:
+        type: string
+        required: true
+
+jobs:
+  CI:
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 8.2
+          - 8.3
+          - 8.4
+          - 8.5
+
+    uses: ./.github/workflows/php-contrib.yml
+    with:
+      job-name: "PHP ${{ matrix.php-version }}"
+      codecov-flags: 'Instrumentation/HttpConfig'
+      package-root: ${{ inputs.package-root || 'src/Instrumentation/HttpConfig' }}
+      php-version: ${{ matrix.php-version }}

--- a/.github/workflows/instrumentation-psr3.yml
+++ b/.github/workflows/instrumentation-psr3.yml
@@ -1,0 +1,37 @@
+name: "[CI] Psr3"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/Instrumentation/Psr3/**'
+
+  pull_request:
+    paths:
+      - 'src/Instrumentation/Psr3/**'
+
+  # To call from https://github.com/opentelemetry-php/contrib-auto-psr3 repo/forks.
+  workflow_call:
+    inputs:
+      package-root:
+        type: string
+        required: true
+
+jobs:
+  CI:
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 8.1
+          - 8.2
+          - 8.3
+          - 8.4
+          - 8.5
+
+    uses: ./.github/workflows/php-contrib.yml
+    with:
+      job-name: "PHP ${{ matrix.php-version }}"
+      codecov-flags: 'Instrumentation/Psr3'
+      package-root: ${{ inputs.package-root || 'src/Instrumentation/Psr3' }}
+      php-version: ${{ matrix.php-version }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -35,7 +35,7 @@ jobs:
           # 'Instrumentation/ExtRdKafka', # # Experiment: moved to instrumentation-ext-rdkafka.yml
           'Instrumentation/Guzzle',
           'Instrumentation/HttpAsyncClient',
-          'Instrumentation/HttpConfig',
+          # 'Instrumentation/HttpConfig', # Experiment: moved to instrumentation-httpconfig.yml
           'Instrumentation/IO',
           # 'Instrumentation/Laravel', # Experiment: moved to instrumentation-laravel.yml
           'Instrumentation/Magento2',

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -45,7 +45,7 @@ jobs:
           'Instrumentation/PDO',
           'Instrumentation/PostgreSql',
           # Sort PSRs numerically.
-          'Instrumentation/Psr3',
+          # 'Instrumentation/Psr3', # Experiment: moved to instrumentation-psr3.yml
           'Instrumentation/Psr6',
           'Instrumentation/Psr14',
           'Instrumentation/Psr15',

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -18,11 +18,32 @@ jobs:
     permissions:
       contents: write # required for pushing changes
     steps:
-      - name: checkout
-        run: git clone "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" "$GITHUB_WORKSPACE" && cd "$GITHUB_WORKSPACE" && git checkout $GITHUB_SHA
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          # There is an official OpenTelemetry GitHub App already, but it is not scoped to create new repositories.
+          # https://github.com/open-telemetry/community/blob/main/assets.md#otelbot
+          #client-id: ${{ vars.OTELBOT_APP_ID }}
+          #private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          client-id: ${{ secrets.OPENTELEMETRY_PHP_APP_ID }}
+          private-key: ${{ secrets.OPENTELEMETRY_PHP_PRIVATE_KEY }}
+          owner: opentelemetry-php
+
+      - name: Ensure target repositories exist
+        run: |
+          yq -r '.splits[] | select(.target != null) | [(.prefix | sub("src/"; "")), (.target | gsub("^.*github\\.com/|\\.git$"; ""))] | @tsv' .gitsplit.yml | while IFS=$'\t' read -r prefix repo; do
+            gh repo view --json url,description --template '{{printf "  -> %s %s\n" .url .description }}' $repo 2>/dev/null || gh repo create $repo --public --description "[READONLY] $prefix subtree split from open-telemetry/opentelemetry-php-contrib"
+          done
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Split repositories
         uses: docker://jderusse/gitsplit:latest@sha256:ca619e08d0608d7ab8067be02db13409ec63a0e241c6308be42593f0c0ac705d
-        with:
-          args: gitsplit
         env:
-          GH_TOKEN: ${{ secrets.GITSPLIT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/src/Instrumentation/HttpConfig/.gitattributes
+++ b/src/Instrumentation/HttpConfig/.gitattributes
@@ -4,6 +4,7 @@
 *.php diff=php
 
 /.gitattributes export-ignore
+/.github export-ignore
 /.gitignore export-ignore
 /.php-cs-fixer.php export-ignore
 /phpstan.neon.dist export-ignore

--- a/src/Instrumentation/HttpConfig/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/HttpConfig/.github/workflows/contrib-ci.yml
@@ -1,0 +1,11 @@
+name: Contrib CI Pipeline
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  CI:
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-httpconfig.yml@main
+    with:
+      package-root: '.'

--- a/src/Instrumentation/Psr3/.gitattributes
+++ b/src/Instrumentation/Psr3/.gitattributes
@@ -4,6 +4,7 @@
 *.php diff=php
 
 /.gitattributes export-ignore
+/.github export-ignore
 /.gitignore export-ignore
 /.phan export-ignore
 /.php-cs-fixer.php export-ignore

--- a/src/Instrumentation/Psr3/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Psr3/.github/workflows/contrib-ci.yml
@@ -1,0 +1,11 @@
+name: Contrib CI Pipeline
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  CI:
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-psr3.yml@main
+    with:
+      package-root: '.'


### PR DESCRIPTION
GitSplit should now be able to automatically create new repos when we add new splits.

Ported a couple more splits into the targeted CI workflows.

The Psr3 workflow was previously failing on phan. It should now allow the pipeline to continue through to tests, with the quality checks being non-fatal.