### PR TITLE
With the component owners workflow, we only wish to have owners requested as reviewers, not assignees

### DIFF
--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # v0.2.0
         with:
-          request-owner-reviews: "true"
+          assign-owners: false


### PR DESCRIPTION
Per https://github.com/dyladan/component-owners/tree/v0.2.0#configuration
 - `assign-owners` defaults to true, so explicitly disable this functionality
 - `request-owner-reviews` defaulted to true, so just removed the option