### PR TITLE
fix(laravel): queue spans per request signature in `ClientRequestWatcher`

### DIFF
--- a/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response as HttpResponse;
 class ClientRequestWatcher extends Watcher
 {
     /**
-     * @var array<string, SpanInterface>
+     * @var array<string, list<SpanInterface>>
      */
     protected array $spans = [];
 
@@ -67,31 +67,25 @@ class ClientRequestWatcher extends Watcher
                 ServerAttributes::SERVER_PORT => $parsedUrl['port'] ?? '',
             ])
             ->startSpan();
-        $this->spans[$this->createRequestComparisonHash($request->request)] = $span;
+        $this->spans[$this->createRequestComparisonHash($request->request)][] = $span;
     }
 
     /** @psalm-suppress PossiblyUnusedMethod */
     public function recordConnectionFailed(ConnectionFailed $request): void
     {
-        $requestHash = $this->createRequestComparisonHash($request->request);
-
-        $span = $this->spans[$requestHash] ?? null;
+        $span = $this->shiftSpan($this->createRequestComparisonHash($request->request));
         if (null === $span) {
             return;
         }
 
         $span->setStatus(StatusCode::STATUS_ERROR, 'Connection failed');
         $span->end();
-
-        unset($this->spans[$requestHash]);
     }
 
     /** @psalm-suppress PossiblyUnusedMethod */
     public function recordResponse(ResponseReceived $request): void
     {
-        $requestHash = $this->createRequestComparisonHash($request->request);
-
-        $span = $this->spans[$requestHash] ?? null;
+        $span = $this->shiftSpan($this->createRequestComparisonHash($request->request));
         if (null === $span) {
             return;
         }
@@ -103,13 +97,26 @@ class ClientRequestWatcher extends Watcher
 
         $this->maybeRecordError($span, $request->response);
         $span->end();
-
-        unset($this->spans[$requestHash]);
     }
 
     private function createRequestComparisonHash(Request $request): string
     {
         return sha1($request->method() . '|' . $request->url() . '|' . $request->body());
+    }
+
+    private function shiftSpan(string $requestHash): ?SpanInterface
+    {
+        if (empty($this->spans[$requestHash])) {
+            return null;
+        }
+
+        $span = array_shift($this->spans[$requestHash]);
+
+        if (empty($this->spans[$requestHash])) {
+            unset($this->spans[$requestHash]);
+        }
+
+        return $span;
     }
 
     private function maybeRecordError(SpanInterface $span, Response $response): void

--- a/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
+++ b/src/Instrumentation/Laravel/src/Watchers/ClientRequestWatcher.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response as HttpResponse;
 class ClientRequestWatcher extends Watcher
 {
     /**
-     * @var array<string, list<SpanInterface>>
+     * @var array<int, SpanInterface>
      */
     protected array $spans = [];
 
@@ -67,13 +67,13 @@ class ClientRequestWatcher extends Watcher
                 ServerAttributes::SERVER_PORT => $parsedUrl['port'] ?? '',
             ])
             ->startSpan();
