### PR TITLE
fix(wordpress): report the response status code and flag server errors

### DIFF
--- a/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
+++ b/src/Instrumentation/Wordpress/src/WordpressInstrumentation.php
@@ -113,10 +113,14 @@ class WordpressInstrumentation
                     //@todo there could be other interesting settings from wordpress...
                     function_exists('is_admin') && $span->setAttribute('wp.is_admin', is_admin());
 
-                    if (function_exists('is_404') && is_404()) {
-                        $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, 404);
+                    $statusCode = http_response_code();
+                    if (is_int($statusCode)) {
+                        $span->setAttribute(TraceAttributes::HTTP_RESPONSE_STATUS_CODE, $statusCode);
+                        if ($statusCode >= 500) {
+                            $span->setAttribute(TraceAttributes::ERROR_TYPE, (string) $statusCode);
+                            $span->setStatus(StatusCode::STATUS_ERROR);
+                        }
                     }
-                    //@todo check for other errors?
 
                     $span->end();
                     $scope = Context::storage()->scope();


### PR DESCRIPTION
## Description

The root span set `http.response.status_code` in exactly one case, when `is_404()` returned true, and never called `setStatus()` at all. Every other response went out without a status code, and no request could ever be marked as failed.

The status code now comes from `http_response_code()` in the shutdown function. That reflects what PHP actually sends and covers the 404 case too, since WordPress' `handle_404()` sets the status via `status_header()`. Responses of 500 and above also set `error.type` and mark the span status as `Error`. The `is_int()` guard keeps both attributes off spans created outside a web server context, such as WP-CLI, where `http_response_code()` returns `false`.

Replacing `is_404()` is more accurate on its own: `is_404()` describes the query result, not the response. If a plugin serves a 404 page with a 200, the old code reported 404 where the new code reports what the client actually received.

## On 4xx responses

4xx responses set the status code but deliberately do not mark the span as an error. Per the [HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/), a 4xx on a server span describes a faulty request rather than a failing server, unlike on the client side where the same code does indicate a failure.