### PR TITLE
(feat): add component owners scaffold to contrib.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 #####################################################
 #
-# List of approvers for OpenTelemetry PHP API/SDK
+# List of approvers for OpenTelemetry PHP Contrib
 #
 #####################################################
 #
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @open-telemetry/php-approvers
+* @open-telemetry/php-contrib-approvers

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -1,0 +1,17 @@
+# Configuration for:
+# .github/workflows/component-owners.yml
+
+# Each component identified by its path prefix has a list of owners
+components:
+  # Ownership applies recursively to any file in a directory
+  src/Instrumentation/Curl:
+    - intuibase
+  src/Instrumentation/Laravel:
+    - ChrisLightfootWild
+  src/SqlCommenter:
+    - jerrytfleung
+
+# Optionally ignore some PR authors to reduce spam for your component owners
+ignored-authors:
+  - dependabot
+  - renovate-bot

--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -1,0 +1,21 @@
+name: 'Component Owners'
+on:
+  # pull_request_target is suggested for projects where pull requests will be
+  # made from forked repositories. If pull_request is used in these cases,
+  # the github token will not have sufficient permission to update the PR.
+  pull_request_target:
+
+permissions:
+  contents: read          # to read changed files
+  issues: write           # to read/write issue assignees
+  pull-requests: write    # to read/write PR reviewers
+
+jobs:
+  run_self:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-php-contrib' }}
+    runs-on: ubuntu-latest
+    name: Auto Assign Owners
+    steps:
+      - uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # v0.2.0
+        with:
+          request-owner-reviews: "true"


### PR DESCRIPTION
Introducing the component owners concept that other SIGs utilise, in a bid to improve repository health and maintenance.

My understanding is that we would need to also create a `php-contrib-contributors` group, which has therefore been requested here: https://github.com/open-telemetry/community/issues/3608