### PR TITLE
feat(psr18): use standardized config options for header capture and add PHP 8.5 support

### DIFF
--- a/src/Instrumentation/Psr18/README.md
+++ b/src/Instrumentation/Psr18/README.md
@@ -19,8 +19,38 @@ Auto-instrumentation hooks are registered via composer, which will:
 
 ## Configuration
 
+### Disabling PSR-18 instrumentation
+
 The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
 ```shell
 OTEL_PHP_DISABLED_INSTRUMENTATIONS=psr18
+```
+
+### Request and response header capturing
+
+PSR-18 auto-instrumentation supports capturing headers from both requests and responses as span attributes. This feature is disabled by default and can be enabled through environment variables or array directives in the `php.ini` configuration file. Header name matching is case-insensitive.
+
+#### Environment variables configuration
+
+```bash
+OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS=host,accept
+OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS=content-type,server
+```
+
+The legacy options are still supported but are not recommended as they may be deprecated in a future release:
+
+```bash
+OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=host,accept
+OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS=content-type,server
+```
+
+#### php.ini configuration
+
+```ini
+otel.instrumentation.http.request_headers[]=host
+otel.instrumentation.http.request_headers[]=accept
+
+otel.instrumentation.http.response_headers[]=content-type
+otel.instrumentation.http.response_headers[]=server
 ```

--- a/src/Instrumentation/Psr18/composer.json
+++ b/src/Instrumentation/Psr18/composer.json
@@ -26,13 +26,13 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",
     "nyholm/psr7": "*",
-    "phan/phan": "^5.0",
+    "phan/phan": "^6.0",
     "php-http/mock-client": "*",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.4.0"
+    "vimeo/psalm": "^6.10.0"
   }
 }

--- a/src/Instrumentation/Psr18/psalm.xml.dist
+++ b/src/Instrumentation/Psr18/psalm.xml.dist
@@ -12,4 +12,7 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <issueHandlers>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+    </issueHandlers>
 </psalm>

--- a/src/Instrumentation/Psr18/src/Psr18Instrumentation.php
+++ b/src/Instrumentation/Psr18/src/Psr18Instrumentation.php
@@ -12,6 +12,7 @@ use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\Context;
 use function OpenTelemetry\Instrumentation\hook;
+use OpenTelemetry\SDK\Common\Configuration\Configuration;
 use OpenTelemetry\SemConv\TraceAttributes;
 use OpenTelemetry\SemConv\Version;
 use Psr\Http\Client\ClientInterface;
