### PR TITLE
fix(laravel): set messaging.operation.type attribute on queue spans

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Queue/Queue.php
@@ -42,6 +42,7 @@ class Queue implements LaravelHook
                     CodeAttributes::CODE_FUNCTION_NAME => sprintf('%s::%s', $class, $function),
                     CodeAttributes::CODE_FILE_PATH => $filename,
                     CodeAttributes::CODE_LINE_NUMBER => $lineno,
+                    MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE => MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_SEND,
                     MessagingIncubatingAttributes::MESSAGING_BATCH_MESSAGE_COUNT => count($params[0] ?? []),
                 ], $this->contextualMessageSystemAttributes($queue, []));
 
@@ -85,6 +86,7 @@ class Queue implements LaravelHook
                     CodeAttributes::CODE_FUNCTION_NAME => sprintf('%s::%s', $class, $function),
                     CodeAttributes::CODE_FILE_PATH => $filename,
                     CodeAttributes::CODE_LINE_NUMBER => $lineno,
+                    MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE => MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_CREATE,
                     'messaging.message.delivery_timestamp' => $estimateDeliveryTimestamp,
                 ];
 
@@ -119,6 +121,7 @@ class Queue implements LaravelHook
             pre: function (QueueContract $queue, array $params, string $_class, string $_function, ?string $_filename, ?int $_lineno) {
                 /** @phan-suppress-next-line PhanParamTooFewUnpack */
                 $attributes = $this->buildMessageAttributes($queue, ...$params);
+                $attributes[MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE] = MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_CREATE;
 
                 $parent = Context::getCurrent();
                 /** @psalm-suppress ArgumentTypeCoercion */

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/SyncQueue.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/SyncQueue.php
@@ -12,6 +12,7 @@ use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\LaravelHookTrait;
 use OpenTelemetry\Contrib\Instrumentation\Laravel\Hooks\PostHookTrait;
 use function OpenTelemetry\Instrumentation\hook;
 use OpenTelemetry\SemConv\Attributes\CodeAttributes;
+use OpenTelemetry\SemConv\Incubating\Attributes\MessagingIncubatingAttributes;
 use Throwable;
 
 class SyncQueue implements LaravelHook
@@ -37,13 +38,14 @@ class SyncQueue implements LaravelHook
                     ->tracer()
                     ->spanBuilder(vsprintf('%s %s', [
                         $queue->getConnectionName(),
-                        'process',
+                        MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
                     ]))
                     ->setSpanKind(SpanKind::KIND_INTERNAL)
                     ->setAttributes([
                         CodeAttributes::CODE_FUNCTION_NAME => sprintf('%s::%s', $class, $function),
                         CodeAttributes::CODE_FILE_PATH => $filename,
                         CodeAttributes::CODE_LINE_NUMBER => $lineno,
+                        MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE => MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
                     ])
                     ->startSpan();
 

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/Worker.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Queue/Worker.php
@@ -51,6 +51,7 @@ class Worker implements LaravelHook
 
                 $queue = $worker->getManager()->connection($connectionName);
                 $attributes = $this->buildMessageAttributes($queue, $job->getRawBody(), $job->getQueue());
+                $attributes[MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE] = MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_PROCESS;
 
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $spanBuilder = $this->instrumentation
@@ -101,6 +102,7 @@ class Worker implements LaravelHook
                 $queue = $params[1];
 
                 $attributes = $this->buildMessageAttributes($connection, '', $queue);
+                $attributes[MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE] = MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_RECEIVE;
 
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $span = $this->instrumentation

--- a/src/Instrumentation/Laravel/tests/Integration/Queue/QueueTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Queue/QueueTest.php
@@ -43,11 +43,19 @@ class QueueTest extends TestCase
         $logRecord0 = $this->storage[0];
         $this->assertEquals('Task: A', $logRecord0->getBody());
         $this->assertEquals('sync process', $this->storage[1]->getName());
+        $this->assertEquals(
+            MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+            $this->storage[1]->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE),
+        );
 
         /** @var \OpenTelemetry\SDK\Logs\ReadWriteLogRecord $logRecord2 */
         $logRecord2 = $this->storage[2];
         $this->assertEquals('Logged from closure', $logRecord2->getBody());
         $this->assertEquals('sync process', $this->storage[3]->getName());
+        $this->assertEquals(
+            MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+            $this->storage[3]->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE),
+        );
     }
 
     public function test_it_can_push_a_message_with_a_delay(): void
