### PR TITLE
feat(laravel): don't create umbrella spans for long-running Artisan commands

### DIFF
--- a/src/Instrumentation/Laravel/README.md
+++ b/src/Instrumentation/Laravel/README.md
@@ -22,3 +22,37 @@ The extension can be disabled via [runtime configuration](https://opentelemetry.
 ```shell
 OTEL_PHP_DISABLED_INSTRUMENTATIONS=laravel
 ```
+
+### Long-running commands
+
+No `Command` span is created for worker / daemon commands, because such a command only returns when
+the process is stopped: the span would never end and would become the ambient parent for every job,
+request and query handled during the process lifetime, collapsing everything into a single unbounded
+trace. The work done inside each iteration (e.g. a queued job) is still traced on its own.
+
+Laravel's own long-running commands are recognised out of the box: `queue:work`, `queue:listen`,
+`horizon`, `horizon:work`, `horizon:supervisor`, `schedule:work`, `reverb:start`, `reverb:restart`,
+`pail`, `octane:start`, `octane:frankenphp`, `octane:swoole`.
+
+Add your own with a comma-separated list of names (`*` wildcards allowed), merged with the built-in
+list:
+
+```shell
+OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS="app:kafka-consume,app:relay-*"
+```
+
+Or mark the command class with an attribute:
+
+```php
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Contracts\Console\LongRunningCommand;
+
+#[LongRunningCommand]
+class KafkaConsumeCommand extends Command
+{
+    // ...
+}
+```
+
+The `Artisan handler` span (only created when `OTEL_PHP_TRACE_CLI_ENABLED=true`) is skipped for the
+same commands. That span sees the command name only, so a custom command marked purely with
+`#[LongRunningCommand]` must also be listed in the environment variable to be skipped there.

--- a/src/Instrumentation/Laravel/src/Contracts/Console/LongRunningCommand.php
+++ b/src/Instrumentation/Laravel/src/Contracts/Console/LongRunningCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Contracts\Console;
+
+use Attribute;
+
+/**
+ * Marks an Artisan command as long-running (a worker / daemon / consumer loop).
+ *
+ * The console instrumentation does not open a `Command` span for a command
+ * carrying this attribute, because such a command only returns when the process
+ * stops. A never-ending span becomes the ambient parent for every job, request
+ * or query handled during the process lifetime, producing a single unbounded
+ * trace.
+ *
+ * Laravel's own long-running commands (`queue:work`, `horizon`, `octane:start`,
+ * ...) are recognised by name out of the box; use this attribute for custom
+ * commands, or the
+ * `OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS` environment variable
+ * for commands you cannot annotate.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class LongRunningCommand
+{
+}

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Console/Command.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Console/Command.php
@@ -32,6 +32,13 @@ class Command implements LaravelHook
             IlluminateCommand::class,
             'execute',
             pre: function (IlluminateCommand $command, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+                // A worker / daemon command (queue:work, horizon, a custom consumer loop) only
+                // returns when the process stops, so its span would never end and would become
+                // the ambient parent for every job the process handles. Skip it entirely.
+                if (LongRunningCommands::matches($command)) {
+                    return;
+                }
+
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $this->instrumentation
                     ->tracer()
@@ -47,6 +54,12 @@ class Command implements LaravelHook
                 return $params;
             },
             post: function (IlluminateCommand $command, array $params, ?int $exitCode, ?Throwable $exception) {
+                // Re-check rather than track state: pre skipped this command, so there is no
+                // span of ours to end and the current scope belongs to something else.
+                if (LongRunningCommands::matches($command)) {
+                    return;
+                }
+
                 $scope = Context::storage()->scope();
                 if (!$scope) {
                     return;

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Console/LongRunningCommands.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Console/LongRunningCommands.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use OpenTelemetry\API\Instrumentation\ConfigurationResolver;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Contracts\Console\LongRunningCommand;
+use ReflectionAttribute;
+use ReflectionClass;
+use Throwable;
+
+/**
+ * Decides whether an Artisan command runs long enough that wrapping it in a
+ * span is harmful.
+ *
+ * A worker / daemon command (`queue:work`, `horizon`, a custom consumer loop)
+ * only returns when the process is stopped, so a span opened for its execution
+ * never ends. While open it is the ambient parent for every job, request and
+ * query handled by the process, collapsing the whole process lifetime into one
+ * unbounded trace.
+ *
+ * A command is treated as long-running when its name matches the built-in list,
+ * matches a pattern in the
+ * `OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS` environment variable
+ * (comma separated, `*` wildcards allowed, merged with the built-in list), or
+ * the command class carries the
+ * {@see \OpenTelemetry\Contrib\Instrumentation\Laravel\Contracts\Console\LongRunningCommand}
+ * attribute.
+ */
+final class LongRunningCommands
+{
+    public const OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS = 'OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS';
+
+    /**
+     * First-party Laravel / ecosystem commands that run until stopped.
+     *
+     * @var list<string>
+     */
+    private const DEFAULTS = [
+        'queue:work',
+        'queue:listen',
+        'horizon',
+        'horizon:work',
+        'horizon:supervisor',
+        'schedule:work',
+        'reverb:start',
+        'reverb:restart',
+        'pail',
+        'octane:start',
+        'octane:frankenphp',
+        'octane:swoole',
+    ];
+
+    public static function matches(?Command $command): bool
+    {
+        if ($command === null) {
+            return false;
+        }
+
+        if (self::matchesName($command->getName())) {
+            return true;
+        }
+
+        return self::hasAttribute($command);
+    }
+
+    public static function matchesName(?string $name): bool
+    {
+        if ($name === null || $name === '') {
+            return false;
+        }
+
+        return Str::is(self::patterns(), $name);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function patterns(): array
+    {
+        $configured = array_map(
+            'trim',
+            (new ConfigurationResolver())->getList(self::OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS),
+        );
+
+        return array_values(array_filter(array_merge(self::DEFAULTS, $configured)));
+    }
+
+    private static function hasAttribute(Command $command): bool
+    {
+        try {
+            return (new ReflectionClass($command))
+                ->getAttributes(LongRunningCommand::class, ReflectionAttribute::IS_INSTANCEOF) !== [];
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Console/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Console/Kernel.php
@@ -10,6 +10,7 @@ use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\Context\Context;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Console\LongRunningCommands;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Queue\AttributesBuilder;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHook;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHookTrait;
@@ -17,6 +18,7 @@ use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\PostHookTrait;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\LaravelInstrumentation;
 use function OpenTelemetry\Instrumentation\hook;
 use OpenTelemetry\SemConv\Attributes\CodeAttributes;
+use Symfony\Component\Console\Input\InputInterface;
 use Throwable;
 
 class Kernel implements LaravelHook
@@ -39,6 +41,14 @@ class Kernel implements LaravelHook
             KernelContract::class,
             'handle',
             pre: function (KernelContract $kernel, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+                // Don't wrap a worker / daemon invocation (queue:work, horizon, ...) in a span
+                // that only ends when the process stops. Only the command name is available
+                // here, so a custom command marked solely with #[LongRunningCommand] still needs
+                // to be listed in OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS.
+                if (LongRunningCommands::matchesName($this->resolveCommandName($params[0] ?? null))) {
+                    return $params;
+                }
+
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = $this->instrumentation
                     ->tracer()
@@ -55,6 +65,11 @@ class Kernel implements LaravelHook
                 return $params;
             },
             post: function (KernelContract $kernel, array $params, ?int $exitCode, ?Throwable $exception) {
+                // Re-check: pre skipped long-running commands, so the current scope is not ours.
+                if (LongRunningCommands::matchesName($this->resolveCommandName($params[0] ?? null))) {
+                    return;
+                }
+
                 $scope = Context::storage()->scope();
                 if (!$scope) {
                     return;
@@ -69,5 +84,18 @@ class Kernel implements LaravelHook
                 $this->endSpan($exception);
             }
         );
+    }
+
+    private function resolveCommandName(mixed $input): ?string
+    {
+        if (!$input instanceof InputInterface) {
+            return null;
+        }
+
+        try {
+            return $input->getFirstArgument();
+        } catch (Throwable) {
+            return null;
+        }
     }
 }

--- a/src/Instrumentation/Laravel/tests/Fixtures/Console/LongRunningFixtureCommand.php
+++ b/src/Instrumentation/Laravel/tests/Fixtures/Console/LongRunningFixtureCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Console;
+
+use Illuminate\Console\Command;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Contracts\Console\LongRunningCommand;
+
+/** @psalm-suppress UnusedClass */
+#[LongRunningCommand]
+class LongRunningFixtureCommand extends Command
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    protected $signature = 'test:long-running-fixture';
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}

--- a/src/Instrumentation/Laravel/tests/Fixtures/Console/NoopCommand.php
+++ b/src/Instrumentation/Laravel/tests/Fixtures/Console/NoopCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Console;
+
+use Illuminate\Console\Command;
+
+/** @psalm-suppress UnusedClass */
+class NoopCommand extends Command
+{
+    /** @psalm-suppress PossiblyUnusedMethod */
+    protected $signature = 'test:noop';
+
+    /** @psalm-suppress PossiblyUnusedMethod */
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}

--- a/src/Instrumentation/Laravel/tests/Integration/Console/CommandTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Console/CommandTest.php
@@ -7,12 +7,22 @@ namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration\Consol
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Console\Kernel;
 use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Console\LongRunningCommands;
 use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Console\FailingCommand;
+use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Console\LongRunningFixtureCommand;
+use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Console\NoopCommand;
 use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration\TestCase;
 
 /** @psalm-suppress UnusedClass */
 class CommandTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        putenv(LongRunningCommands::OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS);
+
+        parent::tearDown();
+    }
+
     public function test_command_tracing(): void
     {
         $this->assertCount(0, $this->storage);
@@ -61,6 +71,51 @@ class CommandTest extends TestCase
         $this->assertCount(1, $this->storage);
         $this->assertSame('Command test:failing-command', $this->storage[0]->getName());
         $this->assertSame(StatusCode::STATUS_ERROR, $this->storage[0]->getStatus()->getCode());
+    }
+
+    public function test_long_running_command_is_not_traced_when_marked_with_attribute(): void
+    {
+        $kernel = $this->kernel();
+        $kernel->registerCommand(new LongRunningFixtureCommand());
+
+        $exitCode = $kernel->handle(
+            new \Symfony\Component\Console\Input\ArrayInput(['test:long-running-fixture']),
+            new \Symfony\Component\Console\Output\NullOutput(),
+        );
+
+        $this->assertEquals(Command::SUCCESS, $exitCode);
+        $this->assertCount(0, $this->storage);
+    }
+
+    public function test_long_running_command_is_not_traced_when_listed_in_env(): void
+    {
+        putenv(LongRunningCommands::OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS . '=test:noop');
+
+        $kernel = $this->kernel();
+        $kernel->registerCommand(new NoopCommand());
+
+        $exitCode = $kernel->handle(
+            new \Symfony\Component\Console\Input\ArrayInput(['test:noop']),
+            new \Symfony\Component\Console\Output\NullOutput(),
+        );
+
+        $this->assertEquals(Command::SUCCESS, $exitCode);
+        $this->assertCount(0, $this->storage);
+    }
+
+    public function test_ordinary_command_is_still_traced(): void
+    {
+        $kernel = $this->kernel();
+        $kernel->registerCommand(new NoopCommand());
+
+        $exitCode = $kernel->handle(
+            new \Symfony\Component\Console\Input\ArrayInput(['test:noop']),
+            new \Symfony\Component\Console\Output\NullOutput(),
+        );
+
+        $this->assertEquals(Command::SUCCESS, $exitCode);
+        $this->assertCount(1, $this->storage);
+        $this->assertSame('Command test:noop', $this->storage[0]->getName());
     }
 
     private function kernel(): Kernel

--- a/src/Instrumentation/Laravel/tests/Unit/Hooks/Illuminate/Console/LongRunningCommandsTest.php
+++ b/src/Instrumentation/Laravel/tests/Unit/Hooks/Illuminate/Console/LongRunningCommandsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Unit\Hooks\Illuminate\Console;
+
+use Illuminate\Console\Command;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Contracts\Console\LongRunningCommand;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\Illuminate\Console\LongRunningCommands;
+use PHPUnit\Framework\TestCase;
+
+class LongRunningCommandsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv(LongRunningCommands::OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv(LongRunningCommands::OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS);
+    }
+
+    /**
+     * @dataProvider builtInNames
+     */
+    public function test_built_in_long_running_commands_match(string $name): void
+    {
+        $this->assertTrue(LongRunningCommands::matchesName($name));
+    }
+
+    public static function builtInNames(): iterable
+    {
+        yield ['queue:work'];
+        yield ['queue:listen'];
+        yield ['horizon'];
+        yield ['horizon:supervisor'];
+        yield ['schedule:work'];
+        yield ['reverb:start'];
+        yield ['octane:start'];
+        yield ['pail'];
+    }
+
+    /**
+     * @dataProvider ordinaryNames
+     */
+    public function test_ordinary_commands_do_not_match(?string $name): void
+    {
+        $this->assertFalse(LongRunningCommands::matchesName($name));
+    }
+
+    public static function ordinaryNames(): iterable
+    {
+        yield [null];
+        yield [''];
+        yield ['migrate'];
+        yield ['optimize:clear'];
+        yield ['queue:table'];
+        yield ['app:import-users'];
+    }
+
+    public function test_env_var_extends_the_built_in_list_and_supports_wildcards(): void
+    {
+        putenv(LongRunningCommands::OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS . '=app:consume-* , app:relay');
+
+        $this->assertTrue(LongRunningCommands::matchesName('app:consume-orders'));
+        $this->assertTrue(LongRunningCommands::matchesName('app:relay'));
+        $this->assertTrue(LongRunningCommands::matchesName('queue:work'));
+        $this->assertFalse(LongRunningCommands::matchesName('app:consume'));
+    }
+
+    public function test_attribute_marks_a_command_regardless_of_name(): void
+    {
+        $command = new class() extends Command {
+            protected $signature = 'app:not-listed-anywhere';
+        };
+        $annotated = new #[LongRunningCommand] class() extends Command {
+            protected $signature = 'app:also-not-listed';
+        };
+
+        $this->assertFalse(LongRunningCommands::matches($command));
+        $this->assertTrue(LongRunningCommands::matches($annotated));
+    }
+
+    public function test_null_command_does_not_match(): void
+    {
+        $this->assertFalse(LongRunningCommands::matches(null));
+    }
+}


