### PR TITLE
fix(wordpress): use INTERNAL span kind for internal WP hooks

### DIFF
--- a/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
+++ b/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
@@ -133,7 +133,7 @@ class WordpressInstrumentation
      * Simple generic hook function which starts and ends a minimal span
      * @psalm-param SpanKind::KIND_* $spanKind
      */
-    private static function _hook(CachedInstrumentation $instrumentation, ?string $class, string $function, string $name, int $spanKind = SpanKind::KIND_SERVER): void
+    private static function _hook(CachedInstrumentation $instrumentation, ?string $class, string $function, string $name, int $spanKind = SpanKind::KIND_INTERNAL): void
     {
         hook(
             class: $class,


### PR DESCRIPTION
## Description

The generic `_hook()` helper in `WordpressInstrumentation` defaults to `SpanKind::KIND_SERVER`. Every hook that relies on that default therefore emits a `SERVER` span:

- `WP.main`
- `WP.init`
- `WP.parse_request`
- `WP.send_headers`
- `WP.query_posts`
- `WP.handle_404`
- `WP.register_globals`
- `get_single_template`

Per the [span kind specification](https://opentelemetry.io/docs/specs/otel/trace/api/#spankind), `SERVER` is reserved for the span that handles a synchronous inbound request — one per trace. In this instrumentation that is the root span created in the `wp_initial_constants` hook, which sets `KIND_SERVER` explicitly. Everything listed above is work nested inside that request and should be `INTERNAL`.

Observed on a live install, e.g. `WP::handle_404`:

    code.function.name  WP::handle_404
    code.file.path      /var/www/html/wordpress/wp-includes/class-wp.php
    otel.scope.name     io.opentelemetry.contrib.php.wordpress
    span.kind           server

## Impact

Many backends derive transaction counts, RED metrics and service maps from `SERVER` spans. A single WordPress request was reported as nine transactions rather than one, distorting request rate and latency distribution, and could surface in service maps as inbound traffic from outside the service.