### PR TITLE
fix(laravel): stop mixing query string into `url.path`

### DIFF
--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
@@ -61,7 +61,7 @@ class Kernel implements LaravelHook
                 if ($request) {
                     /** @phan-suppress-next-line PhanAccessMethodInternal */
                     $parent = Globals::propagator()->extract($request, HeadersPropagator::instance());
-                    $span = $builder
+                    $builder = $builder
                         ->setParent($parent)
                         ->setAttribute(UrlAttributes::URL_FULL, $this->httpFullUrl($request))
                         ->setAttribute(HttpAttributes::HTTP_REQUEST_METHOD, $method)
@@ -70,13 +70,17 @@ class Kernel implements LaravelHook
                         ->setAttribute(NetworkAttributes::NETWORK_PROTOCOL_VERSION, $request->getProtocolVersion())
                         ->setAttribute(NetworkAttributes::NETWORK_PEER_ADDRESS, $request->server('REMOTE_ADDR'))
                         ->setAttribute(UrlAttributes::URL_PATH, $this->httpPath($request))
-                        ->setAttribute(UrlAttributes::URL_QUERY, $request->getQueryString())
                         ->setAttribute(ServerAttributes::SERVER_ADDRESS, $this->httpHostName($request))
                         ->setAttribute(ServerAttributes::SERVER_PORT, $request->getPort())
                         ->setAttribute(ClientAttributes::CLIENT_PORT, $request->server('REMOTE_PORT'))
                         ->setAttribute(ClientAttributes::CLIENT_ADDRESS, $request->ip())
-                        ->setAttribute(UserAgentAttributes::USER_AGENT_ORIGINAL, $request->userAgent())
-                        ->startSpan();
+                        ->setAttribute(UserAgentAttributes::USER_AGENT_ORIGINAL, $request->userAgent());
+
+                    if (null !== $query = $request->getQueryString()) {
+                        $builder = $builder->setAttribute(UrlAttributes::URL_QUERY, $query);
+                    }
+
+                    $span = $builder->startSpan();
                     $request->attributes->set(SpanInterface::class, $span);
                 } else {
                     $span = $builder->startSpan();

--- a/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
+++ b/src/Instrumentation/Laravel/src/Hooks/Illuminate/Contracts/Http/Kernel.php
@@ -69,7 +69,8 @@ class Kernel implements LaravelHook
                         ->setAttribute(UrlAttributes::URL_SCHEME, $request->getScheme())
                         ->setAttribute(NetworkAttributes::NETWORK_PROTOCOL_VERSION, $request->getProtocolVersion())
                         ->setAttribute(NetworkAttributes::NETWORK_PEER_ADDRESS, $request->server('REMOTE_ADDR'))
-                        ->setAttribute(UrlAttributes::URL_PATH, $this->httpTarget($request))
+                        ->setAttribute(UrlAttributes::URL_PATH, $this->httpPath($request))
+                        ->setAttribute(UrlAttributes::URL_QUERY, $request->getQueryString())
                         ->setAttribute(ServerAttributes::SERVER_ADDRESS, $this->httpHostName($request))
                         ->setAttribute(ServerAttributes::SERVER_PORT, $request->getPort())
                         ->setAttribute(ClientAttributes::CLIENT_PORT, $request->server('REMOTE_PORT'))
@@ -117,12 +118,9 @@ class Kernel implements LaravelHook
         );
     }
 
-    private function httpTarget(Request $request): string
+    private function httpPath(Request $request): string
     {
-        $query = $request->getQueryString();
-        $path = $request->getBaseUrl() . $request->getPathInfo();
-
-        return $query ? $path . '?' . $query : $path;
+        return $request->getBaseUrl() . $request->getPathInfo();
     }
 
     private function httpMethod(Request $request): string

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -145,7 +145,8 @@ class LaravelInstrumentationTest extends TestCase
         $this->router()->get('/', fn () => null);
         $this->call('GET', '/?foo=bar');
         $span = $this->storage[0];
-        $this->assertSame('/?foo=bar', $span->getAttributes()->get(UrlAttributes::URL_PATH));
+        $this->assertSame('/', $span->getAttributes()->get(UrlAttributes::URL_PATH));
+        $this->assertSame('foo=bar', $span->getAttributes()->get(UrlAttributes::URL_QUERY));
     }
 
     public function test_url_path_with_query_string(): void
@@ -153,7 +154,16 @@ class LaravelInstrumentationTest extends TestCase
         $this->router()->get('/hello', fn () => null);
         $this->call('GET', '/hello?foo=bar');
         $span = $this->storage[0];
-        $this->assertSame('/hello?foo=bar', $span->getAttributes()->get(UrlAttributes::URL_PATH));
+        $this->assertSame('/hello', $span->getAttributes()->get(UrlAttributes::URL_PATH));
+        $this->assertSame('foo=bar', $span->getAttributes()->get(UrlAttributes::URL_QUERY));
+    }
+
+    public function test_url_query_absent_without_query_string(): void
+    {
+        $this->router()->get('/hello', fn () => null);
+        $this->call('GET', '/hello');
+        $span = $this->storage[0];
+        $this->assertNull($span->getAttributes()->get(UrlAttributes::URL_QUERY));
     }
 
     public function test_malformed_method_override_header_does_not_break_instrumentation(): void

--- a/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
+++ b/src/Instrumentation/Laravel/tests/Integration/LaravelInstrumentationTest.php
@@ -163,7 +163,7 @@ class LaravelInstrumentationTest extends TestCase
         $this->router()->get('/hello', fn () => null);
         $this->call('GET', '/hello');
         $span = $this->storage[0];
-        $this->assertNull($span->getAttributes()->get(UrlAttributes::URL_QUERY));
+        $this->assertFalse($span->getAttributes()->has(UrlAttributes::URL_QUERY));
     }
 
     public function test_malformed_method_override_header_does_not_break_instrumentation(): void


### PR DESCRIPTION
## Summary

### Motivation

`Kernel.php`'s `httpTarget()` appended the query string onto the request path and set the combined result as the `url.path` span attribute. 
OTel semantic conventions define `url.path` as the path component only ([registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/)); the query belongs in the separate `url.query` attribute, which is Conditionally Required (only when a query string was actually received). 
Existing tests asserted the combined `path?query` value as correct, which locked the bug in as expected behaviour.

### What I have done

- Renamed `httpTarget()` to `httpPath()` and removed the query-string concatenation, so it returns the path only.
- `url.path` is now set from `httpPath()`.
- `url.query` is set from `getQueryString()`, guarded behind an explicit `if (null !== $query = ...)` check so the attribute is only added when a query string is actually present. (An earlier version of this fix called `setAttribute` unconditionally and relied on the SDK silently dropping null-valued attributes to keep `url.query` absent otherwise; that's an SDK implementation detail, not a guaranteed contract, so a PR about spec compliance shouldn't lean on it.)
- Updated the existing query-string tests, which previously asserted the buggy `path?query`-in-`url.path` behaviour, to assert the correct split values.
- Added a test covering the no-query-string case, asserting `url.query` is absent via `has()` (not `assertNull()`, which can't distinguish "attribute absent" from "attribute present with a null value").

### Test Plans

- `vendor/bin/phpunit` — 54 tests, all green
- `vendor/bin/phpstan analyse` — no errors
- `vendor/bin/php-cs-fixer fix --dry-run` — clean