-        $this->spans[$this->createRequestComparisonHash($request->request)][] = $span;
+        $this->spans[$this->requestObjectId($request->request)] = $span;
     }
 
     /** @psalm-suppress PossiblyUnusedMethod */
     public function recordConnectionFailed(ConnectionFailed $request): void
     {
-        $span = $this->shiftSpan($this->createRequestComparisonHash($request->request));
+        $span = $this->takeSpan($this->requestObjectId($request->request));
         if (null === $span) {
             return;
         }
@@ -85,7 +85,7 @@ class ClientRequestWatcher extends Watcher
     /** @psalm-suppress PossiblyUnusedMethod */
     public function recordResponse(ResponseReceived $request): void
     {
-        $span = $this->shiftSpan($this->createRequestComparisonHash($request->request));
+        $span = $this->takeSpan($this->requestObjectId($request->request));
         if (null === $span) {
             return;
         }
@@ -99,22 +99,15 @@ class ClientRequestWatcher extends Watcher
         $span->end();
     }
 
-    private function createRequestComparisonHash(Request $request): string
+    private function requestObjectId(Request $request): int
     {
-        return sha1($request->method() . '|' . $request->url() . '|' . $request->body());
+        return spl_object_id($request->toPsrRequest());
     }
 
-    private function shiftSpan(string $requestHash): ?SpanInterface
+    private function takeSpan(int $requestId): ?SpanInterface
     {
-        if (empty($this->spans[$requestHash])) {
-            return null;
-        }
-
-        $span = array_shift($this->spans[$requestHash]);
-
-        if (empty($this->spans[$requestHash])) {
-            unset($this->spans[$requestHash]);
-        }
+        $span = $this->spans[$requestId] ?? null;
+        unset($this->spans[$requestId]);
 
         return $span;
     }

--- a/src/Instrumentation/Laravel/tests/Integration/Http/ClientTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Http/ClientTest.php
@@ -6,8 +6,14 @@ namespace Integration\Http;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Http\Client\Events\ConnectionFailed;
+use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Http\Client\Pool;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SDK\Trace\StatusData;
@@ -89,5 +95,24 @@ class ClientTest extends TestCase
 
         self::assertEquals(500, $secondSpan->getAttributes()->get(HttpAttributes::HTTP_RESPONSE_STATUS_CODE));
         self::assertEquals(StatusCode::STATUS_ERROR, $secondSpan->getStatus()->getCode());
+    }
+
+    public function test_it_ignores_response_with_no_matching_request(): void
+    {
+        $request = new Request(new Psr7Request('GET', 'http://untracked.opentelemetry.io'));
+        $response = new Response(new Psr7Response(200));
+
+        Event::dispatch(new ResponseReceived($request, $response));
+
+        self::assertCount(0, $this->storage);
+    }
+
+    public function test_it_ignores_connection_failure_with_no_matching_request(): void
+    {
+        $request = new Request(new Psr7Request('GET', 'http://untracked.opentelemetry.io'));
+
+        Event::dispatch(new ConnectionFailed($request));
+
+        self::assertCount(0, $this->storage);
     }
 }

--- a/src/Instrumentation/Laravel/tests/Integration/Http/ClientTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/Http/ClientTest.php
@@ -6,10 +6,12 @@ namespace Integration\Http;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Promise\RejectedPromise;
+use Illuminate\Http\Client\Pool;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SDK\Trace\StatusData;
+use OpenTelemetry\SemConv\Attributes\HttpAttributes;
 use OpenTelemetry\SemConv\Attributes\UrlAttributes;
 use OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Integration\TestCase;
 
@@ -59,5 +61,33 @@ class ClientTest extends TestCase
         self::assertEquals('PATCH', $span->getName());
         self::assertEquals('http://fail', $span->getAttributes()->get(UrlAttributes::URL_FULL));
         self::assertEquals(StatusData::create(StatusCode::STATUS_ERROR, 'Connection failed'), $span->getStatus());
+    }
+
+    public function test_it_matches_spans_to_responses_for_concurrent_identical_requests(): void
+    {
+        Http::fake([
+            'same.opentelemetry.io' => Http::sequence()
+                ->push(status: 200)
+                ->push(status: 500),
+        ]);
+
+        $responses = Http::pool(fn (Pool $pool) => [
+            $pool->get('same.opentelemetry.io'),
+            $pool->get('same.opentelemetry.io'),
+        ]);
+
+        self::assertEquals(200, $responses[0]->status());
+        self::assertEquals(500, $responses[1]->status());
+
+        self::assertCount(2, $this->storage);
+
+        $firstSpan = $this->storage[0];
+        $secondSpan = $this->storage[1];
+
+        self::assertEquals(200, $firstSpan->getAttributes()->get(HttpAttributes::HTTP_RESPONSE_STATUS_CODE));
+        self::assertEquals(StatusCode::STATUS_UNSET, $firstSpan->getStatus()->getCode());
+
+        self::assertEquals(500, $secondSpan->getAttributes()->get(HttpAttributes::HTTP_RESPONSE_STATUS_CODE));
+        self::assertEquals(StatusCode::STATUS_ERROR, $secondSpan->getStatus()->getCode());
     }
 }

