### PR TITLE
fix(symfony): update static analysis tools for PHP 8.1-8.5 compatibility

### DIFF
--- a/src/Instrumentation/Symfony/composer.json
+++ b/src/Instrumentation/Symfony/composer.json
@@ -24,14 +24,15 @@
     "friendsofphp/php-cs-fixer": "^3",
     "phan/phan": "^6.0",
     "php-http/mock-client": "*",
-    "phpstan/phpstan": "^1.1",
-    "phpstan/phpstan-phpunit": "^1.0",
+    "phpstan/phpstan": "^2.0",
+    "phpstan/phpstan-phpunit": "^2.0",
     "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/sdk": "^1.8",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.4.0",
+    "vimeo/psalm": "^6.4",
     "symfony/http-client": "^5.4||^6.0",
-    "symfony/messenger": "^5.4||^6.0"
+    "symfony/messenger": "^5.4||^6.0",
+    "open-telemetry/opentelemetry-propagation-traceresponse": "*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/Symfony/psalm.xml.dist
+++ b/src/Instrumentation/Symfony/psalm.xml.dist
@@ -12,4 +12,7 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <issueHandlers>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+    </issueHandlers>
 </psalm>

--- a/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
+++ b/src/Instrumentation/Symfony/src/SymfonyInstrumentation.php
@@ -112,6 +112,7 @@ final class SymfonyInstrumentation
             }
         );
 
+        /** @psalm-suppress UnusedFunctionCall */
         hook(
             HttpKernel::class,
             'terminate',

--- a/src/Instrumentation/Symfony/tests/Integration/SymfonyInstrumentationTest.php
+++ b/src/Instrumentation/Symfony/tests/Integration/SymfonyInstrumentationTest.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Tests\Instrumentation\Symfony\tests\Integration;
 
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\Contrib\Propagation\TraceResponse\TraceResponsePropagator;
 use OpenTelemetry\SemConv\Attributes\HttpAttributes;
 use OpenTelemetry\SemConv\Attributes\NetworkAttributes;
 use OpenTelemetry\SemConv\Attributes\UrlAttributes;


### PR DESCRIPTION
- Upgrade vimeo/psalm ^6.4 (6.16.1) and phpstan/phpstan ^2.0 to handle PHP 8.4 property hooks in Symfony 8.x vendor packages
- Suppress MissingOverrideAttribute in psalm.xml.dist (requires PHP 8.3+ #[Override] attribute, incompatible with PHP 8.1 minimum)