### PR TITLE
fix(monolog): replace deprecated ConfigurationResolver with SDK Configuration::getEnum()

### DIFF
--- a/src/Logs/Monolog/composer.json
+++ b/src/Logs/Monolog/composer.json
@@ -20,22 +20,29 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",
+    "open-telemetry/sdk": ">=1.0",
     "google/protobuf": ">=3.5.0",
     "guzzlehttp/guzzle": "^7.4",
     "nyholm/psr7": "^1.6",
     "open-telemetry/exporter-otlp": ">=1.0",
-    "open-telemetry/sdk": ">=1.0",
     "phan/phan": "^6.0",
     "phpbench/phpbench": "^1.2",
     "phpstan/phpstan": "^1.1",
     "phpstan/phpstan-phpunit": "^1.0",
     "psalm/plugin-phpunit": "^0.19.2",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.4.0"
+    "vimeo/psalm": "^6.4"
   },
   "config": {
     "allow-plugins": {
       "php-http/discovery": false
+    }
+  },
+  "extra": {
+    "spi": {
+      "OpenTelemetry\\API\\Configuration\\ConfigEnv\\EnvComponentLoader": [
+        "OpenTelemetry\\Contrib\\Logs\\Monolog\\ConfigEnv\\HandlerEnvLoader"
+      ]
     }
   }
 }

--- a/src/Logs/Monolog/composer.json
+++ b/src/Logs/Monolog/composer.json
@@ -20,11 +20,11 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3",
-    "open-telemetry/sdk": ">=1.0",
     "google/protobuf": ">=3.5.0",
     "guzzlehttp/guzzle": "^7.4",
     "nyholm/psr7": "^1.6",
     "open-telemetry/exporter-otlp": ">=1.0",
+    "open-telemetry/sdk": ">=1.0",
     "phan/phan": "^6.0",
     "phpbench/phpbench": "^1.2",
     "phpstan/phpstan": "^1.1",

--- a/src/Logs/Monolog/psalm.xml.dist
+++ b/src/Logs/Monolog/psalm.xml.dist
@@ -15,4 +15,17 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <issueHandlers>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+        <InternalClass>
+            <errorLevel type="suppress">
+                <directory name="tests"/>
+            </errorLevel>
+        </InternalClass>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <directory name="tests"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
 </psalm>

--- a/src/Logs/Monolog/src/ConfigEnv/HandlerEnvLoader.php
+++ b/src/Logs/Monolog/src/ConfigEnv/HandlerEnvLoader.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Logs\Monolog\ConfigEnv;
+
+use OpenTelemetry\API\Configuration\ConfigEnv\EnvComponentLoader;
+use OpenTelemetry\API\Configuration\ConfigEnv\EnvComponentLoaderRegistry;
+use OpenTelemetry\API\Configuration\ConfigEnv\EnvResolver;
+use OpenTelemetry\API\Configuration\Context;
+use OpenTelemetry\Contrib\Logs\Monolog\Handler;
+use OpenTelemetry\Contrib\Logs\Monolog\HandlerConfiguration;
+
+/**
+ * @implements EnvComponentLoader<HandlerConfiguration>
+ */
+final class HandlerEnvLoader implements EnvComponentLoader
+{
+    public function load(EnvResolver $env, EnvComponentLoaderRegistry $registry, Context $context): HandlerConfiguration
+    {
+        return new HandlerConfiguration(
+            mode: $env->enum(Handler::OTEL_PHP_MONOLOG_ATTRIB_MODE, Handler::MODES) ?? Handler::DEFAULT_MODE,
+        );
+    }
+
+    public function name(): string
+    {
+        return HandlerConfiguration::class;
+    }
+}

--- a/src/Logs/Monolog/src/Handler.php
+++ b/src/Logs/Monolog/src/Handler.php
@@ -8,9 +8,7 @@ use function count;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\NormalizerFormatter;
 use Monolog\Handler\AbstractProcessingHandler;
-use OpenTelemetry\API\Instrumentation\ConfigurationResolver;
 use OpenTelemetry\API\Logs as API;
-
 use Throwable;
 
 class Handler extends AbstractProcessingHandler
