### PR TITLE
fix(wordpress): report request body size as an integer

### DIFF
--- a/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
+++ b/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
@@ -90,6 +90,7 @@ class WordpressInstrumentation
                 $factory = new Psr17Factory();
                 $request = (new ServerRequestCreator($factory, $factory, $factory, $factory))->fromGlobals();
                 $parent = Globals::propagator()->extract($request->getHeaders());
+                $contentLength = $request->getHeaderLine('Content-Length');
 
                 $span = $instrumentation
                     ->tracer()
@@ -102,7 +103,7 @@ class WordpressInstrumentation
                     ->setAttribute(TraceAttributes::HTTP_REQUEST_METHOD, $request->getMethod())
                     ->setAttribute(TraceAttributes::NETWORK_PROTOCOL_VERSION, $request->getProtocolVersion())
                     ->setAttribute(TraceAttributes::USER_AGENT_ORIGINAL, $request->getHeaderLine('User-Agent'))
-                    ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, $request->getHeaderLine('Content-Length'))
+                    ->setAttribute(TraceAttributes::HTTP_REQUEST_BODY_SIZE, is_numeric($contentLength) ? (int) $contentLength : null)
                     ->setAttribute(TraceAttributes::CLIENT_ADDRESS, $request->getUri()->getHost())
                     ->setAttribute(TraceAttributes::CLIENT_PORT, $request->getUri()->getPort())
                     ->startSpan();


### PR DESCRIPTION
## Description

`http.request.body.size` is [defined as an integer](https://opentelemetry.io/docs/specs/semconv/http/http-spans/), but the root span sets it from `$request->getHeaderLine('Content-Length')`, which returns a `string`. Requests without a body carry no `Content-Length` header at all, and `getHeaderLine()` returns `''` in that case, so every GET request emitted an empty-string attribute.

The header is now converted to an `int` when it is numeric, and the attribute is omitted otherwise.

## Scope

This same pattern exists in eleven other packages in this repository:

- `Instrumentation/CakePHP/src/Hooks/CakeHookTrait.php`
- `Instrumentation/CodeIgniter/src/CodeIgniterInstrumentation.php`
- `Instrumentation/Guzzle/src/GuzzleInstrumentation.php`
- `Instrumentation/HttpAsyncClient/src/HttpAsyncClientInstrumentation.php`
- `Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php`
- `Instrumentation/Psr15/src/Psr15Instrumentation.php`
- `Instrumentation/Psr18/src/Psr18Instrumentation.php`
- `Instrumentation/Slim/src/SlimInstrumentation.php`
- `Instrumentation/Symfony/src/SymfonyInstrumentation.php`
- `Instrumentation/Yii/src/YiiInstrumentation.php`
- `Symfony/src/OtelBundle/HttpKernel/RequestListener.php`

I have deliberately limited this PR to a single package so the approach can be reviewed on a small diff. If you are happy with it, I am glad to follow up with the remaining packages, either as one sweep or one PR per package, whichever you prefer. Happy to fold them into this PR instead if you would rather see the change land everywhere at once.