### PR TITLE
Moved Curl instrumentation to shared CI workflow.

### DIFF
--- a/.github/workflows/instrumentation-curl.yml
+++ b/.github/workflows/instrumentation-curl.yml
@@ -1,0 +1,38 @@
+name: "[CI] Curl"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/Instrumentation/Curl/**'
+
+  pull_request:
+    paths:
+      - 'src/Instrumentation/Curl/**'
+
+  # To call from https://github.com/opentelemetry-php/contrib-auto-curl repo/forks.
+  workflow_call:
+    inputs:
+      package-root:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  CI:
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 8.2
+          - 8.3
+          - 8.4
+
+    uses: ./.github/workflows/php-contrib.yml
+    with:
+      job-name: "PHP ${{ matrix.php-version }}"
+      codecov-flags: 'Instrumentation/Curl'
+      package-root: ${{ inputs.package-root || 'src/Instrumentation/Curl' }}
+      php-version: ${{ matrix.php-version }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,7 +29,7 @@ jobs:
           'Instrumentation/AwsSdk',
           'Instrumentation/CakePHP',
           'Instrumentation/CodeIgniter',
-          'Instrumentation/Curl',
+          # 'Instrumentation/Curl', Experiment: moved to instrumentation-curl.yml
           'Instrumentation/Doctrine',
           'Instrumentation/ExtAmqp',
           # 'Instrumentation/ExtRdKafka', # # Experiment: moved to instrumentation-ext-rdkafka.yml

--- a/src/Instrumentation/Curl/.gitattributes
+++ b/src/Instrumentation/Curl/.gitattributes
@@ -4,6 +4,7 @@
 *.php diff=php
 
 /.gitattributes export-ignore
+/.github export-ignore
 /.gitignore export-ignore
 /.php-cs-fixer.php export-ignore
 /phpstan.neon.dist export-ignore

--- a/src/Instrumentation/Curl/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Curl/.github/workflows/contrib-ci.yml
@@ -1,0 +1,14 @@
+name: Contrib CI Pipeline
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  CI:
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-curl.yml@b7bc976ebc81c1cd5c3abb9077be5072a791e8f2 # main
+    with:
+      package-root: '.'


### PR DESCRIPTION
Split Curl instrumentation into separate workflow.

Also targeted to test the component owner workflow to see if it assigns owners correctly :eyes: 