### PR DESCRIPTION
## Summary

`Hooks/Illuminate/Console/Command.php` opens a `Command <name>` span for every Artisan command and only ends it when `Illuminate\Console\Command::execute()` returns; `Hooks/Illuminate/Contracts/Console/Kernel.php` does the same with an `Artisan handler` span (gated behind `OTEL_PHP_TRACE_CLI_ENABLED`).

For a worker/daemon command — `queue:work`, `queue:listen`, `horizon`, `octane:start`, `schedule:work`, a custom consumer loop — that method never returns until the process is stopped. While the span is open it is the ambient `Context::getCurrent()`, so:

- every span created inside the worker loop (Redis `BLPOP`/`eval` from `migrateExpiredJobs`, DB reconnects, cache polls) nests under it;
- every job whose payload carries no valid `traceparent` gets parented onto it, because `Hooks/Illuminate/Queue/Worker.php::setParentContext()` falls through to `$spanBuilder->setParent(Context::getCurrent())`.

The result is one unbounded trace per worker process — collectors reject it (`TRACE_TOO_LARGE`) and memory grows until the worker restarts.

This is a known issue with an agreed-on design that never got finished:

- #1440 names `Console/Command.php` exactly. @ChrisLightfootWild: *"I actually started work on this but never pushed it up."* Auto-closed stale, no fix landed.
- #1411 (same root cause via `CacheWatcher`) — @LauJosefsen proposed a built-in denylist + `#[LongRunningCommand]` attribute for custom commands + an env var to extend it; a maintainer was receptive. Also auto-closed stale.
- A downstream fork (`cego/php-contrib-auto-laravel`) exists solely to patch this.
- `keepsuit/laravel-opentelemetry` shipped the equivalent fix in 1.13.1 ([keepsuit#57](https://github.com/keepsuit/laravel-opentelemetry/issues/57)); the reporter confirmed it "completely resolved the issue".

This PR implements the design from #1411/#1440.

## What changed

- New `Contracts\Console\LongRunningCommand` attribute — mark a custom worker/consumer command with `#[LongRunningCommand]`.
- New `Hooks\Illuminate\Console\LongRunningCommands` helper — decides whether a command is long-running: built-in list (`queue:work`, `queue:listen`, `horizon`, `horizon:work`, `horizon:supervisor`, `schedule:work`, `reverb:start`, `reverb:restart`, `pail`, `octane:start`, `octane:frankenphp`, `octane:swoole`) ∪ `OTEL_PHP_INSTRUMENTATION_LARAVEL_LONG_RUNNING_COMMANDS` (comma separated, `*` wildcards, merged with the built-in list) ∪ the attribute.
- `Console\Command` and `Contracts\Console\Kernel` hooks: skip span creation for a matching command. The `post` hook re-checks the same condition rather than tracking state, so it never detaches a scope it didn't attach (safe with nested command calls, e.g. `optimize:clear`'s sub-commands, which are untouched by this change).
- README: documents the env var and the attribute.
- Tests: unit coverage for the matching logic (built-in names, non-matches, env-var + wildcards, attribute), integration coverage that a long-running command (by attribute, and by env var) produces no span while an ordinary command still does.

## Known trade-off

Removing the umbrella span means spans created between jobs inside the worker loop (e.g. Redis polling) become their own single-span traces instead of nesting under one giant trace — the same behavior change `keepsuit/laravel-opentelemetry`'s fix produced, and what resolved the equivalent report there. A follow-up could suppress instrumentation during the idle poll loop itself; out of scope here.

## Testing

```
vendor/bin/phpunit --testsuite unit         # 35/35 passing locally
vendor/bin/phpstan analyse                  # no new findings (existing findings are pre-existing, unrelated to this change)
vendor/bin/php-cs-fixer fix --dry-run --diff  # no style findings in the changed files
```

The integration suite (`tests/Integration/Console/CommandTest.php`) needs `ext-opentelemetry`, not available in my local environment — CI covers it; the added assertions follow the exact pattern of the existing `test_command_tracing` / `test_failing_command_sets_status_error` tests in that file.

Fixes #1440
Fixes #1411
