### PR TITLE
fix(doctrine): add re-entrancy guard to prevent duplicate spans in connection wrapper chains

### DIFF
--- a/src/Instrumentation/Doctrine/src/DoctrineInstrumentation.php
+++ b/src/Instrumentation/Doctrine/src/DoctrineInstrumentation.php
@@ -20,6 +20,14 @@ class DoctrineInstrumentation
 {
     public const NAME = 'doctrine';
 
+    /**
+     * Re-entrancy guard: Doctrine's connection wrapper chain fires hooks at
+     * every layer. Only the outermost call creates and ends a span.
+     *
+     * @var array<string, int>
+     */
+    private static array $depth = [];
+
     public static function register(): void
     {
         $instrumentation = new CachedInstrumentation('io.opentelemetry.contrib.php.doctrine');
@@ -28,7 +36,11 @@ class DoctrineInstrumentation
         hook(
             \Doctrine\DBAL\Driver::class,
             'connect',
-            pre: static function (\Doctrine\DBAL\Driver $driver, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+            pre: static function (\Doctrine\DBAL\Driver $driver, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation): void {
+                self::$depth['connect'] = (self::$depth['connect'] ?? 0) + 1;
+                if (self::$depth['connect'] > 1) {
+                    return;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, 'Doctrine\DBAL\Driver::connect', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -41,14 +53,21 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver $driver, array $params, ?\Doctrine\DBAL\Driver\Connection $connection, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['connect'] = max(0, (self::$depth['connect'] ?? 1) - 1);
+                if (self::$depth['connect'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
         hook(
             \Doctrine\DBAL\Driver\Connection::class,
             'query',
-            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation): void {
+                self::$depth['query'] = (self::$depth['query'] ?? 0) + 1;
+                if (self::$depth['query'] > 1) {
+                    return;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, AttributesResolver::getDbQuerySummary($params), $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT);
@@ -60,14 +79,21 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, mixed $statement, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['query'] = max(0, (self::$depth['query'] ?? 1) - 1);
+                if (self::$depth['query'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
         hook(
             \Doctrine\DBAL\Driver\Connection::class,
             'exec',
-            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation): void {
+                self::$depth['exec'] = (self::$depth['exec'] ?? 0) + 1;
+                if (self::$depth['exec'] > 1) {
+                    return;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, AttributesResolver::getDbQuerySummary($params), $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -80,14 +106,21 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, mixed $statement, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['exec'] = max(0, (self::$depth['exec'] ?? 1) - 1);
+                if (self::$depth['exec'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
         hook(
             \Doctrine\DBAL\Driver\Connection::class,
             'prepare',
-            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation): void {
+                self::$depth['prepare'] = (self::$depth['prepare'] ?? 0) + 1;
+                if (self::$depth['prepare'] > 1) {
+                    return;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, AttributesResolver::getDbQuerySummary($params), $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -107,14 +140,21 @@ class DoctrineInstrumentation
                         $tracker->trackStatement($statement, $span->getContext());
                     }
                 }
-                self::end($exception);
+                self::$depth['prepare'] = max(0, (self::$depth['prepare'] ?? 1) - 1);
+                if (self::$depth['prepare'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
         hook(
             \Doctrine\DBAL\Driver\Connection::class,
             'beginTransaction',
-            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation): void {
+                self::$depth['beginTransaction'] = (self::$depth['beginTransaction'] ?? 0) + 1;
+                if (self::$depth['beginTransaction'] > 1) {
+                    return;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, 'Doctrine::beginTransaction', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -125,14 +165,21 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, mixed $statement, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['beginTransaction'] = max(0, (self::$depth['beginTransaction'] ?? 1) - 1);
+                if (self::$depth['beginTransaction'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
         hook(
             \Doctrine\DBAL\Driver\Connection::class,
             'commit',
-            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation): void {
+                self::$depth['commit'] = (self::$depth['commit'] ?? 0) + 1;
+                if (self::$depth['commit'] > 1) {
+                    return;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, 'Doctrine::commit', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -143,14 +190,21 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, mixed $statement, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['commit'] = max(0, (self::$depth['commit'] ?? 1) - 1);
+                if (self::$depth['commit'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
         hook(
             \Doctrine\DBAL\Driver\Connection::class,
             'rollBack',
-            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+            pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation): void {
+                self::$depth['rollBack'] = (self::$depth['rollBack'] ?? 0) + 1;
+                if (self::$depth['rollBack'] > 1) {
+                    return;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, 'Doctrine::rollBack', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -160,14 +214,21 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, mixed $statement, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['rollBack'] = max(0, (self::$depth['rollBack'] ?? 1) - 1);
+                if (self::$depth['rollBack'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
         hook(
             \Doctrine\DBAL\Driver\Statement::class,
             'execute',
-            pre: static function (\Doctrine\DBAL\Driver\Statement $statement, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation, $tracker) {
+            pre: static function (\Doctrine\DBAL\Driver\Statement $statement, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation, $tracker): void {
+                self::$depth['execute'] = (self::$depth['execute'] ?? 0) + 1;
+                if (self::$depth['execute'] > 1) {
+                    return;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, 'Doctrine::execute', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -181,7 +242,10 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Statement $statement, array $params, ?ResultInterface $result, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['execute'] = max(0, (self::$depth['execute'] ?? 1) - 1);
+                if (self::$depth['execute'] === 0) {
+                    self::end($exception);
+                }
             }
         );
     }

--- a/src/Instrumentation/Doctrine/tests/Integration/DoctrineInstrumentationTest.php
+++ b/src/Instrumentation/Doctrine/tests/Integration/DoctrineInstrumentationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Instrumentation\Doctrine\Integration;
 
 use ArrayObject;
+use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\DriverManager;
 use OpenTelemetry\API\Instrumentation\Configurator;
 use OpenTelemetry\Context\ScopeInterface;
@@ -13,6 +14,7 @@ use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\SemConv\TraceAttributes;
+use OpenTelemetry\Tests\Instrumentation\Doctrine\Integration\Fixtures\WrappingMiddleware;
 use PHPUnit\Framework\TestCase;
 
 class DoctrineInstrumentationTest extends TestCase
@@ -236,5 +238,54 @@ class DoctrineInstrumentationTest extends TestCase
         $span = $this->storage->offsetGet(0);
         $this->assertSame('Error', $span->getStatus()->getCode());
         $this->assertStringContainsString('Unable to execute', $span->getStatus()->getDescription());
+    }
+
+    /**
+     * A middleware chain makes every hooked method fire once per layer. Only the
+     * outermost invocation may create a span.
+     *
+     * @see https://github.com/open-telemetry/opentelemetry-php/issues/1931
+     */
+    public function test_wrapper_chain_does_not_duplicate_spans(): void
+    {
+        $configuration = new Configuration();
+        $configuration->setMiddlewares([new WrappingMiddleware()]);
+
+        $connection = DriverManager::getConnection([
+            'driver' => 'sqlite3',
+            'memory' => true,
+        ], $configuration);
+
+        // Trigger internal connect
+        $connection->getServerVersion();
+        $this->assertCount(1, $this->storage, 'connect must emit exactly one span');
+        $this->assertSame('Doctrine\DBAL\Driver::connect', $this->storage->offsetGet(0)->getName());
+
+        $this->storage->exchangeArray([]);
+        $connection->executeStatement(self::fillDB());
+        $this->assertCount(1, $this->storage, 'exec must emit exactly one span');
+
+        $this->storage->exchangeArray([]);
+        $statement = $connection->prepare('SELECT * FROM `technology`');
+        $this->assertCount(1, $this->storage, 'prepare must emit exactly one span');
+
+        $this->storage->exchangeArray([]);
+        $statement->executeQuery();
+        $this->assertCount(1, $this->storage, 'execute must emit exactly one span');
+        $this->assertSame('Doctrine::execute', $this->storage->offsetGet(0)->getName());
+
+        $this->storage->exchangeArray([]);
+        $connection->beginTransaction();
+        $this->assertCount(1, $this->storage, 'beginTransaction must emit exactly one span');
+
+        $this->storage->exchangeArray([]);
+        $connection->commit();
+        $this->assertCount(1, $this->storage, 'commit must emit exactly one span');
+
+        $this->storage->exchangeArray([]);
+        $connection->beginTransaction();
+        $this->storage->exchangeArray([]);
+        $connection->rollBack();
+        $this->assertCount(1, $this->storage, 'rollBack must emit exactly one span');
     }
 }

--- a/src/Instrumentation/Doctrine/tests/Integration/Fixtures/WrappingConnection.php
+++ b/src/Instrumentation/Doctrine/tests/Integration/Fixtures/WrappingConnection.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Instrumentation\Doctrine\Integration\Fixtures;
+
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+
+final class WrappingConnection extends AbstractConnectionMiddleware
+{
+}

--- a/src/Instrumentation/Doctrine/tests/Integration/Fixtures/WrappingDriver.php
+++ b/src/Instrumentation/Doctrine/tests/Integration/Fixtures/WrappingDriver.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Instrumentation\Doctrine\Integration\Fixtures;
+
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+
+final class WrappingDriver extends AbstractDriverMiddleware
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function connect(array $params): DriverConnection
+    {
+        return new WrappingConnection(parent::connect($params));
+    }
+}

--- a/src/Instrumentation/Doctrine/tests/Integration/Fixtures/WrappingMiddleware.php
+++ b/src/Instrumentation/Doctrine/tests/Integration/Fixtures/WrappingMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Instrumentation\Doctrine\Integration\Fixtures;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Middleware;
+
+/**
+ * Minimal middleware that adds one delegating layer to the driver and to the
+ * connection, reproducing the wrapper chain shipped by real-world middlewares.
+ */
+final class WrappingMiddleware implements Middleware
+{
+    public function wrap(Driver $driver): Driver
+    {
+        return new WrappingDriver($driver);
+    }
+}


### PR DESCRIPTION
## Problem

`DoctrineInstrumentation` registers hooks on `Doctrine\DBAL\Driver::connect`, `Doctrine\DBAL\Driver\Connection::{query,exec,prepare,beginTransaction,commit,rollBack}` and `Doctrine\DBAL\Driver\Statement::execute`. Those are *interface* methods, so the hooks fire at **every layer of a connection wrapper chain** — a custom `Middleware`, or any `Driver` that delegates to an inner `Driver`.

The result is N spans for one logical database operation, where N is the number of wrapper layers. Traces become noisy and the nesting is misleading.

## Fix

A per-method static re-entrancy depth counter. The pre-hook increments it and skips span creation when `depth > 1`; the post-hook decrements it and only calls `end()` at depth 0. Only the outermost invocation creates and ends a span, so behaviour is unchanged for anyone without a wrapper chain.

The pre-hook closures also get an explicit `: void` return type. They already returned an implicit `null`; the guard's early exit made that inconsistent, which Phan flags as `PhanPluginInconsistentReturnFunction`.

## Test

`test_wrapper_chain_does_not_duplicate_spans` puts a two-layer middleware (driver + connection) in front of the in-memory SQLite driver and asserts exactly one span for connect, exec, prepare, execute, beginTransaction, commit and rollBack.

Without the guard the test fails immediately — `connect` alone emits **3** spans instead of 1.

Local run against `main`, PHP 8.2.30, DBAL 4.4.4:

| Check | Result |
|---|---|
| PHPUnit | OK (10 tests, 56 assertions) |
| PHP-CS-Fixer | 0 of 8 files need fixing |
| Phan | no issues |
| Psalm | no errors found |
| PHPStan | no errors |

## Notes

Fixes open-telemetry/opentelemetry-php#1931, which has a second reporter confirming the same behaviour.

This supersedes opentelemetry-php/contrib-auto-doctrine#3, which I opened in March against the read-only subtree split before realising PRs belong here. I will close that one once this lands.