--- a/src/Instrumentation/Laravel/tests/Unit/Watchers/ClientRequestWatcherTest.php
+++ b/src/Instrumentation/Laravel/tests/Unit/Watchers/ClientRequestWatcherTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Instrumentation\Laravel\Unit\Watchers;
+
+use ArrayObject;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Http\Client\Events\RequestSending;
+use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\Response;
+use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Instrumentation\Configurator;
+use OpenTelemetry\Context\ScopeInterface;
+use OpenTelemetry\Contrib\Instrumentation\Laravel\Watchers\ClientRequestWatcher;
+use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
+use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\SemConv\Attributes\HttpAttributes;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+class ClientRequestWatcherTest extends TestCase
+{
+    private ScopeInterface $scope;
+    private ArrayObject $storage;
+
+    protected function setUp(): void
+    {
+        $this->storage = new ArrayObject();
+        $tracerProvider = new TracerProvider(
+            new SimpleSpanProcessor(
+                new InMemoryExporter($this->storage),
+            ),
+        );
+
+        $this->scope = Configurator::create()
+            ->withTracerProvider($tracerProvider)
+            ->activate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->scope->detach();
+    }
+
+    private function trackedSpans(ClientRequestWatcher $watcher): array
+    {
+        $prop = new ReflectionProperty(ClientRequestWatcher::class, 'spans');
+        $prop->setAccessible(true);
+
+        return $prop->getValue($watcher);
+    }
+
+    public function test_it_matches_the_correct_span_when_responses_resolve_out_of_order(): void
+    {
+        $watcher = new ClientRequestWatcher(new CachedInstrumentation('io.opentelemetry.contrib.php.laravel'));
+
+        $psr7RequestA = new Psr7Request('GET', 'http://same.opentelemetry.io');
+        $psr7RequestB = new Psr7Request('GET', 'http://same.opentelemetry.io');
+
+        $requestA = new Request($psr7RequestA);
+        $requestB = new Request($psr7RequestB);
+
+        $watcher->recordRequest(new RequestSending($requestA));
+        $watcher->recordRequest(new RequestSending($requestB));
+
+        $idA = spl_object_id($psr7RequestA);
+        $idB = spl_object_id($psr7RequestB);
+
+        $this->assertArrayHasKey($idA, $this->trackedSpans($watcher));
+        $this->assertArrayHasKey($idB, $this->trackedSpans($watcher));
+
+        $watcher->recordResponse(new ResponseReceived($requestB, new Response(new Psr7Response(500))));
+
+        $remaining = $this->trackedSpans($watcher);
+        $this->assertArrayNotHasKey($idB, $remaining);
+        $this->assertArrayHasKey($idA, $remaining);
+
+        $watcher->recordResponse(new ResponseReceived($requestA, new Response(new Psr7Response(200))));
+
+        $this->assertSame([], $this->trackedSpans($watcher));
+
+        $this->assertCount(2, $this->storage);
+        $this->assertEquals(500, $this->storage[0]->getAttributes()->get(HttpAttributes::HTTP_RESPONSE_STATUS_CODE));
+        $this->assertEquals(200, $this->storage[1]->getAttributes()->get(HttpAttributes::HTTP_RESPONSE_STATUS_CODE));
+    }
+}


### PR DESCRIPTION
## Summary

### Motivation

`ClientRequestWatcher` tracks in-flight HTTP client spans in a single array slot keyed by `sha1(method|url|body)`. 
When two requests share the same signature and are in flight at the same time — e.g. identical calls sent through `Http::pool()`, or a retried request — the second `recordRequest()` overwrites the first entry in `$this->spans`. 
The overwritten span is never ended (it leaks), and whichever `ResponseReceived`/`ConnectionFailed` event fires next gets attributed to the wrong span (or to none, once both slots have been consumed).

### What I have done
- Changed `$spans` from `array<string, SpanInterface>` to `array<string, list<SpanInterface>>`: one queue per request signature instead of one slot.
- `recordRequest()` now appends the new span to the queue for its signature.
- `recordResponse()`/`recordConnectionFailed()` now pop the oldest span for that signature via a new `shiftSpan()` helper (FIFO), instead of reading/deleting a single keyed entry.
- Concurrent requests with an identical signature are now matched back to their own response/failure in send order, instead of colliding.

### Test Plans
- Added `test_it_matches_spans_to_responses_for_concurrent_identical_requests` to `ClientTest.php`: sends two identical `GET` requests through `Http::pool()`, with `Http::sequence()` returning a distinct status (200, then 500) for each, and asserts each recorded span carries the correct status and error state for its own response.
- Verified this test reproduces the bug: reverting the `ClientRequestWatcher.php` change while keeping the test causes it to fail (only 1 span recorded instead of 2).
