### PR TITLE
feat(guzzle): support Guzzle 8

### DIFF
--- a/.github/workflows/instrumentation-guzzle.yml
+++ b/.github/workflows/instrumentation-guzzle.yml
@@ -1,0 +1,40 @@
+name: "[CI] Guzzle"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/Instrumentation/Guzzle/**'
+
+  pull_request:
+    paths:
+      - 'src/Instrumentation/Guzzle/**'
+
+  # To call from https://github.com/opentelemetry-php/contrib-auto-guzzle repo/forks.
+  workflow_call:
+    inputs:
+      package-root:
+        type: string
+        required: true
+
+jobs:
+  CI:
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 8.1
+          - 8.2
+          - 8.3
+          - 8.4
+        guzzle-version:
+          - ^7
+          - ^8
+
+    uses: ./.github/workflows/php-contrib.yml
+    with:
+      job-name: "PHP ${{ matrix.php-version }}: Guzzle ${{ matrix.guzzle-version }}"
+      codecov-flags: 'Instrumentation/Guzzle'
+      package-root: ${{ inputs.package-root || 'src/Instrumentation/Guzzle' }}
+      php-version: ${{ matrix.php-version }}
+      composer-requires: "guzzlehttp/guzzle:${{ matrix.guzzle-version }}"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -33,7 +33,7 @@ jobs:
           'Instrumentation/Doctrine',
           'Instrumentation/ExtAmqp',
           # 'Instrumentation/ExtRdKafka', # # Experiment: moved to instrumentation-ext-rdkafka.yml
-          'Instrumentation/Guzzle',
+          # 'Instrumentation/Guzzle', # Needs a guzzle version matrix: moved to instrumentation-guzzle.yml
           'Instrumentation/HttpAsyncClient',
           # 'Instrumentation/HttpConfig', # Experiment: moved to instrumentation-httpconfig.yml
           'Instrumentation/IO',

--- a/src/Instrumentation/Guzzle/.gitattributes
+++ b/src/Instrumentation/Guzzle/.gitattributes
@@ -4,6 +4,7 @@
 *.php diff=php
 
 /.gitattributes export-ignore
+/.github export-ignore
 /.gitignore export-ignore
 /.phan export-ignore
 /.php-cs-fixer.php export-ignore

--- a/src/Instrumentation/Guzzle/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Guzzle/.github/workflows/contrib-ci.yml
@@ -1,0 +1,9 @@
+name: Contrib CI Pipeline
+on:
+  workflow_dispatch:
+
+jobs:
+  CI:
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-guzzle.yml@main
+    with:
+      package-root: '.'

--- a/src/Instrumentation/Guzzle/composer.json
+++ b/src/Instrumentation/Guzzle/composer.json
@@ -13,11 +13,11 @@
     "ext-opentelemetry": "*",
     "open-telemetry/api": "^1.0",
     "open-telemetry/sem-conv": "^1.32",
-    "guzzlehttp/guzzle": "^7"
+    "guzzlehttp/guzzle": "^7 || ^8"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",
-    "guzzlehttp/promises": "^2",
+    "guzzlehttp/promises": "^2 || ^3",
     "nyholm/psr7": "*",
     "phan/phan": "^5.0",
     "phpstan/phpstan-mockery": "^1.1.0",

--- a/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php
+++ b/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php
@@ -128,7 +128,9 @@ class GuzzleInstrumentation
                         $span->end();
                     },
                     onRejected: function (\Throwable $t) use ($span) {
-                        if ($t instanceof BadResponseException && $t->hasResponse()) {
+                        // BadResponseException always carries a response, in both guzzle 7 and 8.
+                        // Guzzle 8 dropped RequestException::hasResponse(), so don't call it.
+                        if ($t instanceof BadResponseException) {
                             $response = $t->getResponse();
                             $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $response->getStatusCode());
                             $span->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $response->getProtocolVersion());

--- a/src/Instrumentation/Guzzle/tests/Integration/GuzzleInstrumentationTest.php
+++ b/src/Instrumentation/Guzzle/tests/Integration/GuzzleInstrumentationTest.php
@@ -87,7 +87,7 @@ class GuzzleInstrumentationTest extends TestCase
     /**
      * @dataProvider methodProvider
      */
