### PR TITLE
fix(wordpress): report request URI host and port as server, not client

### DIFF
--- a/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
+++ b/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
@@ -103,8 +103,8 @@ class WordpressInstrumentation
                     ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $request->getProtocolVersion())
                     ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->getHeaderLine('User-Agent'))
                     ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->getHeaderLine('Content-Length'))
-                    ->setAttribute(TraceAttributes::CLIENT_ADDRESS, $request->getUri()->getHost())
-                    ->setAttribute(TraceAttributes::CLIENT_PORT, $request->getUri()->getPort())
+                    ->setAttribute(TraceAttributes::SERVER_ADDRESS, $request->getUri()->getHost())
+                    ->setAttribute(TraceAttributes::SERVER_PORT, $request->getUri()->getPort())
                     ->startSpan();
                 Context::storage()->attach($span->storeInContext(Context::getCurrent()));
 


### PR DESCRIPTION
## Description

The root span created in the `wp_initial_constants` hook sets `client.address` and `client.port` from `$request->getUri()->getHost()` and `->getPort()`. The request URI describes the address the client connected *to*, not the peer it connected from, so both attributes were populated with server-side data under client semantics.

Per the [general attributes specification](https://opentelemetry.io/docs/specs/semconv/general/attributes/), `server.address` and `server.port` describe the server receiving the request, while `client.address` and `client.port` describe the immediate peer sending it.

The `CodeIgniter` instrumentation already derives `server.address` and `server.port` from exactly these URI getters, so this aligns the two.

## Impact

Backends that group or filter by `server.address` saw nothing for WordPress services, while anything reading `client.address` as a client identity — access patterns, rate limiting, geo breakdowns — was silently reading the server's own hostname.

## On client attributes

This change does not populate `client.address` and `client.port` from `REMOTE_ADDR` in their place. Client IP addresses are personal data under the GDPR and comparable regimes, and traces are routinely exported to third-party backends. Collecting them should be opt-in rather than a side effect of a correctness fix, so it is deliberately left to a separate change and discussion.