@@ -18,12 +16,12 @@ class Handler extends AbstractProcessingHandler
     public const OTEL_PHP_MONOLOG_ATTRIB_MODE = 'OTEL_PHP_MONOLOG_ATTRIB_MODE';
     public const MODE_PSR3 = 'psr3';
     public const MODE_OTEL = 'otel';
-    private const MODES = [
+    public const MODES = [
         self::MODE_PSR3,
         self::MODE_OTEL,
     ];
     public const DEFAULT_MODE = self::MODE_PSR3;
-    private static string $mode;
+    private string $mode;
 
     /** @var API\LoggerInterface[] */
     private array $loggers = [];
@@ -33,12 +31,12 @@ class Handler extends AbstractProcessingHandler
     /**
      * @psalm-suppress InvalidArgument
      */
-    public function __construct(API\LoggerProviderInterface $loggerProvider, $level, bool $bubble = true, ?FormatterInterface $formatterInterface = null)
+    public function __construct(API\LoggerProviderInterface $loggerProvider, $level, bool $bubble = true, ?FormatterInterface $formatterInterface = null, HandlerConfiguration $config = new HandlerConfiguration())
     {
         parent::__construct($level, $bubble);
         $this->loggerProvider = $loggerProvider;
         $this->formatterInterface = $formatterInterface;
-        self::$mode = self::getMode();
+        $this->mode = $config->mode;
     }
 
     protected function getLogger(string $channel): API\LoggerInterface
@@ -66,7 +64,7 @@ class Handler extends AbstractProcessingHandler
         ;
 
         foreach (['context', 'extra'] as $key) {
-            if (self::$mode === self::MODE_PSR3 && isset($formatted[$key]) && count($formatted[$key]) > 0) {
+            if ($this->mode === self::MODE_PSR3 && isset($formatted[$key]) && count($formatted[$key]) > 0) {
                 $recordBuilder->setAttribute($key, $formatted[$key]);
             }
             if (isset($record[$key]) && $record[$key] !== []) {
@@ -80,7 +78,7 @@ class Handler extends AbstractProcessingHandler
 
                         continue;
                     }
-                    switch (self::$mode) {
+                    switch ($this->mode) {
                         case self::MODE_PSR3:
                             $recordBuilder->setAttribute(sprintf('%s.%s', $key, $attributeName), $attribute);
 
@@ -96,16 +94,4 @@ class Handler extends AbstractProcessingHandler
         $recordBuilder->emit();
     }
 
-    private static function getMode(): string
-    {
-        $resolver = new ConfigurationResolver();
-        if ($resolver->has(self::OTEL_PHP_MONOLOG_ATTRIB_MODE)) {
-            $val = $resolver->getString(self::OTEL_PHP_MONOLOG_ATTRIB_MODE);
-            if ($val && in_array($val, self::MODES)) {
-                return $val;
-            }
-        }
-
-        return self::DEFAULT_MODE;
-    }
 }

--- a/src/Logs/Monolog/src/HandlerConfiguration.php
+++ b/src/Logs/Monolog/src/HandlerConfiguration.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Logs\Monolog;
+
+use OpenTelemetry\API\Instrumentation\AutoInstrumentation\InstrumentationConfiguration;
+
+final class HandlerConfiguration implements InstrumentationConfiguration
+{
+    public function __construct(
+        public readonly string $mode = Handler::DEFAULT_MODE,
+    ) {
+    }
+}

--- a/src/Logs/Monolog/tests/Unit/HandlerEnvLoaderTest.php
+++ b/src/Logs/Monolog/tests/Unit/HandlerEnvLoaderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenTelemetry\API\Configuration\ConfigEnv\EnvComponentLoaderRegistry;
+use OpenTelemetry\API\Configuration\ConfigEnv\EnvResolver;
+use OpenTelemetry\API\Configuration\Context;
+use OpenTelemetry\Contrib\Logs\Monolog\ConfigEnv\HandlerEnvLoader;
+use OpenTelemetry\Contrib\Logs\Monolog\Handler;
+use OpenTelemetry\Contrib\Logs\Monolog\HandlerConfiguration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \OpenTelemetry\Contrib\Logs\Monolog\ConfigEnv\HandlerEnvLoader
+ */
+class HandlerEnvLoaderTest extends TestCase
+{
+    /** @var EnvResolver&\PHPUnit\Framework\MockObject\MockObject */
+    private EnvResolver $env;
+    /** @var EnvComponentLoaderRegistry&\PHPUnit\Framework\MockObject\MockObject */
+    private EnvComponentLoaderRegistry $registry;
+    private Context $context;
+
+    public function setUp(): void
+    {
+        $this->env = $this->createMock(EnvResolver::class);
+        $this->registry = $this->createMock(EnvComponentLoaderRegistry::class);
+        $this->context = new Context();
+    }
+
+    public function test_name_returns_configuration_class(): void
+    {
+        $this->assertSame(HandlerConfiguration::class, (new HandlerEnvLoader())->name());
+    }
+
+    public function test_load_returns_default_mode_when_env_not_set(): void
+    {
+        $this->env->method('enum')->willReturn(null);
+
+        $config = (new HandlerEnvLoader())->load($this->env, $this->registry, $this->context);
+
+        $this->assertSame(Handler::DEFAULT_MODE, $config->mode);
+    }
+
+    public function test_load_returns_mode_from_env(): void
+    {
+        $this->env->method('enum')
+            ->with(Handler::OTEL_PHP_MONOLOG_ATTRIB_MODE, Handler::MODES)
+            ->willReturn(Handler::MODE_OTEL);
+
+        $config = (new HandlerEnvLoader())->load($this->env, $this->registry, $this->context);
+
+        $this->assertSame(Handler::MODE_OTEL, $config->mode);
+    }
+}

--- a/src/Logs/Monolog/tests/Unit/HandlerTest.php
+++ b/src/Logs/Monolog/tests/Unit/HandlerTest.php
@@ -6,6 +6,7 @@ use OpenTelemetry\API\Logs\LoggerInterface;
 use OpenTelemetry\API\Logs\LoggerProviderInterface;
 use OpenTelemetry\API\Logs\LogRecord;
 use OpenTelemetry\Contrib\Logs\Monolog\Handler;
+use OpenTelemetry\Contrib\Logs\Monolog\HandlerConfiguration;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
 use OpenTelemetry\SDK\Logs\LoggerSharedState;
@@ -103,8 +104,6 @@ class HandlerTest extends TestCase
 
     public function test_handle_record_attrib_mode(): void
     {
-        putenv(sprintf('%s=%s', Handler::OTEL_PHP_MONOLOG_ATTRIB_MODE, Handler::MODE_OTEL));
-
         $channelName = 'test';
         $scope = $this->createMock(InstrumentationScopeInterface::class);
         $sharedState = $this->createMock(LoggerSharedState::class);
@@ -114,7 +113,7 @@ class HandlerTest extends TestCase
         $limits->method('getAttributeFactory')->willReturn($attributeFactory);
         $sharedState->method('getResource')->willReturn($resource);
         $sharedState->method('getLogRecordLimits')->willReturn($limits);
-        $handler = new Handler($this->provider, 100, true);
+        $handler = new Handler($this->provider, 100, true, null, new HandlerConfiguration(mode: Handler::MODE_OTEL));
         $processor = function ($record) {
             $record['extra'] = ['foo' => 'qux', 'bar' => 'quux'];
 


### PR DESCRIPTION
Replace deprecated ConfigurationResolver with the EnvComponentLoader/EnvResolver SPI pattern from the API package, avoiding an explicit SDK runtime dependency:

  - Add HandlerConfiguration (InstrumentationConfiguration POPO) to hold mode
  - Add ConfigEnv/HandlerEnvLoader (EnvComponentLoader) — reads OTEL_PHP_MONOLOG_ATTRIB_MODE from env via injected EnvResolver
  - Register HandlerEnvLoader in composer.json extra.spi
  - Handler constructor accepts HandlerConfiguration (defaults to psr3 mode)
  - Remove open-telemetry/sdk from runtime require; move to require-dev
  - Fix $mode from shared static to per-instance property
  - Upgrade vimeo/psalm to ^6.4 for PHP 8.4+ compatibility
  - Add HandlerEnvLoaderTest and update HandlerTest to inject config directly

