### PR TITLE
fix(aws): remove deprecated InstrumentationInterface and update static analysis

### DIFF
--- a/src/Aws/composer.json
+++ b/src/Aws/composer.json
@@ -32,7 +32,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "~9",
         "psalm/plugin-phpunit": "^0.19.2",
-        "vimeo/psalm": "6.4.0"
+        "vimeo/psalm": "^6.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Aws/psalm.xml.dist
+++ b/src/Aws/psalm.xml.dist
@@ -12,4 +12,7 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <issueHandlers>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+    </issueHandlers>
 </psalm>

--- a/src/Aws/src/AwsSdkInstrumentation.php
+++ b/src/Aws/src/AwsSdkInstrumentation.php
@@ -9,12 +9,12 @@ use Aws\Middleware;
 use Aws\ResultInterface;
 use Closure;
 use GuzzleHttp\Promise;
-use OpenTelemetry\API\Instrumentation\InstrumentationInterface;
-use OpenTelemetry\API\Instrumentation\InstrumentationTrait;
+use OpenTelemetry\API\Trace\NoopTracerProvider;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\API\Trace\TracerProviderInterface;
+use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
 use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
 use Psr\Http\Message\RequestInterface;
 use Stringable;
@@ -23,15 +23,22 @@ use Throwable;
 /**
  * @experimental
  */
-class AwsSdkInstrumentation implements InstrumentationInterface
+class AwsSdkInstrumentation
 {
-    use InstrumentationTrait;
-
     public const NAME = 'AWS SDK Instrumentation';
     public const VERSION = '0.0.1';
     public const SPAN_KIND = SpanKind::KIND_CLIENT;
 
+    private TracerProviderInterface $tracerProvider;
+    private TextMapPropagatorInterface $propagator;
+
     private array $clients = [];
+
+    public function __construct()
+    {
+        $this->tracerProvider = new NoopTracerProvider();
+        $this->propagator = new NoopTextMapPropagator();
+    }
 
     private array $instrumentedClients = [];
 
@@ -163,6 +170,7 @@ class AwsSdkInstrumentation implements InstrumentationInterface
 
         $onRejected =  function ($reason) use ($hash) {
             if (empty($this->spanStorage[$hash])) {
+                /** @phan-suppress-next-line PhanTemplateTypeConstraintViolation */
                 return Promise\Create::rejectionFor($reason);
             }
             [$span, $scope] = $this->spanStorage[$hash];
@@ -177,6 +185,7 @@ class AwsSdkInstrumentation implements InstrumentationInterface
             $span->end();
             $scope->detach();
 
+            /** @phan-suppress-next-line PhanTemplateTypeConstraintViolation */
             return Promise\Create::rejectionFor($reason);
         };
 

--- a/src/Aws/src/Lambda/AwsLambdaWrapper.php
+++ b/src/Aws/src/Lambda/AwsLambdaWrapper.php
@@ -64,6 +64,7 @@ class AwsLambdaWrapper
                 ?: self::DEFAULT_OTLP_EXPORTER_ENDPOINT,
             'application/x-protobuf'
         );
+        /** @phan-suppress-next-line PhanTypeMismatchArgument */
         $exporter = new OtlpExporter($transport);
 
         $spanProcessor = new SimpleSpanProcessor($exporter);


### PR DESCRIPTION
- Replace deprecated InstrumentationInterface + InstrumentationTrait in AwsSdkInstrumentation with direct property declarations
- Add inline @phan-suppress for PhanTemplateTypeConstraintViolation in Guzzle rejection handler (mixed reason vs PromiseInterface<mixed,mixed> template)
- Add inline @phan-suppress for PhanTypeMismatchArgument in AwsLambdaWrapper (OtlpHttpTransportFactory returns untyped TransportInterface)
- Update vimeo/psalm to ^6.4 to resolve crash on newer PHP versions
- Suppress MissingOverrideAttribute in Psalm (#[Override] requires PHP 8.3+)