### PR TITLE
feat(guzzle): use standardized config options for header capture and add PHP 8.5 support

### DIFF
--- a/src/Instrumentation/Guzzle/README.md
+++ b/src/Instrumentation/Guzzle/README.md
@@ -19,8 +19,38 @@ Auto-instrumentation hooks are registered via composer.
 
 ## Configuration
 
+### Disabling Guzzle instrumentation
+
 The extension can be disabled via [runtime configuration](https://opentelemetry.io/docs/instrumentation/php/sdk/#configuration):
 
 ```shell
 OTEL_PHP_DISABLED_INSTRUMENTATIONS=guzzle
+```
+
+### Request and response header capturing
+
+Guzzle auto-instrumentation supports capturing headers from both requests and responses as span attributes. This feature is disabled by default and can be enabled through environment variables or array directives in the `php.ini` configuration file. Header name matching is case-insensitive.
+
+#### Environment variables configuration
+
+```bash
+OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS=host,accept
+OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS=content-type,server
+```
+
+The legacy options are still supported but are not recommended as they may be deprecated in a future release:
+
+```bash
+OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS=host,accept
+OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS=content-type,server
+```
+
+#### php.ini configuration
+
+```ini
+otel.instrumentation.http.request_headers[]=host
+otel.instrumentation.http.request_headers[]=accept
+
+otel.instrumentation.http.response_headers[]=content-type
+otel.instrumentation.http.response_headers[]=server
 ```

--- a/src/Instrumentation/Guzzle/composer.json
+++ b/src/Instrumentation/Guzzle/composer.json
@@ -19,14 +19,14 @@
     "friendsofphp/php-cs-fixer": "^3",
     "guzzlehttp/promises": "^2 || ^3",
     "nyholm/psr7": "*",
-    "phan/phan": "^5.0",
+    "phan/phan": "^6.0",
     "phpstan/phpstan-mockery": "^1.1.0",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.4.0"
+    "vimeo/psalm": "^6.10.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Guzzle/psalm.xml.dist
+++ b/src/Instrumentation/Guzzle/psalm.xml.dist
@@ -12,4 +12,7 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <issueHandlers>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+    </issueHandlers>
 </psalm>

--- a/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php
+++ b/src/Instrumentation/Guzzle/src/GuzzleInstrumentation.php
@@ -16,6 +16,7 @@ use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\Context;
 use function OpenTelemetry\Instrumentation\hook;
+use OpenTelemetry\SDK\Common\Configuration\Configuration;
 use OpenTelemetry\SemConv\TraceAttributes;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -28,6 +29,11 @@ class GuzzleInstrumentation
 {
     /** @psalm-suppress ArgumentTypeCoercion */
     public const NAME = 'guzzle';
+
+    private const CAPTURE_REQUEST_HEADERS_LEGACY_CFG_OPT_NAME = 'OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS';
+    private const CAPTURE_REQUEST_HEADERS_CFG_OPT_NAME = 'OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS';
+    private const CAPTURE_RESPONSE_HEADERS_LEGACY_CFG_OPT_NAME = 'OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS';
+    private const CAPTURE_RESPONSE_HEADERS_CFG_OPT_NAME = 'OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS';
 
     public static function register(): void
     {
@@ -70,7 +76,7 @@ class GuzzleInstrumentation
                 foreach ($propagator->fields() as $field) {
                     $request = $request->withoutHeader($field);
                 }
-                foreach ((array) (get_cfg_var('otel.instrumentation.http.request_headers') ?: []) as $header) {
+                foreach (self::getRequestHeadersToCapture() as $header) {
                     if ($request->hasHeader($header)) {
                         $spanBuilder->setAttribute(
                             sprintf('http.request.header.%s', strtolower($header)),
@@ -116,7 +122,7 @@ class GuzzleInstrumentation
                         $span->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $response->getProtocolVersion());
                         $span->setAttribute(TraceAttributes::HTTP_RESPONSE_BODY_SIZE, $response->getHeaderLine('Content-Length'));
 
-                        foreach ((array) (get_cfg_var('otel.instrumentation.http.response_headers') ?: []) as $header) {
+                        foreach (self::getResponseHeadersToCapture() as $header) {
                             if ($response->hasHeader($header)) {
                                 /** @psalm-suppress ArgumentTypeCoercion */
                                 $span->setAttribute(sprintf('http.response.header.%s', strtolower($header)), $response->getHeader($header));
@@ -148,5 +154,39 @@ class GuzzleInstrumentation
                 }
             }
         );
+    }
+
+    private static function getRequestHeadersToCapture(): array
+    {
+        if (
+            class_exists(Configuration::class)
+            &&
+            (
+                (count($values = Configuration::getList(self::CAPTURE_REQUEST_HEADERS_LEGACY_CFG_OPT_NAME, [])) > 0)
+                ||
+                (count($values = Configuration::getList(self::CAPTURE_REQUEST_HEADERS_CFG_OPT_NAME, [])) > 0)
+            )
+        ) {
+            return $values;
+        }
+
+        return (array) (get_cfg_var('otel.instrumentation.http.request_headers') ?: []);
+    }
+
+    private static function getResponseHeadersToCapture(): array
+    {
+        if (
+            class_exists(Configuration::class)
+            &&
+            (
+                (count($values = Configuration::getList(self::CAPTURE_RESPONSE_HEADERS_LEGACY_CFG_OPT_NAME, [])) > 0)
+                ||
+                (count($values = Configuration::getList(self::CAPTURE_RESPONSE_HEADERS_CFG_OPT_NAME, [])) > 0)
+            )
+        ) {
+            return $values;
+        }
+
+        return (array) (get_cfg_var('otel.instrumentation.http.response_headers') ?: []);
     }
 }

--- a/src/Instrumentation/Guzzle/tests/Integration/GuzzleInstrumentationTest.php
+++ b/src/Instrumentation/Guzzle/tests/Integration/GuzzleInstrumentationTest.php
@@ -309,4 +309,61 @@ class GuzzleInstrumentationTest extends TestCase
             'runtime exception' => [new \RuntimeException('runtime error')],
         ];
     }
+
+    /**
+     * @dataProvider requestHeadersEnvProvider
+     */
+    public function test_capture_request_headers(string $envVar): void
+    {
+        putenv(sprintf('%s=x-custom-header,accept', $envVar));
+
+        try {
+            $this->mock->append(new Response());
+            $request = new Request('GET', 'https://example.com/foo', ['x-custom-header' => 'my-value', 'accept' => 'application/json']);
+            $this->client->send($request);
+
+            $span = $this->storage->offsetGet(0);
+            assert($span instanceof ImmutableSpan);
+            $this->assertSame(['my-value'], $span->getAttributes()->get('http.request.header.x-custom-header'));
+            $this->assertSame(['application/json'], $span->getAttributes()->get('http.request.header.accept'));
+        } finally {
+            putenv($envVar);
+        }
+    }
+
+    public static function requestHeadersEnvProvider(): array
+    {
+        return [
+            'standardized' => ['OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS'],
+            'legacy' => ['OTEL_PHP_INSTRUMENTATION_HTTP_REQUEST_HEADERS'],
+        ];
+    }
+
+    /**
+     * @dataProvider responseHeadersEnvProvider
+     */
+    public function test_capture_response_headers(string $envVar): void
+    {
+        putenv(sprintf('%s=x-custom-header,content-type', $envVar));
+
+        try {
+            $this->mock->append(new Response(200, ['x-custom-header' => 'my-value', 'content-type' => 'application/json']));
+            $this->client->get('/foo');
+
+            $span = $this->storage->offsetGet(0);
+            assert($span instanceof ImmutableSpan);
+            $this->assertSame(['my-value'], $span->getAttributes()->get('http.response.header.x-custom-header'));
+            $this->assertSame(['application/json'], $span->getAttributes()->get('http.response.header.content-type'));
+        } finally {
+            putenv($envVar);
+        }
+    }
+
+    public static function responseHeadersEnvProvider(): array
+    {
+        return [
+            'standardized' => ['OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS'],
+            'legacy' => ['OTEL_PHP_INSTRUMENTATION_HTTP_RESPONSE_HEADERS'],
+        ];
+    }
 }


### PR DESCRIPTION
Switch request/response header capture configuration from php.ini-only (get_cfg_var) to the standardized OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS and OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS env vars, with legacy OTEL_PHP_INSTRUMENTATION_HTTP_* and php.ini array directives retained as fallbacks.

Bump phan to ^6.0 and vimeo/psalm to ^6.10.0 to support PHP 8.5, and suppress MissingOverrideAttribute in psalm.xml.dist accordingly.