### PR TITLE
Use toMql when encountering a mongodb eloquent builder instead of toSql.

### DIFF
--- a/src/Instrumentation/Laravel/composer.json
+++ b/src/Instrumentation/Laravel/composer.json
@@ -30,6 +30,7 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.50",
     "guzzlehttp/guzzle": "*",
+    "mongodb/laravel-mongodb": "^5.9",
     "nunomaduro/collision": "*",
     "open-telemetry/sdk": "^1.8",
     "orchestra/testbench": ">=7.41.3",

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Database/Eloquent/Model.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Database/Eloquent/Model.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Database\Eloquent;
 
 use Illuminate\Database\Eloquent\Model as EloquentModel;
+use MongoDB\Laravel\Query\Builder as MongoQuery;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\Context\Context;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHook;
@@ -159,6 +160,14 @@ class Model implements LaravelHook
             'getModels',
             pre: function ($builder, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
                 $model = $builder->getModel();
+                $query = $builder->getQuery();
+
+                if ($query instanceof MongoQuery) {
+                    $statement = json_encode($query->toMql());
+                } else {
+                    $statement = $query->toSql();
+                }
+
                 $builder = $this->instrumentation
                     ->tracer()
                     ->spanBuilder($model::class . '::get')
@@ -169,7 +178,7 @@ class Model implements LaravelHook
                     ->setAttribute('laravel.eloquent.model', $model::class)
                     ->setAttribute('laravel.eloquent.table', $model->getTable())
                     ->setAttribute('laravel.eloquent.operation', 'get')
-                    ->setAttribute('db.statement', $builder->getQuery()->toSql());
+                    ->setAttribute('db.statement', $statement);
 
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();

--- a/src/Instrumentation/Laravel/tests/Fixtures/Models/TestMongoModel.php
+++ b/src/Instrumentation/Laravel/tests/Fixtures/Models/TestMongoModel.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models;
+
+use MongoDB\Laravel\Eloquent\Model;
+
+/**
+ * @psalm-suppress UnusedClass
+ */
+class TestMongoModel extends Model
+{
+    protected $connection = 'mongodb';
+    protected $table = 'test_models_mongo';
+    protected $fillable = ['name'];
+}

--- a/src/Instrumentation/Laravel/tests/Integration/Database/Eloquent/ModelTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Database/Eloquent/ModelTest.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration\Database\Eloquent;
 
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use MongoDB\Laravel\MongoDBServiceProvider;
+use MongoDB\Laravel\Query\Builder as MongoQueryBuilder;
 use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel;
+use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestMongoModel;
 use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration\TestCase;
 
 /**
@@ -14,6 +19,11 @@ use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration\TestCase;
  */
 class ModelTest extends TestCase
 {
+    protected function getPackageProviders($app): array
+    {
+        return [MongoDBServiceProvider::class];
+    }
+
     protected function getEnvironmentSetUp($app): void
     {
         // Setup default database to use sqlite :memory:
@@ -22,6 +32,11 @@ class ModelTest extends TestCase
             'driver'   => 'sqlite',
             'database' => ':memory:',
             'prefix'   => '',
+        ]);
+        $app['config']->set('database.connections.mongodb', [
+            'driver'   => 'mongodb',
+            'dsn'      => 'mongodb://127.0.0.1:27017',
+            'database' => 'test_models_mongo_db',
         ]);
     }
 
@@ -100,7 +115,7 @@ class ModelTest extends TestCase
         // Mark as exists = false required, because performUpdate called if exists = true.
         $model = (new TestModel())->newInstance(['id' => 1, 'name' => 'test'], false);
         $model->save();
-        
+
         $spans = $this->filterOnlyEloquentSpans();
         $this->assertCount(1, $spans);
 
@@ -155,6 +170,36 @@ class ModelTest extends TestCase
         $this->assertSame('OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Models\TestModel', $span->getAttributes()->get('laravel.eloquent.model'));
         $this->assertSame('test_models', $span->getAttributes()->get('laravel.eloquent.table'));
         $this->assertSame('get', $span->getAttributes()->get('laravel.eloquent.operation'));
+    }
+
+    public function test_get_models_uses_mql_statement_for_mongodb_query(): void
+    {
+        $model = new TestMongoModel();
+
+        $query = new class($model->getConnection()) extends MongoQueryBuilder {
+            #[\Override]
+            public function get($columns = [])
+            {
+                return new Collection();
+            }
+        };
+
+        $builder = new EloquentBuilder($query);
+        $builder->setModel($model);
+
+        $builder->getModels();
+
+        $expectedStatement = json_encode($query->toMql());
+
+        $spans = $this->filterOnlyEloquentSpans();
+        $this->assertCount(1, $spans);
+
+        $span = $spans[0];
+        $this->assertSame(TestMongoModel::class . '::get', $span->getName());
+        $this->assertSame(TestMongoModel::class, $span->getAttributes()->get('laravel.eloquent.model'));
+        $this->assertSame('test_models_mongo', $span->getAttributes()->get('laravel.eloquent.table'));
+        $this->assertSame('get', $span->getAttributes()->get('laravel.eloquent.operation'));
+        $this->assertSame($expectedStatement, $span->getAttributes()->get('db.statement'));
     }
 
     public function test_destory(): void


### PR DESCRIPTION
We installed the auto-laravel package into a Laravel project of ours that uses mongo and discovered that it is not compatible with `mongodb/laravel-mongodb`, as mongodb query builders error when calling `->toSql()`, `->toMql()` is expected instead.

This fix allows the auto-laravel package to work seemlessly with mongodb eloquent models and builders. I opted to avoid setting up a mongodb in tests and stub it out instead as it seemed like unnecessary work to test adding a span for a query. 

Let me know if you'd like any changes, thanks for your time! 