### PR TITLE
Skip shared contrib-ci workflows from being updated by renovate.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,5 +29,8 @@
   ],
   "labels": [
     "dependencies"
+  ],
+  "ignorePaths": [
+    "src/**/.github/workflows/contrib-ci.yml"
   ]
 }

--- a/src/Instrumentation/Curl/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Curl/.github/workflows/contrib-ci.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-curl.yml@4f68ecb9760605760d991360df23c6cdeee7dab4 # main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-curl.yml@main
     with:
       package-root: '.'

--- a/src/Instrumentation/Curl/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Curl/.github/workflows/contrib-ci.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-curl.yml@main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-curl.yml@main # zizmor: ignore[unpinned-uses]
     with:
       package-root: '.'

--- a/src/Instrumentation/ExtRdKafka/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/ExtRdKafka/.github/workflows/contrib-ci.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-ext-rdkafka.yml@c8d47c130fdda58dcc06baa3d3a822b8060b99a5 # main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-ext-rdkafka.yml@main
     with:
       package-root: '.'

--- a/src/Instrumentation/ExtRdKafka/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/ExtRdKafka/.github/workflows/contrib-ci.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-ext-rdkafka.yml@main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-ext-rdkafka.yml@main # zizmor: ignore[unpinned-uses]
     with:
       package-root: '.'

--- a/src/Instrumentation/Guzzle/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Guzzle/.github/workflows/contrib-ci.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-guzzle.yml@4f68ecb9760605760d991360df23c6cdeee7dab4 # main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-guzzle.yml@main
     with:
       package-root: '.'

--- a/src/Instrumentation/Guzzle/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Guzzle/.github/workflows/contrib-ci.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-guzzle.yml@main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-guzzle.yml@main # zizmor: ignore[unpinned-uses]
     with:
       package-root: '.'

--- a/src/Instrumentation/HttpConfig/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/HttpConfig/.github/workflows/contrib-ci.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-httpconfig.yml@4f68ecb9760605760d991360df23c6cdeee7dab4 # main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-httpconfig.yml@main
     with:
       package-root: '.'

--- a/src/Instrumentation/HttpConfig/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/HttpConfig/.github/workflows/contrib-ci.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-httpconfig.yml@main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-httpconfig.yml@main # zizmor: ignore[unpinned-uses]
     with:
       package-root: '.'

--- a/src/Instrumentation/Laravel/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Laravel/.github/workflows/contrib-ci.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-laravel.yml@4f68ecb9760605760d991360df23c6cdeee7dab4 # main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-laravel.yml@main
     with:
       package-root: '.'

--- a/src/Instrumentation/Laravel/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Laravel/.github/workflows/contrib-ci.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-laravel.yml@main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-laravel.yml@main # zizmor: ignore[unpinned-uses]
     with:
       package-root: '.'

--- a/src/Instrumentation/MySqli/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/MySqli/.github/workflows/contrib-ci.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-mysqli.yml@4f68ecb9760605760d991360df23c6cdeee7dab4 # main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-mysqli.yml@main
     with:
       package-root: '.'

--- a/src/Instrumentation/MySqli/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/MySqli/.github/workflows/contrib-ci.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-mysqli.yml@main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-mysqli.yml@main # zizmor: ignore[unpinned-uses]
     with:
       package-root: '.'

--- a/src/Instrumentation/Psr3/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Psr3/.github/workflows/contrib-ci.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-psr3.yml@4f68ecb9760605760d991360df23c6cdeee7dab4 # main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-psr3.yml@main
     with:
       package-root: '.'

--- a/src/Instrumentation/Psr3/.github/workflows/contrib-ci.yml
+++ b/src/Instrumentation/Psr3/.github/workflows/contrib-ci.yml
@@ -9,6 +9,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-psr3.yml@main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/instrumentation-psr3.yml@main # zizmor: ignore[unpinned-uses]
     with:
       package-root: '.'

--- a/src/Metrics/Runtime/.github/workflows/contrib-ci.yml
+++ b/src/Metrics/Runtime/.github/workflows/contrib-ci.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/metrics-runtime.yml@4f68ecb9760605760d991360df23c6cdeee7dab4 # main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/metrics-runtime.yml@main
     with:
       package-root: '.'

--- a/src/Metrics/Runtime/.github/workflows/contrib-ci.yml
+++ b/src/Metrics/Runtime/.github/workflows/contrib-ci.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   CI:
-    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/metrics-runtime.yml@main
+    uses: open-telemetry/opentelemetry-php-contrib/.github/workflows/metrics-runtime.yml@main # zizmor: ignore[unpinned-uses]
     with:
       package-root: '.'


### PR DESCRIPTION
Prevent renovate from touching the shared workflow references, instead always pointing to main in this repository.

https://docs.renovatebot.com/configuration-options/#ignorepaths