-    public function test_magic_methods(string $method, string $expected): void
+    public function test_helper_methods(string $method, string $expected): void
     {
         $this->mock->append(new Response());
         $this->assertCount(0, $this->storage);
@@ -105,7 +105,7 @@ class GuzzleInstrumentationTest extends TestCase
     /**
      * @dataProvider methodProvider
      */
-    public function test_magic_methods_async(string $method, string $expected): void
+    public function test_helper_methods_async(string $method, string $expected): void
     {
         $this->mock->append(new Response());
         $promise = $this->client->{$method . 'Async'}('/');
@@ -121,17 +121,36 @@ class GuzzleInstrumentationTest extends TestCase
         $this->assertSame(200, $span->getAttributes()->get(TraceAttributes::HTTP_RESPONSE_STATUS_CODE));
     }
 
+    /**
+     * Guzzle 8 removed Client::__call(), so only the methods declared on
+     * ClientTrait are covered here. OPTIONS is covered by test_request_methods().
+     */
     public static function methodProvider(): array
     {
         return [
             'delete' => ['delete', 'DELETE'],
             'get' => ['get', 'GET'],
             'head' => ['head', 'HEAD'],
-            'options' => ['options', 'OPTIONS'],
             'patch' => ['patch', 'PATCH'],
             'post' => ['post', 'POST'],
             'put' => ['put', 'PUT'],
         ];
+    }
+
+    public function test_request_methods(): void
+    {
+        $this->mock->append(new Response());
+        $this->client->request('OPTIONS', '/foo');
+        $this->mock->append(new Response());
+        $this->client->requestAsync('OPTIONS', '/foo')->wait();
+
+        $this->assertCount(2, $this->storage);
+        foreach ($this->storage as $span) {
+            assert($span instanceof ImmutableSpan);
+            $this->assertSame('OPTIONS', $span->getAttributes()->get(TraceAttributes::HTTP_REQUEST_METHOD));
+            $this->assertSame('/foo', $span->getAttributes()->get(TraceAttributes::URL_PATH));
+            $this->assertSame(200, $span->getAttributes()->get(TraceAttributes::HTTP_RESPONSE_STATUS_CODE));
+        }
     }
 
     public function test_concurrent_async(): void


### PR DESCRIPTION
Fixes open-telemetry/opentelemetry-php#2027

Guzzle 8.0.0 shipped on 2026-07-20. `open-telemetry/opentelemetry-auto-guzzle` is pinned to `guzzlehttp/guzzle: ^7`, so it cannot be installed alongside it, and widening the constraint alone is not enough.

## What breaks under Guzzle 8

> [!IMPORTANT]
> The first one is silent. Spans are dropped with no error surfaced anywhere.

<details>
<summary><strong>1. Every 4xx/5xx request loses its span</strong></summary>

Guzzle 8 reworked the exception hierarchy. `RequestException` no longer carries a response, so `hasResponse()` and the nullable `getResponse()` are gone; response-bearing exceptions now derive from the new `ResponseException`, and `BadResponseException extends ResponseException`.

The `onRejected` handler still called `$t->hasResponse()`, raising `Error: Call to undefined method`. That happens *inside* a promise handler, where `Promise::callHandler()` catches any `Throwable` and rejects the chained promise. So nothing is logged, no warning is emitted, and `$span->end()` is simply never reached.[^1]

`BadResponseException` narrows `getResponse()` to a non-nullable `ResponseInterface` in Guzzle 7 as well, so the `instanceof` check alone is correct on both majors.

</details>

<details>
<summary><strong>2. <code>Client::__call()</code> was removed</strong></summary>

`options()` / `optionsAsync()` no longer exist; only the methods declared on `ClientTrait` remain. This does not affect the instrumentation itself, since the hook targets `Client::transfer()`, which is unchanged. It only affected the test suite's `methodProvider`.

OPTIONS is now covered through `request()` / `requestAsync()`, which is the supported spelling on both majors.

</details>

## CI

`php.yml` installs the highest satisfiable version, so widening the constraint there would silently drop all Guzzle 7 coverage. Guzzle moves to its own `instrumentation-guzzle.yml` with a `guzzle-version` matrix, following the pattern already used by `instrumentation-laravel.yml`, and is commented out of `php.yml` the same way the other migrated packages are.

## Verification

Full quality gate run locally in Docker across the same 4 PHP versions the new workflow uses (8.1 and 8.4 shown, 8.2/8.3 sit between them), against each Guzzle major, installed exactly as CI does it (`composer require guzzlehttp/guzzle:<constraint>` on a clean checkout):

| PHP | Guzzle | php-cs-fixer | phan | psalm | phpstan | phpunit |
|-----|--------|--------------|------|-------|---------|---------|
| 8.1 | ^7 (7.15.3) | ✅ | ✅ | ✅ | ✅ | ✅ 25/25 |
| 8.1 | ^8 (8.0.2)  | ✅ | ✅ | ✅ | ✅ | ✅ 25/25 |
| 8.4 | ^7 (7.15.3) | ✅ | ✅ | ✅ | ✅ | ✅ 25/25 |
| 8.4 | ^8 (8.0.2)  | ✅ | ✅ | ✅ | ✅ | ✅ 25/25 |

- [ ] Feature: Guzzle 8 support
<details>
  <summary>Scenario: response-bearing error is recorded on the span</summary>

- Given a client with `http_errors` enabled, on Guzzle 8
- When a request returns 400, 404, 500 or 503
- Then one span is exported, with `http.response.status_code`, `network.protocol.version` and `http.response.body.size` set and status `ERROR`
</details>
<details>
  <summary>Scenario: OPTIONS requests are instrumented</summary>

- Given a client on either Guzzle major
- When `request('OPTIONS', ...)` or `requestAsync('OPTIONS', ...)` is sent
- Then a span is exported with `http.request.method` = `OPTIONS`
</details>
<details>
  <summary>Scenario: Guzzle 7 is unaffected</summary>

- Given the same package on Guzzle 7
- When the full test suite runs
- Then all 25 tests pass, unchanged in behaviour
</details>

[^1]: `guzzlehttp/promises` also moves to 3.x alongside Guzzle 8, hence the `require-dev` widening.
  `Promise::then()` keeps its `onFulfilled` / `onRejected` parameter names and `Is::settled()` still
  exists, so the promise handling in the post hook needed no changes.
