### PR TITLE
fix(pdo): update static analysis tools for PHP 8.2-8.5 compatibility

### DIFF
--- a/src/Instrumentation/PDO/composer.json
+++ b/src/Instrumentation/PDO/composer.json
@@ -23,14 +23,14 @@
     "friendsofphp/php-cs-fixer": "^3",
     "phan/phan": "^6.0",
     "php-http/mock-client": "*",
-    "phpstan/phpstan": "^1.1",
-    "phpstan/phpstan-phpunit": "^1.0",
+    "phpstan/phpstan": "^2.0",
+    "phpstan/phpstan-phpunit": "^2.0",
     "psalm/plugin-phpunit": "^0.19.2",
     "open-telemetry/opentelemetry-sqlcommenter": "^0.2",
     "open-telemetry/sdk": "^1.0",
     "open-telemetry/test-utils": "^0.2.0",
     "phpunit/phpunit": "^9.5",
-    "vimeo/psalm": "6.4.0"
+    "vimeo/psalm": "^6.4"
   },
   "autoload": {
     "psr-4": {

--- a/src/Instrumentation/PDO/ignore-by-php-version.neon.php
+++ b/src/Instrumentation/PDO/ignore-by-php-version.neon.php
@@ -7,14 +7,12 @@ $ignoreErrors = [];
 if (version_compare(PHP_VERSION, '8.4', '<')) {
     $ignoreErrors = [
         '#Call to an undefined static method PDO::connect\(\)#',
-        '#PHPDoc tag @var for variable \$db contains unknown class PDO\\\\Sqlite#',
-        '#Call to method createFunction\(\) on an unknown class PDO\\\\Sqlite#',
-        '#Call to method exec\(\) on an unknown class PDO\\\\Sqlite#',
-        '#Call to method query\(\) on an unknown class PDO\\\\Sqlite#',
+        '#Class Pdo\\\\Sqlite referenced with incorrect case: PDO\\\\Sqlite#',
     ];
 } elseif (version_compare(PHP_VERSION, '8.4', '>=')) {
     $ignoreErrors = [
-        '#Call to an undefined method Pdo\\\\Sqlite::createFunction\(\)#',
+        '#Call to function method_exists\(\) with .PDO. and .connect. will always evaluate to true#',
+        '#PDOInstrumentationTest::createDBWithNewSubclass\(\) should return PDO but returns#',
     ];
 }
 

--- a/src/Instrumentation/PDO/psalm.xml.dist
+++ b/src/Instrumentation/PDO/psalm.xml.dist
@@ -14,4 +14,7 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <issueHandlers>
+        <MissingOverrideAttribute errorLevel="suppress"/>
+    </issueHandlers>
 </psalm>

--- a/src/Instrumentation/PDO/src/PDOTracker.php
+++ b/src/Instrumentation/PDO/src/PDOTracker.php
@@ -30,7 +30,7 @@ final class PDOTracker
     public function __construct()
     {
         /** @psalm-suppress PropertyTypeCoercion */
-        $this->pdoToAttributesMap = new WeakMap();
+        $this->pdoToAttributesMap = new WeakMap(); // @phpstan-ignore assign.propertyType
         /** @psalm-suppress PropertyTypeCoercion */
         $this->statementMapToPdoMap = new WeakMap();
         $this->preparedStatementToSpanMap = new WeakMap();
@@ -82,7 +82,7 @@ final class PDOTracker
             $attributes[DbAttributes::DB_SYSTEM_NAME] = 'other_sql';
         }
 
-        $this->pdoToAttributesMap[$pdo] = $attributes;
+        $this->pdoToAttributesMap[$pdo] = $attributes; // @phpstan-ignore assign.propertyType
 
         return $attributes;
     }
@@ -156,11 +156,11 @@ final class PDOTracker
         if (str_starts_with($dsn, 'sqlsrv:')) {
             if (preg_match('/Server=([^,;]+)(?:,([0-9]+))?/', $dsn, $serverMatches)) {
                 $server = $serverMatches[1];
-                if ($server !== '') {
+                if ($server !== '') { // @phpstan-ignore notIdentical.alwaysTrue
                     $attributes[ServerAttributes::SERVER_ADDRESS] = $server;
                 }
 
-                if (isset($serverMatches[2]) && $serverMatches[2] !== '') {
+                if (isset($serverMatches[2]) && $serverMatches[2] !== '') { // @phpstan-ignore notIdentical.alwaysTrue
                     $attributes[ServerAttributes::SERVER_PORT] = (int) $serverMatches[2];
                 }
             }
@@ -191,7 +191,7 @@ final class PDOTracker
             }
         } elseif (preg_match('/mysql:([^;:]+)/', $dsn, $hostMatches)) {
             $host = $hostMatches[1];
-            if ($host !== '' && $host !== 'dbname') {
+            if ($host !== '' && $host !== 'dbname') { // @phpstan-ignore notIdentical.alwaysTrue
                 $attributes[ServerAttributes::SERVER_ADDRESS] = $host;
             }
         }


### PR DESCRIPTION
- Upgrade phpstan/phpstan ^1.1 → ^2.0 and phpstan/phpstan-phpunit ^1.0 → ^2.0
- Upgrade vimeo/psalm 6.4.0 → ^6.4
- Suppress MissingOverrideAttribute in psalm.xml.dist (#[Override] requires PHP 8.3+)
- Refresh ignore-by-php-version.neon.php: PHPStan 2.x reports Pdo\Sqlite as a class.nameCase mismatch below PHP 8.4 rather than an unknown class, and on PHP 8.4+ it flags the now-always-true method_exists(PDO::connect) guard plus the PDO::connect() return type
- Suppress assign.propertyType on the WeakMap writes; WeakMap's TValue template is invariant, so PHPStan 2.x rejects the otherwise identical type