@@ -26,6 +27,11 @@ class Psr18Instrumentation
 {
     /** @psalm-suppress ArgumentTypeCoercion */
     public const NAME = 'psr18';
+
+    private const CAPTURE_REQUEST_HEADERS_LEGACY_CFG_OPT_NAME = 'OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS';
+    private const CAPTURE_REQUEST_HEADERS_CFG_OPT_NAME = 'OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS';
+    private const CAPTURE_RESPONSE_HEADERS_LEGACY_CFG_OPT_NAME = 'OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS';
+    private const CAPTURE_RESPONSE_HEADERS_CFG_OPT_NAME = 'OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS';
 
     public static function register(): void
     {
@@ -70,8 +76,7 @@ class Psr18Instrumentation
                 foreach ($propagator->fields() as $field) {
                     $request = $request->withoutHeader($field);
                 }
-                //@todo could we use SDK Configuration to retrieve this, and move into a key such as OTEL_PHP_xxx?
-                foreach ((array) (get_cfg_var('otel.instrumentation.http.request_headers') ?: []) as $header) {
+                foreach (self::getRequestHeadersToCapture() as $header) {
                     if ($request->hasHeader($header)) {
                         $spanBuilder->setAttribute(
                             sprintf('http.request.header.%s', strtolower($header)),
@@ -104,7 +109,7 @@ class Psr18Instrumentation
                     $span->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $response->getProtocolVersion());
                     $span->setAttribute(TraceAttributes::HTTP_RESPONSE_BODY_SIZE, $response->getHeaderLine('Content-Length'));
 
-                    foreach ((array) (get_cfg_var('otel.instrumentation.http.response_headers') ?: []) as $header) {
+                    foreach (self::getResponseHeadersToCapture() as $header) {
                         if ($response->hasHeader($header)) {
                             /** @psalm-suppress ArgumentTypeCoercion */
                             $span->setAttribute(sprintf('http.response.header.%s', strtolower($header)), $response->getHeader($header));
@@ -122,5 +127,39 @@ class Psr18Instrumentation
                 $span->end();
             },
         );
+    }
+
+    private static function getRequestHeadersToCapture(): array
+    {
+        if (
+            class_exists(Configuration::class)
+            &&
+            (
+                (count($values = Configuration::getList(self::CAPTURE_REQUEST_HEADERS_LEGACY_CFG_OPT_NAME, [])) > 0)
+                ||
+                (count($values = Configuration::getList(self::CAPTURE_REQUEST_HEADERS_CFG_OPT_NAME, [])) > 0)
+            )
+        ) {
+            return $values;
+        }
+
+        return (array) (get_cfg_var('otel.instrumentation.http.request_headers') ?: []);
+    }
+
+    private static function getResponseHeadersToCapture(): array
+    {
+        if (
+            class_exists(Configuration::class)
+            &&
+            (
+                (count($values = Configuration::getList(self::CAPTURE_RESPONSE_HEADERS_LEGACY_CFG_OPT_NAME, [])) > 0)
+                ||
+                (count($values = Configuration::getList(self::CAPTURE_RESPONSE_HEADERS_CFG_OPT_NAME, [])) > 0)
+            )
+        ) {
+            return $values;
+        }
+
+        return (array) (get_cfg_var('otel.instrumentation.http.response_headers') ?: []);
     }
 }

--- a/src/Instrumentation/Psr18/tests/Integration/Psr18InstrumentationTest.php
+++ b/src/Instrumentation/Psr18/tests/Integration/Psr18InstrumentationTest.php
@@ -95,4 +95,63 @@ class Psr18InstrumentationTest extends TestCase
             ['POST', 'https://example.com/bar', 401],
         ];
     }
+
+    /**
+     * @dataProvider requestHeadersEnvProvider
+     */
+    public function test_capture_request_headers(string $envVar): void
+    {
+        putenv(sprintf('%s=x-custom-header,accept', $envVar));
+
+        try {
+            $request = new Request('GET', 'http://example.com/foo', ['x-custom-header' => 'my-value', 'accept' => 'application/json']);
+            $this->client->method('sendRequest')->willReturn(new Response(200));
+            $this->client->sendRequest($request);
+
+            /** @var ImmutableSpan $span */
+            $span = $this->storage[0];
+            $this->assertSame(['my-value'], $span->getAttributes()->get('http.request.header.x-custom-header'));
+            $this->assertSame(['application/json'], $span->getAttributes()->get('http.request.header.accept'));
+        } finally {
+            putenv($envVar);
+        }
+    }
+
+    public static function requestHeadersEnvProvider(): array
+    {
+        return [
+            'standardized' => ['OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS'],
+            'legacy' => ['OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS'],
+        ];
+    }
+
+    /**
+     * @dataProvider responseHeadersEnvProvider
+     */
+    public function test_capture_response_headers(string $envVar): void
+    {
+        putenv(sprintf('%s=x-custom-header,content-type', $envVar));
+
+        try {
+            $request = new Request('GET', 'http://example.com/foo');
+            $response = new Response(200, ['x-custom-header' => 'my-value', 'content-type' => 'application/json']);
+            $this->client->method('sendRequest')->willReturn($response);
+            $this->client->sendRequest($request);
+
+            /** @var ImmutableSpan $span */
+            $span = $this->storage[0];
+            $this->assertSame(['my-value'], $span->getAttributes()->get('http.response.header.x-custom-header'));
+            $this->assertSame(['application/json'], $span->getAttributes()->get('http.response.header.content-type'));
+        } finally {
+            putenv($envVar);
+        }
+    }
+
+    public static function responseHeadersEnvProvider(): array
+    {
+        return [
+            'standardized' => ['OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS'],
+            'legacy' => ['OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS'],
+        ];
+    }
 }


### PR DESCRIPTION
## Summary

Adds support for capturing outgoing HTTP request and response headers as span
attributes in the PSR-18 auto-instrumentation.

Header capture uses the standardized OpenTelemetry configuration options
`OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS` and `OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS`,
consistent with the [HTTP client instrumentation spec](https://opentelemetry.io/docs/specs/semconv/http/http-spans/).

Legacy `OTEL_PHP_INSTRUMENTATION_HTTP_*` options and php.ini array
directives remain supported as fallbacks.

Also bumps `phan` to `^6.0` and `vimeo/psalm` to `^6.10.0` to support PHP 8.5

Related to #670 and #669 