@@ -59,6 +67,10 @@ class QueueTest extends TestCase
         $this->assertEquals('create sync', $this->storage[2]->getName());
         $this->assertIsInt(
             $this->storage[2]->getAttributes()->get('messaging.message.delivery_timestamp'),
+        );
+        $this->assertEquals(
+            MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_CREATE,
+            $this->storage[2]->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE),
         );
 
         $this->assertEquals('create sync', $this->storage[5]->getName());
@@ -102,6 +114,10 @@ class QueueTest extends TestCase
 
         $this->assertEquals('send dummy-queue', $this->storage[0]->getName());
         $this->assertEquals(10, $this->storage[0]->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_BATCH_MESSAGE_COUNT));
+        $this->assertEquals(
+            MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_SEND,
+            $this->storage[0]->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE),
+        );
     }
 
     public function test_it_can_create_with_redis(): void
@@ -124,6 +140,35 @@ class QueueTest extends TestCase
         $this->assertEquals('send queues:default', $this->storage[0]->getName());
         $this->assertEquals(2, $this->storage[0]->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_BATCH_MESSAGE_COUNT));
         $this->assertEquals('redis', $this->storage[0]->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_SYSTEM));
+        $this->assertEquals(
+            MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_SEND,
+            $this->storage[0]->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE),
+        );
+    }
+
+    public function test_it_records_operation_type_on_receive_span(): void
+    {
+        $mockQueueManager = $this->createMock(QueueManager::class);
+
+        $mockQueueManager->method('connection')
+            ->with('sqs')
+            ->willReturn($this->createMock(SqsQueue::class));
+
+        /**
+         * @psalm-suppress PossiblyNullReference
+         * @var Worker $worker
+         */
+        $worker = $this->app->make(Worker::class, [
+            'manager' => $mockQueueManager,
+            'isDownForMaintenance' => fn () => false,
+        ]);
+
+        $worker->runNextJob('sqs', 'default', new WorkerOptions(sleep: 0));
+
+        $this->assertEquals(
+            MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_RECEIVE,
+            $this->storage[0]->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE),
+        );
     }
 
     public function test_it_drops_empty_receives(): void

--- a/src/Instrumentation/Laravel/tests/Integration/Queue/WorkerTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Queue/WorkerTest.php
@@ -7,6 +7,7 @@ namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration\Queue;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
+use OpenTelemetry\SemConv\Incubating\Attributes\MessagingIncubatingAttributes;
 use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Jobs\DummyJob;
 use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Jobs\IsolatedJob;
 use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Fixtures\Jobs\LinkedJob;
@@ -49,6 +50,10 @@ class WorkerTest extends TestCase
         $this->assertSame('Task: job-with-parent-trace', $this->storage[0]->getBody());
         $this->assertSame('process (anonymous)', $this->storage[1]->getName());
         $this->assertSame(DummyJob::class, $span->getAttributes()->get('messaging.message.job_name'));
+        $this->assertSame(
+            MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+            $span->getAttributes()->get(MessagingIncubatingAttributes::MESSAGING_OPERATION_TYPE),
+        );
     }
 
     public function test_linked_job_has_new_trace_with_link_to_parent(): void


### PR DESCRIPTION
## Summary

### Motivation
Queue/Worker instrumentation embeds the messaging operation (send/create/process/receive) into the span *name* only, e.g. `spanBuilder(vsprintf('%s %s', [MESSAGING_OPERATION_TYPE_VALUE_SEND, ...]))`. 
It was never set as the `messaging.operation.type` span attribute, which the OTel messaging semantic conventions require. 

Therefore, These spans without a queryable/filterable field that every compliant messaging span is expected to carry.

### What I have done
- `Queue::hookBulk` → set `MESSAGING_OPERATION_TYPE` to `send`
- `Queue::hookLater` → set `MESSAGING_OPERATION_TYPE` to `create`
- `Queue::hookPushRaw` → set `MESSAGING_OPERATION_TYPE` to `create`
- `Worker::hookWorkerProcess` → set `MESSAGING_OPERATION_TYPE` to `process`
- `Worker::hookWorkerGetNextJob` → set `MESSAGING_OPERATION_TYPE` to `receive`
- `SyncQueue::hookPush` → set `MESSAGING_OPERATION_TYPE` to `process` (also replaced the hardcoded `'process'` string in the span name with the `MessagingIncubatingAttributes` constant, for consistency with the other hooks touched here)

### Test Plans
- Extended `QueueTest.php` (`test_it_handles_pushing_to_a_queue`, `test_it_can_push_a_message_with_a_delay`, `test_it_can_publish_in_bulk`, `test_it_can_create_with_redis`) and `WorkerTest.php` (`test_job_has_parent_trace_by_default`) with assertions on the new attribute
- Added `test_it_records_operation_type_on_receive_span` to cover the `receive` case